### PR TITLE
bump up version for zipline-ai-dev

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 setup(


### PR DESCRIPTION
As titled

### Testing plan:

```
pip3 install zipline-ai-dev --index-url <PATH> --upgrade

Successfully installed zipline-ai-dev-0.0.4
```