### PR TITLE
add team name to group by's metadata

### DIFF
--- a/api/py/ai/zipline/group_by.py
+++ b/api/py/ai/zipline/group_by.py
@@ -1,6 +1,7 @@
 import ai.zipline.api.ttypes as ttypes
 import ai.zipline.utils as utils
 import copy
+import inspect
 from typing import List, Optional, Union, Dict, Callable, Tuple
 
 OperationType = int  # type(zthrift.Operation.FIRST)
@@ -136,8 +137,9 @@ def GroupBy(sources: Union[List[ttypes.Source], ttypes.Source],
                 src.entities.query.selects.update({"ts": src.entities.query.timeColumn})
 
     deps = [dep for src in sources for dep in utils.get_dependencies(src, dependencies)]
-
-    metadata = ttypes.MetaData(online=online, production=production, dependencies=deps)
+    # get caller's filename to assign team
+    team = inspect.stack()[1].filename.split("/")[-2]
+    metadata = ttypes.MetaData(online=online, production=production, dependencies=deps, team=team)
 
     return ttypes.GroupBy(
         sources=updated_sources,


### PR DESCRIPTION
Adding team name to meta data of GroupBy, otherwise, the join job will error out with `Exception in thread "main" java.lang.AssertionError: assertion failed: groupBy.metaData.team needs to be set for joinPart null`

### Testing plan: 
```
python3 compile.py --zipline_root=/Users/pengyu_hou/workspace/ml_models/zipline/ --input_path=joins/relevance/search_benchmarks.py --force-overwrite

      "groupBy": {
        "metaData": {
          "dependencies": [
            "{\"name\": \"wait_for_search_ranking_training.relevance_fct_daily_listing_stats_v2_core_homes_v1_ds\", \"spec\": \"search_ranking_training.relevance_fct_daily_listing_stats_v2_core_homes_v1/ds={{ ds }}\", \"start\": \"2020-06-01\", \"end\": null}"
          ],
          "team": "relevance"
        },
```