### PR TITLE
Fixed step day error for batch upload job and added staging query subcommand 

### DIFF
--- a/api/py/ai/zipline/repo/run.py
+++ b/api/py/ai/zipline/repo/run.py
@@ -24,8 +24,7 @@ ROUTES = {
         'backfill': 'join',
     },
     'staging_queries': {
-        # TODO: Implement staging query subcommand.
-        # 'backfill': 'StagingQuery',
+        'backfill': 'staging-query-backfill',
     },
 }
 

--- a/spark/src/main/scala/ai/zipline/spark/Args.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Args.scala
@@ -8,7 +8,7 @@ import scala.reflect.ClassTag
 class Args(args: Seq[String]) extends ScallopConf(args) {
   val confPath: ScallopOption[String] = opt[String](required = true)
   val endDate: ScallopOption[String] = opt[String](required = false)
-  val stepDays: ScallopOption[Int] = opt[Int](required = false, default = Option(30)) // doesn't apply to uploads
+  val stepDays: ScallopOption[Int] = opt[Int](required = false) // doesn't apply to uploads
   val skipEqualCheck: ScallopOption[Boolean] =
     opt[Boolean](required = false, default = Some(false)) // only applies to join job for versioning
   def parseConf[T <: TBase[_, _]: Manifest: ClassTag]: T =


### PR DESCRIPTION
Assertion failed for batch upload job because step day was set across all the Args. This fix will only set step day for join backfill, group by backfill and staging query backfill. 

Besides, the staging query subcommand is added to the latest run.py complete. 

### testing plan
- [x] test on dev box for group by batch upload 
```
python3 new_run.py  --conf ~/ml_models/zipline/production/group_bys/trust_v21/dbx.users.pii_90d_v1  --mode upload  --ds 2022-01-11 | tee ~/test/upload.log
```
- [x] test on dev box for staging query job 