### PR TITLE
[Zipline][PyApi] default -> required

### DIFF
--- a/api/py/ai/zipline/repo/compile.py
+++ b/api/py/ai/zipline/repo/compile.py
@@ -33,7 +33,7 @@ def get_folder_name_from_class_name(class_name):
     '--zipline_root',
     envvar='ZIPLINE_ROOT',
     help='Path to the root zipline folder',
-    default=False)
+    required=True)
 @click.option(
     '--input_path',
     help='Relative Path to the root zipline folder, which contains the objects to be serialized',


### PR DESCRIPTION
A quick fix I noticed while going through the test flow w/ compile:

By adding default=False click assumes the type of the variable is boolean.

before:
```
(ml_models21) (master)cristian_figueroa@MacBook-Pro: zipline $ python api/py/ai/zipline/repo/compile.py --help
Usage: compile.py [OPTIONS]

  CLI tool to convert Python zipline GroupBy's, Joins and Staging queries into
  their thrift representation. The materialized objects are what will be
  submitted to spark jobs - driven by airflow, or by manual user testing.

Options:
  --zipline_root BOOLEAN  Path to the root zipline folder
  --input_path TEXT       Relative Path to the root zipline folder, which
                          contains the objects to be serialized  [required]
  --output_root TEXT      Relative Path to the root zipline folder, to where
                          the serialized output should be written
  --debug                 debug mode
  --force-overwrite       Force overwriting existing materialized conf.
  --help                  Show this message and exit.
  ```
  
now:
```
(ml_models21) (master)cristian_figueroa@MacBook-Pro: zipline $ python api/py/ai/zipline/repo/compile.py --help
Usage: compile.py [OPTIONS]

  CLI tool to convert Python zipline GroupBy's, Joins and Staging queries into
  their thrift representation. The materialized objects are what will be
  submitted to spark jobs - driven by airflow, or by manual user testing.

Options:
  --zipline_root TEXT  Path to the root zipline folder
  --input_path TEXT    Relative Path to the root zipline folder, which
                       contains the objects to be serialized  [required]
  --output_root TEXT   Relative Path to the root zipline folder, to where the
                       serialized output should be written
  --debug              debug mode
  --force-overwrite    Force overwriting existing materialized conf.
  --help               Show this message and exit.
```

@better365 @ezvz @patyoon 