### PR TITLE
[zipline] insert metadata to group bys materialized with join

### DIFF
--- a/api/py/ai/zipline/repo/compile.py
+++ b/api/py/ai/zipline/repo/compile.py
@@ -92,6 +92,7 @@ def extract_and_convert(zipline_root, input_path, output_root, debug, force_over
         # load materialized joins to validate the additional group_bys against.
         validator.load_objs()
         for name, obj in extra_online_group_bys.items():
+            _set_team_level_metadata(obj, teams_path, team_name)
             if _write_obj(full_output_root, validator, name, obj, log_level, force_compile=True):
                 num_written_group_bys += 1
         print(f"Successfully wrote {num_written_group_bys} online GroupBy objects to {full_output_root}")


### PR DESCRIPTION
When you materialize online join, you materialize all online group bys in it. We need to make sure these group bys get the metaData populated as well.

@airbnb/zipline-maintainers 