### PR TITLE
wip latency benchmark tool

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/Driver.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Driver.scala
@@ -1,21 +1,28 @@
 package ai.zipline.spark
 
 import ai.zipline.api
-import ai.zipline.api.Extensions.{GroupByOps, SourceOps}
-import ai.zipline.api.ThriftJsonCodec
+import ai.zipline.api.Extensions.{GroupByOps, MetadataOps, SourceOps}
+import ai.zipline.api.{ThriftJsonCodec, GroupBy => GroupByConf, Join => JoinConf}
 import ai.zipline.online.{Api, Fetcher, MetadataStore}
 import com.google.gson.GsonBuilder
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.thrift.TBase
 import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
-
 import java.io.File
-import scala.collection.JavaConverters.mapAsScalaMapConverter
+import java.util.concurrent.Executors
+
+import scala.collection.JavaConversions.mapAsScalaMap
+import scala.collection.JavaConverters.{asScalaBufferConverter, asScalaIteratorConverter, mapAsScalaMapConverter}
 import scala.collection.mutable
-import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
+import scala.collection.parallel.{ForkJoinTaskSupport, ThreadPoolTaskSupport}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.forkjoin.ForkJoinPool
 import scala.reflect.ClassTag
 import scala.reflect.internal.util.ScalaClassLoader
+import scala.util.{Failure, Success}
+
+import ai.zipline.online.Fetcher.Request
 
 // The mega zipline cli
 object Driver {
@@ -162,6 +169,94 @@ object Driver {
     }
   }
 
+  object BenchmarkCli {
+
+    class Args extends Subcommand("benchmark") with OnlineSubcommand {
+
+      val confPath: ScallopOption[String] =
+        opt[String](required = true, descr = "Path to the Zipline config file")
+      val ds: ScallopOption[String] =
+        opt[String](required = true, descr = "ds to run benchmark")
+      val numKeys: ScallopOption[Int] =
+        opt[Int](required = true, descr = "number of keys to run benchmark")
+      val concurrency: ScallopOption[Int] =
+        opt[Int](required = false, default = Some(5), descr = "number of fetch request running in parallel")
+      val batchSize: ScallopOption[Int] =
+        opt[Int](required = false, default = Some(5), descr = "number of requests in a batch call")
+      val `type`: ScallopOption[String] = choice(Seq("join", "group-by"), descr = "the type of conf to fetch")
+
+    }
+
+    def run(args: Args): Unit = {
+      val session = SparkSessionBuilder.build("zipline benchmark")
+      val fetcher = new Fetcher(args.impl(args.serializableProps).genKvStore)
+      val conf = args.confPath()
+      val (name, keyMaps): (String, Array[Map[String, AnyRef]]) = if (args.`type`() == "join") {
+        println(s"Reading join from file: $conf")
+        val joinConf: JoinConf = ThriftJsonCodec.fromJsonFile[JoinConf](conf, check = true)
+        val joinTable = s"${joinConf.metaData.outputNamespace}.${joinConf.metaData.cleanName}"
+        val leftQuery = joinConf.left.query
+        val keys = joinConf.joinParts.asScala.flatMap {
+          case jp =>
+            val keyColumns = jp.getGroupBy.getKeyColumns.asScala
+            println(keyColumns.mkString(", "))
+            Option(jp.keyMapping) match {
+              case Some(keyMapping) => keyColumns.map { case k: String => keyMapping.map(_.swap)
+                .getOrElse(k, k)
+              }
+              case _ => keyColumns
+            }
+        }
+        println(s"left : ${leftQuery.selects.asScala.filterKeys(k => keys.contains(k))}")
+        val selectClauseStr = leftQuery.selects.asScala.filterKeys(k => keys.contains(k)).map {
+          case (name, expression) => s"($name) as `$name`"
+        }.mkString(",\n     ")
+        val whereClauseStr = s"ds = '${args.ds()}'"
+        val limitClauseStr = s"LIMIT ${args.numKeys()}"
+        val sqlText = s"SELECT $selectClauseStr FROM $joinTable WHERE $whereClauseStr $limitClauseStr"
+        println(s"sqlText: $sqlText")
+        val keyDf = session.sql(sqlText)
+        (joinConf.getMetaData.name, keyDf.collect().map { row => row.getValuesMap[AnyRef](row.schema.fieldNames) })
+      } else {
+        println(s"Reading groupBy from file: $conf")
+        val groupBy = ThriftJsonCodec.fromJsonFile[GroupByConf](conf, true)
+        val keyFields = groupBy.getKeyColumns.asScala
+        println(s"keys: ${keyFields.mkString(", ")}")
+        val groupByName = groupBy.metaData.name
+        val groupByTable = s"${groupBy.metaData.outputNamespace}.${groupBy.metaData.cleanName}_upload"
+        val groupByServingInfo = fetcher.getGroupByServingInfo(groupByName)
+        val keyCodec = groupByServingInfo.keyCodec
+        val sqlText = s"SELECT key_bytes FROM $groupByTable LIMIT ${args.numKeys()}"
+        println(s"sqlText: $sqlText")
+        val keyDf = session.sql(sqlText)
+        (groupByName, keyDf.collect().map { row => keyCodec.decodeMap(row.getAs[Array[Byte]]("key_bytes"))})
+      }
+      val concurrency = args.concurrency()
+      val batchSize = args.batchSize()
+      val pool = Executors.newFixedThreadPool(5)
+      implicit val xc = ExecutionContext.fromExecutorService(pool)
+      val chunkSize = keyMaps.size / concurrency
+      println(s"starting to fetch $name: ${keyMaps.size} records, with concurrency $concurrency")
+
+      val chunks = keyMaps.grouped(chunkSize).toParArray
+      chunks.tasksupport = new ThreadPoolTaskSupport()
+
+      chunks.map { chunk =>
+        val requests = chunk.sliding(batchSize, batchSize).map(_.map(Request(name, _))).toArray
+        val responseFutures: Array[Future[Seq[Fetcher.Response]]] = if (args.`type`() == "group-by") {
+          requests.map(fetcher.fetchGroupBys(_))
+        } else {
+          requests.map(fetcher.fetchJoin(_))
+        }
+        responseFutures.map { f =>
+          Await.result(f, Duration.Inf)
+        }
+        println(s"processed ${requests.size} requests")
+      }
+      println(s"processed ${chunks.size} chunks")
+    }
+  }
+
   object MetadataUploader {
     class Args extends Subcommand("metadata-upload") with OnlineSubcommand {
       val confPath: ScallopOption[String] =
@@ -254,6 +349,8 @@ object Driver {
     addSubcommand(MetadataUploaderArgs)
     object GroupByStreamingArgs extends GroupByStreaming.Args
     addSubcommand(GroupByStreamingArgs)
+    object BenchmarkCliArgs extends BenchmarkCli.Args
+    addSubcommand(BenchmarkCliArgs)
     requireSubcommand()
     verify()
   }
@@ -283,6 +380,7 @@ object Driver {
           }
           case args.MetadataUploaderArgs => MetadataUploader.run(args.MetadataUploaderArgs)
           case args.FetcherCliArgs       => FetcherCli.run(args.FetcherCliArgs)
+          case args.BenchmarkCliArgs     => BenchmarkCli.run(args.BenchmarkCliArgs)
           case _                         => println(s"Unknown subcommand: ${x}")
         }
       case None => println(s"specify a subcommand please")


### PR DESCRIPTION
Move latency benchmark tool in Treehouse PR under driver.

## What is it?

The tool reads from join / group by output table, and sends requests in parallel to measure the read latency. You can configure the concurrency and also the number of requests in the batch to see how it affects the latency.

## How to use it 

### Group by benchmark

- prerequisite: 
    - Must have zipline jar and treehouse online JAR on airflow devbox.
    - Must have group by upload job completed.

#### command
- Run on airflow devbox
- Make sure not to run this with single mussel dispatcher node. Always use `mussel-ml-dispatcher-http.synapse:6252`

```
APP_NAME=zipline-benchmark  /usr/bin/emr-spark-submit --spark-version 2.4.0 --emr-cluster zipline-prod  --queue default  --driver-java-options  ' -Dlog4j.configuration=file:/tmp/log4j_file' --conf 'spark.executor.extraJavaOptions= -XX:ParallelGCThreads=4 -XX:+UseParallelGC -XX:+UseCompressedOops' --conf spark.reducer.maxReqsInFlight=1024 --conf spark.reducer.maxBlocksInFlightPerAddress=1024 --conf spark.reducer.maxSizeInFlight=256M --conf spark.shuffle.file.buffer=1M --conf spark.shuffle.service.enabled=true --conf spark.shuffle.service.index.cache.entries=2048 --conf spark.shuffle.io.serverThreads=128 --conf spark.shuffle.io.backLog=1024 --conf spark.shuffle.registration.timeout=2m --conf spark.shuffle.registration.maxAttempts=5 --conf spark.unsafe.sorter.spill.reader.buffer.size=1M --conf spark.sql.shuffle.partitions=2000 --conf spark.kryoserializer.buffer.max=2000 --conf spark.rdd.compress=true --conf spark.shuffle.compress=true --conf spark.shuffle.spill.compress=true  --conf spark.yarn.submit.waitAppCompletion=false  --conf spark.io.compression.codec=zstd --conf spark.io.compression.zstd.level=2 --conf spark.io.compression.zstd.bufferSize=1M --conf spark.dynamicAllocation.enabled=true --conf spark.dynamicAllocation.minExecutors=2 --conf spark.dynamicAllocation.maxExecutors=8000 --conf spark.default.parallelism=2000 --conf spark.port.maxRetries=20 --conf spark.task.maxFailures=20 --conf spark.stage.maxConsecutiveAttempts=12 --conf spark.maxRemoteBlockSizeFetchToMem=2G --conf spark.network.timeout=90s --conf spark.executor.heartbeatInterval=60s --conf spark.local.dir=/tmp --conf spark.jars.ivy=/tmp --conf spark.executor.cores=1 --conf spark.sql.files.maxPartitionBytes=1073741824 --conf spark.debug.maxToStringFields=1000 --conf spark.driver.maxResultSize=32G --deploy-mode client --master yarn --executor-memory 4G --driver-memory 48G --conf spark.executor.memoryOverhead=2G --conf spark.app.name=bb --conf spark.airflow.dag.name=bb_patrick_yoon_test --conf spark.airflow.taskId=bb_patrick_yoon_test --conf spark.airflow.attemptId=1 --conf 'spark.airflow.cost.meta=\{}' --class ai.zipline.spark.Driver /home/patrick_yoon/zipline/spark/target/scala-2.11/spark-assembly-0.1.0-SNAPSHOT.jar benchmark --online-class com.airbnb.bighead.zipline.online.MusselZiplineOnlineImpl --online-jar ~/treehouse/projects/bighead/zipline/online/build/libs/online-all.jar --num-keys 4000 -Zmussel-host=mussel-ml-dispatcher-http.synapse -Zmussel-port=6252 --conf-path ~/ml_models/zipline/production/group_bys/zipline_test/test_online_group_by_small.v1  -t group-by -d 2021-01-01 --concurrency 5
```

### join benchmark

- prerequisite: 
    - Must have zipline jar and treehouse online JAR on airflow devbox.
    - Must have group by upload job completed for all group bys included.
    - Must have join metadata job completed.
    - Must have join job landed (for getting keys) for the specified ds


#### command
- Run on airflow devbox
- Make sure not to run this with single mussel dispatcher node. Always use `mussel-ml-dispatcher-http.synapse:6252`

```
 APP_NAME=zipline-benchmark  /usr/bin/emr-spark-submit --spark-version 2.4.0 --emr-cluster zipline-prod  --queue default  --driver-java-options  ' -Dlog4j.configuration=file:/tmp/log4j_file' --conf 'spark.executor.extraJavaOptions= -XX:ParallelGCThreads=4 -XX:+UseParallelGC -XX:+UseCompressedOops' --conf spark.reducer.maxReqsInFlight=1024 --conf spark.reducer.maxBlocksInFlightPerAddress=1024 --conf spark.reducer.maxSizeInFlight=256M --conf spark.shuffle.file.buffer=1M --conf spark.shuffle.service.enabled=true --conf spark.shuffle.service.index.cache.entries=2048 --conf spark.shuffle.io.serverThreads=128 --conf spark.shuffle.io.backLog=1024 --conf spark.shuffle.registration.timeout=2m --conf spark.shuffle.registration.maxAttempts=5 --conf spark.unsafe.sorter.spill.reader.buffer.size=1M --conf spark.sql.shuffle.partitions=2000 --conf spark.kryoserializer.buffer.max=2000 --conf spark.rdd.compress=true --conf spark.shuffle.compress=true --conf spark.shuffle.spill.compress=true  --conf spark.yarn.submit.waitAppCompletion=false  --conf spark.io.compression.codec=zstd --conf spark.io.compression.zstd.level=2 --conf spark.io.compression.zstd.bufferSize=1M --conf spark.dynamicAllocation.enabled=true --conf spark.dynamicAllocation.minExecutors=2 --conf spark.dynamicAllocation.maxExecutors=8000 --conf spark.default.parallelism=2000 --conf spark.port.maxRetries=20 --conf spark.task.maxFailures=20 --conf spark.stage.maxConsecutiveAttempts=12 --conf spark.maxRemoteBlockSizeFetchToMem=2G --conf spark.network.timeout=90s --conf spark.executor.heartbeatInterval=60s --conf spark.local.dir=/tmp --conf spark.jars.ivy=/tmp --conf spark.executor.cores=1 --conf spark.sql.files.maxPartitionBytes=1073741824 --conf spark.debug.maxToStringFields=1000 --conf spark.driver.maxResultSize=32G --deploy-mode client --master yarn --executor-memory 4G --driver-memory 48G --conf spark.executor.memoryOverhead=2G --conf spark.app.name=bb --conf spark.airflow.dag.name=bb_patrick_yoon_test --conf spark.airflow.taskId=bb_patrick_yoon_test --conf spark.airflow.attemptId=1 --conf 'spark.airflow.cost.meta=\{}' --class ai.zipline.spark.Driver /home/patrick_yoon/zipline/spark/target/scala-2.11/spark-assembly-0.1.0-SNAPSHOT.jar benchmark --online-class com.airbnb.bighead.zipline.online.MusselZiplineOnlineImpl --online-jar ~/treehouse/projects/bighead/zipline/online/build/libs/online-all.jar --num-keys 4000 -Zmussel-host=mussel-ml-dispatcher-http.synapse -Zmussel-port=6252 --conf-path ~/ml_models/zipline/production/joins/zipline_test/test_online_join_small.v1  -t join -d 2021-01-01 --concurrency 5
```
<img width="1014" alt="Screen Shot 2022-02-07 at 8 47 57 AM" src="https://user-images.githubusercontent.com/3076437/152833266-301d5fc8-c7af-41f3-b6ff-f069d6878dcd.png">


### TODO 

- [x] Make it actually work.
 
- [ ] fix avro issue: Reading some avro bytes group by `key_bytes` in group by upload table gives:

```
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: -52
	at org.apache.avro.io.parsing.Symbol$Alternative.getSymbol(Symbol.java:424)
	at org.apache.avro.io.ResolvingDecoder.doAction(ResolvingDecoder.java:290)
	at org.apache.avro.io.parsing.Parser.advance(Parser.java:88)
	at org.apache.avro.io.ResolvingDecoder.readIndex(ResolvingDecoder.java:267)
	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:179)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:153)
	at org.apache.avro.generic.GenericDatumReader.readField(GenericDatumReader.java:232)
	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:222)
	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:175)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:153)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:145)
	at ai.zipline.online.AvroCodec.decode(AvroCodec.scala:78)
	at ai.zipline.online.AvroCodec.decodeMap(AvroCodec.scala:87)
	at ai.zipline.spark.Driver$BenchmarkCli$$anonfun$23.apply(Driver.scala:232)
	at ai.zipline.spark.Driver$BenchmarkCli$$anonfun$23.apply(Driver.scala:232)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:186)
	at ai.zipline.spark.Driver$BenchmarkCli$.run(Driver.scala:232)
	at ai.zipline.spark.Driver$.main(Driver.scala:385)
	at ai.zipline.spark.Driver.main(Driver.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:849)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:167)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:195)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:86)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:924)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:933)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

### Appendix. How to generated flamegraph?

I used https://app.opsian.com/welcome. It gives interactive flamegraph 


- [ ] Document how it can be used
- [ ] Carefully monitor load on the mussel side.

@airbnb/zipline-maintainers 

