### PR TITLE
Dropping spurious hive metastore version

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/zipline/spark/SparkSessionBuilder.scala
@@ -33,7 +33,6 @@ object SparkSessionBuilder {
       .config("spark.sql.legacy.allowCreatingManagedTableUsingNonemptyLocation", "true")
       .config("spark.sql.warehouse.dir", warehouseDir.getAbsolutePath)
       .config("spark.sql.catalogImplementation", "hive")
-      .config("spark.sql.hive.metastore.version", "1.2.1")
 
     val builder = if (local) {
       baseBuilder


### PR DESCRIPTION
The version specification is incorrect - and causes tests to fail.