### PR TITLE
add sbt publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+early_exit_for_release_prs: &early_exit_for_release_prs
+    run:
+        name: Early exit for release PRs
+        command: |
+            if expr "${CIRCLE_BRANCH}" : '^release-branch--[a-z][a-z]-v[0-9.]*$' ; then
+                circleci-agent step halt
+            fi
+
 base_defaults: &base_defaults
     resource_class: xlarge
     working_directory: /zipline
@@ -91,8 +99,18 @@ jobs:
                       tox                                               # Run tests
                       popd
 
-workflows:
+    "Publish Zipline JAR to Artifactory":
+        executor: docker_baseimg_executor
+        steps:
+            - <<: *early_exit_for_release_prs
+            - checkout
+            - run:
+                name: Run sbt publish
+                command: |
+                      sed -i -e "s/<username>/${ARTIFACTORY_USERNAME}/g" -e "s/<password>/${ARTIFACTORY_PASSWORD}/g" /zipline/artifactory_credentials.properties
+                      sbt publish
 
+workflows:
     build_test_deploy:
         jobs:
             - "Docker Base Build":
@@ -111,3 +129,9 @@ workflows:
             - "Zipline Python Lint":
                 requires:
                   - "Docker Base Build"
+            - "Publish Zipline JAR to Artifactory":
+                  filters:
+                      tags:
+                          only: /^release-zl.*/
+                      branches:
+                          ignore: /.*/

--- a/artifactory_credentials.properties
+++ b/artifactory_credentials.properties
@@ -1,0 +1,4 @@
+realm=Artifactory Realm
+host=artifactory.d.musta.ch
+user=<username>
+password=<password>

--- a/devnotes.md
+++ b/devnotes.md
@@ -4,12 +4,12 @@ Brain dump of commands used to do various things
 
 ## Commands
 
-***All commands assume you are in the root directory of this project***. 
+***All commands assume you are in the root directory of this project***.
 For me, that looks like `~/repos/zipline`.
 
 ### Prerequisites
 
-Add the following to your shell run command files e.g. `~/.bashrc`. 
+Add the following to your shell run command files e.g. `~/.bashrc`.
 
 ```
 export ZIPLINE_OS=<path/to/zipline/repo>
@@ -32,10 +32,10 @@ Mark the following directories as `Test Root` in a similar way:
 - api/src/test/scala
 - spark/src/test/scala
 
-The project should then automatically start indexing, and when it finishes you should be good to go. 
+The project should then automatically start indexing, and when it finishes you should be good to go.
 
 ### Generate python thrift definitions
- 
+
 ```shell
 cd $ZIPLINE_OS
 thrift --gen py -out api/py/ai/zipline api/thrift/api.thrift
@@ -63,7 +63,7 @@ sbt "aggregator/test"
 ### Build a fat jar
 ```
 sbt assemble
-``` 
+```
 
 Building a fat jar for just one submodule
 ```
@@ -104,3 +104,17 @@ python ~/repos/ml_models/zipline/joins/new_algo/search_benchmarks.py > ~/bench3_
 scp ~/repos/ml_models/zipline/joins/new_algo/spark_submit.sh $AFDEV_HOST:~/
 ```
 
+
+### Pushing the JAR to artifactory
+
+- Switch to master branch.
+- Tag your change.
+
+``` shell
+git tag -a -m 'new release' release-zl-0.0.2
+```
+- Push the tag to artifactory
+
+``` shell
+ git push origin release-zl-0.0.2
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,6 @@ ENV THRIFT_VERSION 0.11.0
 WORKDIR /img-build
 
 
-
 # Add sbt repo to sources list
 RUN echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
 RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
@@ -35,6 +34,7 @@ RUN apt-get update && apt-get -y -q install \
     pkg-config \
     sbt \
     && apt-get clean
+
 # Install thrift
 RUN curl -sSL "http://apache.mirrors.spacedump.net/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
Add publish to artifactory with `sbt publish`. 

- Generate credential file
- pushes to `artifactory-airbnb-releases/ai/zipline/spark_2.11/`
- if the format of the version does not follow `release-zl-X.X.X` it won't be pushed to release repo.
@airbnb/zipline-maintainers 