### PR TITLE
Fix sbt clean assemble build error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,8 @@ lazy val spark = project
       "org.apache.spark" %% "spark-hive" % "2.4.0" % "provided",
       "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
       "org.apache.spark" %% "spark-streaming" % "2.4.0" % "provided",
-      "org.rogach" %% "scallop" % "4.0.1" % "provided"
+      "org.rogach" %% "scallop" % "4.0.1" % "provided",
+      "com.jayway.jsonpath" % "json-path" % "2.6.0" % "provided"
     ),
     testOptions in Test += Tests.Setup(() => cleanSparkMeta),
     testOptions in Test += Tests.Cleanup(() => cleanSparkMeta)


### PR DESCRIPTION
This PR will fix the dependencies that caused a build error as following:
```
java.lang.RuntimeException: deduplicate: different file contents found in the following:
[error] /Users/pengyu_hou/.ivy2/cache/com.google.code.gson/gson/jars/gson-2.8.6.jar:module-info.class
[error] /Users/pengyu_hou/.ivy2/cache/org.ow2.asm/asm/jars/asm-9.1.jar:module-info.class
```

### Testing plan: 
- [x]  sbt clean package assembly
- [x] push to artifactory works now 