### PR TITLE
Remove hive metastore versioning

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/zipline/spark/SparkSessionBuilder.scala
@@ -33,7 +33,6 @@ object SparkSessionBuilder {
       .config("spark.sql.legacy.allowCreatingManagedTableUsingNonemptyLocation", "true")
       .config("spark.sql.warehouse.dir", warehouseDir.getAbsolutePath)
       .config("spark.sql.catalogImplementation", "hive")
-      .config("spark.sql.hive.metastore.version", "1.2.1")
 
     val builder = if (local) {
       baseBuilder


### PR DESCRIPTION
As titled, tested on dev box. Otherwise, the job will exit with `java.lang.NoSuchMethodException: org.apache.hadoop.hive.ql.metadata.Hive.XXX`