### PR TITLE
Bump up zipline-ai-dev version to 18

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 
 
 setup(


### PR DESCRIPTION
This will include the latest changes to remove shorthand.py from the APIs. 