### PR TITLE
stop deleting /tmp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,8 @@ lazy val spark = project
       "org.rogach" %% "scallop" % "4.0.1",
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0"
     ),
-    testOptions in Test += Tests.Setup(() => Folder.clean(file("/tmp"), file(".") / "spark-warehouse", file(".") / "metastore_db")),
-    testOptions in Test += Tests.Cleanup(() => Folder.clean(file("/tmp"), file(".") / "spark-warehouse", file(".") / "metastore_db"))
+    testOptions in Test += Tests.Setup(() => Folder.clean(file(".") / "spark-warehouse", file(".") / "metastore_db")),
+    testOptions in Test += Tests.Cleanup(() => Folder.clean(file(".") / "spark-warehouse", file(".") / "metastore_db"))
   )
 
 // TODO add benchmarks - follow this example


### PR DESCRIPTION
This is unnecessary from the circleci change. @airbnb/zipline-maintainers 