### PR TITLE
release zipline-ai-dev 0.0.3

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.1"
+__version__ = "0.0.3"
 
 
 setup(


### PR DESCRIPTION
Release the version of 0.0.3

![image](https://user-images.githubusercontent.com/3771747/120714747-769c3380-c478-11eb-890e-0b4bd4524f84.png)
