### PR TITLE
Fixing compile to set name properly on objects

### DIFF
--- a/api/py/ai/zipline/join.py
+++ b/api/py/ai/zipline/join.py
@@ -5,6 +5,7 @@ import json
 import logging
 import ai.zipline.api.ttypes as api
 import ai.zipline.utils as utils
+import ai.zipline.repo.extract_objects as eo
 from typing import List, Dict, Union, Optional, Iterable
 
 logging.basicConfig(level=logging.INFO)
@@ -26,7 +27,7 @@ def JoinPart(group_by: api.GroupBy,
             break
     logging.debug("group_by's module info from garbage collector {}".format(group_by_module_name))
     group_by_module = importlib.import_module(group_by_module_name)
-    __builtins__['__import__'] = utils.import_module_set_name(group_by_module, api.GroupBy)
+    __builtins__['__import__'] = eo.import_module_set_name(group_by_module, api.GroupBy)
     if keyMapping:
         utils.check_contains(keyMapping.values(),
                              group_by.keyColumns,

--- a/api/py/ai/zipline/repo/compile.py
+++ b/api/py/ai/zipline/repo/compile.py
@@ -83,7 +83,6 @@ def extract_and_convert(zipline_root, input_path, output_root, debug, force_over
     teams_path = os.path.join(zipline_root_path, TEAMS_FILE_PATH)
     for name, obj in results.items():
         _set_team_level_metadata(obj, teams_path, team_name)
-        obj.metaData.name = name.split('.', 1)[1]
         if _write_obj(full_output_root, validator, name, obj, log_level, force_overwrite):
             num_written_objs += 1
             # In case of online join, we need to materialize the underlying online group_bys.
@@ -151,7 +150,7 @@ def _write_obj_as_json(name: str, obj: object, output_file: str, obj_class: type
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
     assert os.path.isdir(output_folder), f"{output_folder} isn't a folder."
-    assert hasattr(obj, "name"), f"Can't serialize objects without the name attribute for object {name}"
+    assert (hasattr(obj, "name") or hasattr(obj, "metaData")), f"Can't serialize objects without the name attribute for object {name}"
     with open(output_file, "w") as f:
         _print_highlighted(f"Writing {class_name} to", output_file)
         f.write(thrift_simple_json_protected(obj, obj_class))

--- a/api/py/ai/zipline/repo/extract_objects.py
+++ b/api/py/ai/zipline/repo/extract_objects.py
@@ -4,7 +4,6 @@ import importlib.util
 import logging
 import os
 
-import ai.zipline.utils as utils
 from ai.zipline.logger import get_logger
 
 
@@ -28,6 +27,20 @@ def from_folder(root_path: str,
     return result
 
 
+def import_module_set_name(module, cls):
+    """evaluate imported modules to assign object name"""
+    for name, obj in list(module.__dict__.items()):
+        if isinstance(obj, cls):
+            # the name would be `team_name.python_script_name.[group_by_name|join_name|staging_query_name]`
+            # real world case: psx.reservation_status.v1
+            if hasattr(obj, "metaData"):
+                obj.metaData.name = module.__name__.partition(".")[2] + "." + name
+            else:
+                # StagingQuery has no metaData property
+                obj.name = module.__name__.partition(".")[2] + "." + name
+    return module
+
+
 def from_file(root_path: str,
               file_path: str,
               cls: type,
@@ -44,7 +57,12 @@ def from_file(root_path: str,
 
     # the key of result dict would be `team_name.python_script_name.[group_by_name|join_name|staging_query_name]`
     # real world case: psx.reservation_status.v1
-    utils.import_module_set_name(mod, cls)
-    result = {obj.name: obj
-              for obj in mod.__dict__.values() if isinstance(obj, cls)}
+    import_module_set_name(mod, cls)
+    result = {}
+
+    for obj in [o for o in mod.__dict__.values() if isinstance(o, cls)]:
+        if hasattr(obj, "metaData"):
+            result[obj.metaData.name] = obj
+        else:
+            result[obj.name] = obj
     return result

--- a/api/py/ai/zipline/utils.py
+++ b/api/py/ai/zipline/utils.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from typing import List, Union
 
 import ai.zipline.api.ttypes as api
+import ai.zipline.repo.extract_objects as eo
 import gc
 import json
 import shutil
@@ -113,16 +114,6 @@ def get_columns(source: api.Source):
     return columns
 
 
-def import_module_set_name(module, cls):
-    """evaluate imported modules to assign object name"""
-    for name, obj in list(module.__dict__.items()):
-        if isinstance(obj, cls):
-            # the name would be `team_name.python_script_name.[group_by_name|join_name|staging_query_name]`
-            # real world case: psx.reservation_status.v1
-            obj.name = module.__name__.partition(".")[2] + "." + name
-    return module
-
-
 def get_mod_name_from_gc(obj, mod_prefix):
     """get an object's module information from garbage collector"""
     mod_name = None
@@ -138,5 +129,5 @@ def get_mod_name_from_gc(obj, mod_prefix):
 def get_staging_query_output_table_name(staging_query: api.StagingQuery):
     """generate output table name for staging query job"""
     staging_query_module = importlib.import_module(get_mod_name_from_gc(staging_query, "staging_queries"))
-    import_module_set_name(staging_query_module, api.StagingQuery)
+    eo.import_module_set_name(staging_query_module, api.StagingQuery)
     return staging_query.name.replace('.', '_')


### PR DESCRIPTION
Fixing the `import_module_set_name` function to set name on metadata when applicable.

**NOTE:** There is some complexity currently because StagingQuery doesn't use the `metaData` API. We should eventually fix that, and get rid of the `if hasattr` conditions. But I think that should be its own PR.