### PR TITLE
[zipline] print warning if zipline package version is not the latest

### DIFF
--- a/api/py/ai/zipline/__init__.py
+++ b/api/py/ai/zipline/__init__.py
@@ -1,0 +1,3 @@
+PY_PACKAGE_NAME = "zipline-ai-dev"
+# TODO: Switch to PyPI repo once we are ready to release.
+PACKAGE_INDEX_URL = "https://artifactory.d.musta.ch/artifactory/api/pypi/pypi/simple"

--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -1,5 +1,5 @@
 from setuptools import find_packages, setup
-
+from ai.zipline import PY_PACKAGE_NAME
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -22,7 +22,7 @@ setup(
     description="Zipline python API library",
     include_package_data=True,
     install_requires=basic_requirements,
-    name="zipline-ai-dev",
+    name=PY_PACKAGE_NAME,
     packages=find_packages(),
     python_requires=">=3.7",
     url=None,


### PR DESCRIPTION
Before materializer runs check if the installed version is the latest version and print warning if not.

Prints out
```
Latest zipline-ai-dev version is 0.0.4 but you have 0.0.3. Upgrade to latest version by running 'pip install --upgrade zipline-ai-dev  --index-url https://artifactory.d.musta.ch/artifactory/api/pypi/pypi/simple'
```


@airbnb/zipline-maintainers 