### PR TITLE
Patrick  publish fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,14 +124,22 @@ workflows:
                       - "Docker Base Build"
                   filters:
                       tags:
-                          only: /^release-zl-.*/
+                          ignore: /^release-zl-.*/
             - "Zipline Python Tests":
-                requires:
-                  - "Docker Base Build"
+                  requires:
+                      - "Docker Base Build"
+                  filters:
+                      tags:
+                          ignore: /^release-zl-.*/
             - "Zipline Python Lint":
-                requires:
-                  - "Docker Base Build"
+                  requires:
+                      - "Docker Base Build"
+                  filters:
+                      tags:
+                          ignore: /^release-zl-.*/
             - "Publish Zipline JAR to Artifactory":
+                  requires:
+                      - "Docker Base Build"
                   filters:
                       tags:
                           only: /^release-zl.*/


### PR DESCRIPTION
- need to run `Docker Base Build` to publish a Docker image with no branch name before running.
- guard tests to not run for publish command