### PR TITLE
syntactic sugar for migrating to V2.1

### DIFF
--- a/api/py/ai/zipline/group_by.py
+++ b/api/py/ai/zipline/group_by.py
@@ -36,6 +36,33 @@ class Operation():
     BOTTOM_K = collector(ttypes.Operation.BOTTOM_K)
 
 
+def Aggregations(**agg_dict):
+    assert all(isinstance(agg, ttypes.Aggregation) for agg in agg_dict.values())
+    return agg_dict.values()
+
+
+def DefaultAggregation(keys, sources):
+    aggregate_columns = []
+    for source in sources:
+        query = utils.get_query(source)
+        columns = utils.get_columns(source)
+        non_aggregate_columns = keys + [
+            "ts",
+            query.timeColumn,
+            query.partitionColumn
+        ]
+        aggregate_columns += [
+            column
+            for column in columns
+            if column not in non_aggregate_columns
+        ]
+    return [
+        Aggregation(
+            operation=Operation.LAST,
+            input_column=column) for column in aggregate_columns
+    ]
+
+
 class TimeUnit():
     HOURS = ttypes.TimeUnit.HOURS
     DAYS = ttypes.TimeUnit.DAYS


### PR DESCRIPTION
Syntactic sugar for migrating to V2.1

- `Aggregations`: Take dict of V2.1 `Aggregation` objects and return just the values. `Aggregations` is used extensively in V2.0 Trust conf (example: https://git.musta.ch/airbnb/ml_models/blob/master/zipline/group_bys/trust/dbx/reservation2s.py#L72-L123) and I felt it is easier to create this.
- `DefaultAggregation`: Same case. Instead of translating it, it is easier to add this helper method.
- `dependencies` in `Query`: There are helper methods that sets `dependencies` at the Query level (example: https://git.musta.ch/airbnb/ml_models/blob/master/zipline/group_bys/trust/util.py#L16-L25) . We should provide a support for this and eventually add them all to join / group bys's metaData's `dependencies` when we materialize. 

@airbnb/zipline-owners 