### PR TITLE
[CI] Add test coverage + store test perf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,22 @@ jobs:
                   command: |
                       # Increase if we see OOM.
                       export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-                      sbt test
+                      sbt jacocoAggregate
+            - store_test_results:
+                  path: /zipline/spark/target/test-reports
+            - store_test_results:
+                  path: /zipline/aggregator/target/test-reports
+            - store_artifacts:
+                  path: /zipline/target/scala-2.11/jacoco/report/html
+            - store_artifacts:
+                  path: /zipline/spark/target/scala-2.11/jacoco/report/html
+                  destination: spark-line-coverage
+            - store_artifacts:
+                  path: /zipline/fetcher/target/scala-2.11/jacoco/report/html
+                  destination: fetcher-line-coverage
+            - store_artifacts:
+                  path: /zipline/aggregator/target/scala-2.11/jacoco/report/html
+                  destination: aggregator-line-coverage
 
     "Zipline Python Lint":
         executor: docker_baseimg_executor

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.3.0")


### PR DESCRIPTION
### What 

I noticed our scala tests run for a bit (~20 min). I'd like to make changes to make this faster. 

* Adding jacoco to the plugins.
* Adding coverage reports in CI (artifacts).
* storing test results (to gather data in which tests take how long, for future improvements) (https://circleci.com/docs/2.0/collect-test-data/)

I did consider parallelizing... however we can't really parallelize and have coverage as well. I believe due to jacoco limitation on sbt, but I didn't want to go too deep on that rabbit hole. (https://tanin.nanakorn.com/technical/2018/09/10/parallelise-tests-in-sbt-on-circle-ci.html)

At least know if tests run for long time, we can know which tests take the most time and refactor appropriately.

Either way before setting up parallelization it's good for circle ci to have historic data on runtimes. (https://circleci.com/docs/2.0/parallelism-faster-jobs/) 

### Tested
<img width="905" alt="Screen Shot 2021-07-22 at 11 33 07 AM" src="https://user-images.githubusercontent.com/4719506/126690994-f35d0e45-567e-4403-bfda-746b13b6bee3.png">
<img width="215" alt="Screen Shot 2021-07-22 at 11 32 55 AM" src="https://user-images.githubusercontent.com/4719506/126691005-652049d6-41ec-404f-bacc-a6a04efd12a1.png">


### Reviewer
@ezvz @nikhilsimha 