### PR TITLE
Removed provided for scallop in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val spark = project
       "org.apache.spark" %% "spark-hive" % "2.4.0" % "provided",
       "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
       "org.apache.spark" %% "spark-streaming" % "2.4.0" % "provided",
-      "org.rogach" %% "scallop" % "4.0.1" % "provided",
+      "org.rogach" %% "scallop" % "4.0.1",
       "com.jayway.jsonpath" % "json-path" % "2.6.0" % "provided"
     ),
     testOptions in Test += Tests.Setup(() => cleanSparkMeta),


### PR DESCRIPTION
This PR should fix the `NoClassDefFoundError` for `Scallop`. 

### Testing plan 
- [ ] test with treehouse 