### PR TITLE
add metadata-upload mode

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.19"
+__version__ = "0.0.20"
 
 
 setup(


### PR DESCRIPTION
Add `metadata-upload` command to `run.py`.

Tested with 

```
python3 ~/workspace/zipline/api/py/ai/zipline/repo/run.py --conf ~/workspace/ml_models/zipline/production/ --mode metadata-upload --user_jar /tmp/zipline-streaming-v21_production_zipline-streaming-v21_c99f59498596c8ca9769fa351da446671dc91d89_80563713-8313-4183-b85c-70659a2b8461_patrick_yoon --args "--online-class com.airbnb.bighead.zipline.online.MusselZiplineOnlineImpl  --online-jar build/libs/online-all.jar   -Zmussel-host=mussel-ml-dispatcher.aws.us-east-1.prod.musta.ch -Zmussel-port=6252" --repo ~/workspace/ml_models/zipline/
```

@airbnb/zipline-maintainers 