### PR TITLE
[zipline] fix for unwindowed case

### DIFF
--- a/api/py/ai/zipline/shorthand.py
+++ b/api/py/ai/zipline/shorthand.py
@@ -72,7 +72,7 @@ class Agg:
         aggregations = []
         for op in self._all_ops():
             windows = self._all_window_groups()
-            if None in windows:
+            if not windows or None in windows:
                 agg = api.Aggregation(inputColumn=self.column, operation=op[0], argMap=op[1], windows=None)
                 aggregations.append(agg)
             pure_windows = [parse_window(window) for window in windows if window is not None]


### PR DESCRIPTION
Without this fix, shorthand does not create `Aggregation` for `GroupBy`s with no windows. 

@airbnb/zipline-maintainers 