### PR TITLE
[JoinJob][Versioning] Added skipEqualCheck flag to skip equality check

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/Join.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Join.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.DataFrame
 import java.util.Base64
 import scala.collection.JavaConverters._
 
-class Join(joinConf: JoinConf, endPartition: String, tableUtils: TableUtils, skipEqualCheck: Boolean) {
+class Join(joinConf: JoinConf, endPartition: String, tableUtils: TableUtils, skipEqualCheck: Boolean = false) {
   assert(Option(joinConf.metaData.outputNamespace).nonEmpty, s"output namespace could not be empty or null")
   private val outputTable = s"${joinConf.metaData.outputNamespace}.${joinConf.metaData.cleanName}"
 

--- a/spark/src/test/scala/ai/zipline/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/zipline/spark/test/FetcherTest.scala
@@ -166,7 +166,7 @@ class FetcherTest extends TestCase {
       ),
       metaData = Builders.MetaData(name = "test.payments_join", namespace = namespace, team = "zipline")
     )
-    val joinedDf = new Join(joinConf, today, tableUtils, false).computeJoin()
+    val joinedDf = new Join(joinConf, today, tableUtils).computeJoin()
     val joinTable = s"$namespace.join_test_expected"
     joinedDf.save(joinTable)
     val todaysExpected = tableUtils.sql(s"SELECT * FROM $joinTable WHERE ds='$today'")

--- a/spark/src/test/scala/ai/zipline/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/zipline/spark/test/JoinTest.scala
@@ -113,7 +113,7 @@ class JoinTest {
       metaData = Builders.MetaData(name = "test.user_transaction_features", namespace = namespace, team = "zipline")
     )
 
-    val runner1 = new Join(joinConf, end, tableUtils, false)
+    val runner1 = new Join(joinConf, end, tableUtils)
 
     spark.sql(
       s"DROP TABLE IF EXISTS test_namespace_jointest.test_user_transaction_features_10_unit_test_user_transactions")
@@ -215,7 +215,7 @@ class JoinTest {
       metaData = Builders.MetaData(name = "test.country_features", namespace = namespace, team = "zipline")
     )
 
-    val runner = new Join(joinConf, end, tableUtils, false)
+    val runner = new Join(joinConf, end, tableUtils)
     val computed = runner.computeJoin(Some(7))
     val expected = tableUtils.sql(s"""
     |WITH 
@@ -307,7 +307,7 @@ class JoinTest {
       metaData = Builders.MetaData(name = "test.item_snapshot_features_2", namespace = namespace, team = "zipline")
     )
 
-    val join = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val join = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils)
     val computed = join.computeJoin()
     computed.show()
 
@@ -377,7 +377,7 @@ class JoinTest {
 
     val start = Constants.Partition.minus(today, new Window(100, TimeUnit.DAYS))
 
-    val join = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val join = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils)
     val computed = join.computeJoin(Some(100))
     computed.show()
 
@@ -438,7 +438,7 @@ class JoinTest {
         |  ds >= '2021-06-03' AND ds <= '2021-06-03'""".stripMargin
     spark.sql(q).show()
     val start = Constants.Partition.minus(today, new Window(100, TimeUnit.DAYS))
-    val join = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val join = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils)
     val computed = join.computeJoin(Some(100))
     computed.show()
 
@@ -580,7 +580,7 @@ class JoinTest {
       metaData = Builders.MetaData(name = "test.user_features", namespace = namespace, team = "zipline")
     )
 
-    val runner = new Join(joinConf, end, tableUtils, false)
+    val runner = new Join(joinConf, end, tableUtils)
     val computed = runner.computeJoin(Some(7))
     println(s"join start = $start")
     val expected = tableUtils.sql(s"""
@@ -623,7 +623,7 @@ class JoinTest {
     joinConf.getMetaData.setName(s"${joinConf.getMetaData.getName}_versioning")
 
     // Run the old join to ensure that tables exist
-    val oldJoin = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val oldJoin = new Join(joinConf = joinConf, endPartition = dayAndMonthBefore, tableUtils)
     oldJoin.computeJoin(Some(100))
 
     // Make sure that there is no versioning-detected changes at this phase
@@ -633,7 +633,7 @@ class JoinTest {
     // First test changing the left side table - this should trigger a full recompute
     val leftChangeJoinConf = joinConf.deepCopy()
     leftChangeJoinConf.getLeft.getEvents.setTable("some_other_table_name")
-    val leftChangeJoin = new Join(joinConf = leftChangeJoinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val leftChangeJoin = new Join(joinConf = leftChangeJoinConf, endPartition = dayAndMonthBefore, tableUtils)
     val leftChangeRecompute = leftChangeJoin.getJoinPartsToRecompute(leftChangeJoin.getLastRunJoinOpt)
     assertEquals(leftChangeRecompute.size, 2)
     assertEquals(leftChangeRecompute.head.groupBy.getMetaData.getName, "unit_test.item_views")
@@ -643,7 +643,7 @@ class JoinTest {
     val existingJoinPart = addPartJoinConf.getJoinParts.get(0)
     val newJoinPart = Builders.JoinPart(groupBy = getViewsGroupBy(), prefix = "user_2")
     addPartJoinConf.setJoinParts(Seq(existingJoinPart, newJoinPart).asJava)
-    val addPartJoin = new Join(joinConf = addPartJoinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val addPartJoin = new Join(joinConf = addPartJoinConf, endPartition = dayAndMonthBefore, tableUtils)
     val addPartRecompute = addPartJoin.getJoinPartsToRecompute(addPartJoin.getLastRunJoinOpt)
     assertEquals(addPartRecompute.size, 1)
     assertEquals(addPartRecompute.head.groupBy.getMetaData.getName, "unit_test.item_views")
@@ -653,13 +653,13 @@ class JoinTest {
     // Test modifying only one of two joinParts
     val rightModJoinConf = addPartJoinConf.deepCopy()
     rightModJoinConf.getJoinParts.get(1).setPrefix("user_3")
-    val rightModJoin = new Join(joinConf = rightModJoinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val rightModJoin = new Join(joinConf = rightModJoinConf, endPartition = dayAndMonthBefore, tableUtils)
     val rightModRecompute = rightModJoin.getJoinPartsToRecompute(rightModJoin.getLastRunJoinOpt)
     assertEquals(rightModRecompute.size, 1)
     assertEquals(rightModRecompute.head.groupBy.getMetaData.getName, "unit_test.item_views")
     // Modify both
     rightModJoinConf.getJoinParts.get(0).setPrefix("user_4")
-    val rightModBothJoin = new Join(joinConf = rightModJoinConf, endPartition = dayAndMonthBefore, tableUtils, false)
+    val rightModBothJoin = new Join(joinConf = rightModJoinConf, endPartition = dayAndMonthBefore, tableUtils)
     // Compute to ensure that it works
     val computed = rightModBothJoin.computeJoin(Some(100))
 


### PR DESCRIPTION
Added flag to potentially turn off the object equality check for versioning for backward compatibility. The latest `JoinConf` will not match with the older json config. 

This bug is not caught because our UT changed directly on the Scala objects, instead of from the JSON strings. 

### Testing plan:
- [x] dev box
```
airflow test zipline_join_relevance_agg_listing_place_id_join_v1 compute_join_relevance_agg_listing_place_id_join_v1 2021-06-22
```