### PR TITLE
[wip] infer key type from groupbyservinginfo

### DIFF
--- a/aggregator/src/main/scala/ai/zipline/aggregator/base/TimedAggregators.scala
+++ b/aggregator/src/main/scala/ai/zipline/aggregator/base/TimedAggregators.scala
@@ -150,11 +150,11 @@ class OrderByLimitTimed(
   }
 
   override def denormalize(ir: Any): util.ArrayList[TimeTuple.typ] = {
-    val irCast = ir.asInstanceOf[util.ArrayList[Array[Any]]]
-    val result = new util.ArrayList[TimeTuple.typ](irCast.size())
-    val it = irCast.iterator()
+    val irCast = ir.asInstanceOf[Array[Any]]
+    val result = new util.ArrayList[TimeTuple.typ](irCast.length)
+    val it = irCast.iterator
     while (it.hasNext) {
-      result.add(ArrayUtils.fromArray(it.next()))
+      result.add(ArrayUtils.fromArray(it.next().asInstanceOf[Array[Any]]))
     }
     result
   }

--- a/spark/src/main/scala/ai/zipline/spark/Driver.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Driver.scala
@@ -187,13 +187,8 @@ object Driver {
         fetcher.fetchJoin(Seq(Fetcher.Request(args.name(), castedKeyMap)))
       } else {
         // group bys
-        val groupByServingInfo = fetcher.getGroupByServingInfo(args.name())
-        groupByServingInfo match {
-          case Failure(ex) =>
-            println(s"Failed to find groupByServingInfo for ${args.name}")
-            println(ex.getMessage)
-        }
-        fetcher.fetchGroupBys(Seq(Fetcher.Request(args.name(), castKeysForGroupBy(groupByServingInfo.get, keyMap))))
+        val groupByServingInfo = fetcher.getGroupByServingInfo(args.name()).get
+        fetcher.fetchGroupBys(Seq(Fetcher.Request(args.name(), castKeysForGroupBy(groupByServingInfo, keyMap))))
       }
       val result = Await.result(resultFuture, 5.seconds)
       val awaitTimeMs = (System.nanoTime - startNs) / 1e6d


### PR DESCRIPTION
When users use ztool fetch, we need to infer key type from group by serving info to create requests.

### TODO

- [ ] test with group by fecth
- [ ] test with join fetch

@airbnb/zipline-maintainers 