### PR TITLE
[zipline] fix fetcher and meta put for join endpoint

### DIFF
--- a/fetcher/src/main/scala/ai.zipline.fetcher/Fetcher.scala
+++ b/fetcher/src/main/scala/ai.zipline.fetcher/Fetcher.scala
@@ -129,7 +129,7 @@ class Fetcher(kvStore: KVStore, metaDataSet: String = ZiplineMetadataKey, timeou
       val responses: Seq[Response] = requestParFanout.map {
         case (request, GroupByRequestMeta(groupByServingInfo, batchRequest, streamingRequestOpt, atMillis)) =>
          // pick the batch version with highest timestamp
-          val batchOption = Option(responsesMap(batchRequest)).map(_.maxBy(_.millis))
+          val batchOption = responsesMap.get(batchRequest).flatMap(Option(_)).map(_.maxBy(_.millis))
           val batchTime: Option[Long] = batchOption.map(_.millis)
 
           val servingInfo = if (batchTime.exists(_ > groupByServingInfo.batchEndTsMillis)) {

--- a/spark/src/test/scala/ai/zipline/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/zipline/spark/test/FetcherTest.scala
@@ -75,7 +75,7 @@ class FetcherTest extends TestCase {
     val singleFilePut = singleFileMetadataStore.putZiplineConf(
       "./spark/src/test/scala/ai/zipline/spark/test/resources/joins/team/team.example_join.v1")
     Await.result(singleFilePut, Duration.Inf)
-    val response = inMemoryKvStore.get(GetRequest("joins/team/team.example_join.v1".getBytes(), singleFileDataSet))
+    val response = inMemoryKvStore.get(GetRequest("joins/team.example_join.v1".getBytes(), singleFileDataSet))
     val res = Await.result(response, Duration.Inf)
     val actual = new String(res.values.head.bytes)
 
@@ -87,7 +87,7 @@ class FetcherTest extends TestCase {
     val directoryPut = directoryMetadataStore.putZiplineConf("./spark/src/test/scala/ai/zipline/spark/test/resources")
     Await.result(directoryPut, Duration.Inf)
     val dirResponse =
-      inMemoryKvStore.get(GetRequest("joins/team/team.example_join.v1".getBytes(), directoryDataSetDataSet))
+      inMemoryKvStore.get(GetRequest("joins/team.example_join.v1".getBytes(), directoryDataSetDataSet))
     val dirRes = Await.result(dirResponse, Duration.Inf)
     val dirActual = new String(dirRes.values.head.bytes)
 


### PR DESCRIPTION
- Metadata store: the name after join/ should match up with the join's actual name in the conf.
- Fix group by fetcher when there is no batch value.
@airbnb/zipline-maintainers 