### PR TITLE
Print out path in metadata uploader, skip bad confs

### DIFF
--- a/online/src/main/scala/ai/zipline/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/zipline/online/MetadataStore.scala
@@ -4,7 +4,6 @@ import ai.zipline.api.Constants.ZiplineMetadataKey
 import ai.zipline.api.Extensions.{JoinOps, StringOps}
 import ai.zipline.api._
 import ai.zipline.online.KVStore.PutRequest
-import ai.zipline.online.MetadataStore.parseName
 import com.google.gson.Gson
 import org.apache.thrift.TBase
 
@@ -72,13 +71,13 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ZiplineMetadataKey, 
           case _                                           => println(s"unknown config type in file $path"); ("", None)
         }
         confJsonOpt.map { conf =>
-            println(s"Putting metadata for $key to KV store")
-            PutRequest(keyBytes = key.getBytes(),
-                       valueBytes = conf.getBytes(),
-                       dataset = dataset,
-                       tsMillis = Some(System.currentTimeMillis()))
+          println(s"Putting metadata for $key to KV store")
+          PutRequest(keyBytes = key.getBytes(),
+                     valueBytes = conf.getBytes(),
+                     dataset = dataset,
+                     tsMillis = Some(System.currentTimeMillis()))
         }
-    }
+      }
     println(s"Putting ${puts.size} configs to KV Store, dataset=$dataset")
     kvStore.multiPut(puts)
   }
@@ -122,8 +121,9 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ZiplineMetadataKey, 
         .flatMap(Option(_))
         .map(_.asInstanceOf[String])
     } catch {
-      case _: Throwable => println(s"Failed to parse Zipline config as JSON: file path = $path")
-  None
+      case _: Throwable =>
+        println(s"Failed to parse Zipline config as JSON: file path = $path")
+        None
     }
   }
 }


### PR DESCRIPTION
Print conf path in metadata uploader to help with debugging 

Tested w/ Ztool:
```
(zipline-os) cristian_figueroa@MacBook-Pro: zipline $ ztool metadata-upload -o <redacted>/build/libs/online-all.jar --online-class <redacted> -c <redacted>/test_online_join.v1 -Zkv-host=<redacted> -Zkv-port=<redacted>
Uploading Zipline configs from <redacted>/test_online_join.v1
Putting metadata for joins/<redacted>.test_online_join.v1 to KV store
Putting 1 configs to KV Store, dataset=<redacted>
Uploaded Zipline Configs to the KV store, success count = 1, failure count = 0
```