### PR TITLE
[Test] Fix flakiness

### DIFF
--- a/spark/src/test/scala/ai/zipline/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/zipline/spark/test/JoinTest.scala
@@ -144,7 +144,7 @@ class JoinTest {
         |     where user_name IS NOT null
         |         AND ts IS NOT NULL
         |         AND ds IS NOT NULL
-        |         AND ds >= '$dropStart'
+        |         AND ds >= '$start'
         |         and ds <= '$end'),
         |   grouped_transactions AS (
         |      SELECT user, 


### PR DESCRIPTION
I was looking into the flakiness of this test and found that the ds that was in the diff dataframe was not part of the expected dataframe.

Then realized there was a dropStart instead of an start which would cover the date range that was missing.

Still testing, but I think this should do it.