### PR TITLE
Use group by's input dataframe schema directly for streaming Avro schema

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/zipline/spark/GroupByUpload.scala
@@ -102,9 +102,7 @@ object GroupByUpload {
     groupByServingInfo.setKeyAvroSchema(groupBy.keySchema.toAvroSchema("Key").toString(true))
     groupByServingInfo.setSelectedAvroSchema(groupBy.preAggSchema.toAvroSchema("Value").toString(true))
 
-    // used by streaming jobs to deserialize from kafka/kinesis etc.
-    val inputTable = groupByConf.streamingSource.getOrElse(groupByConf.sources.get(0)).table
-    val inputSchema = tableUtils.sparkSession.table(inputTable).schema.toAvroSchema(name = "Input").toString(true)
+    val inputSchema = groupBy.inputDf.schema.toAvroSchema(name = "Input").toString(true)
     groupByServingInfo.setInputAvroSchema(inputSchema)
 
     val metaRows = Seq(


### PR DESCRIPTION
The group by batch upload ran into some issues if there are unsupported data types in the original input table, especially if there is a nested struct field. 

This PR will use the schema of data frame after running sql query for the input table, which can reflect the future input streaming schema better without processing the unused fields in the later computations. 

### Testing plan: 
- [x] tested with short term user features 
- [x] verified results with output tables 