### PR TITLE
[Ztool][Non-urgent] Print help as default

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/Driver.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Driver.scala
@@ -254,7 +254,6 @@ object Driver {
     addSubcommand(MetadataUploaderArgs)
     object GroupByStreamingArgs extends GroupByStreaming.Args
     addSubcommand(GroupByStreamingArgs)
-    requireSubcommand()
     verify()
   }
 
@@ -285,7 +284,7 @@ object Driver {
           case args.FetcherCliArgs       => FetcherCli.run(args.FetcherCliArgs)
           case _                         => println(s"Unknown subcommand: ${x}")
         }
-      case None => println(s"specify a subcommand please")
+      case None => args.printHelp()
     }
     if (shouldExit) {
       System.exit(0)


### PR DESCRIPTION
If someone runs ztool without arguments, redirect to usage and skip the step where they have to rerun with -h

```
(crf__print_help_as_default)cristian_figueroa@MacBook-Pro: zipline $ spark/target-embedded/pack/bin/ztool
  -h, --help   Show help message

Subcommand: join
  -c, --conf-path  <arg>   Path to conf
  -e, --end-date  <arg>    End date to compute as of, start date is taken from
                           conf.
      --skip-equal-check   Check if this join has already run with a different
                           conf, if so it will fail the job
  -s, --step-days  <arg>   Runs backfill in steps, step-days at a time. Default
                           is 30 days
  -h, --help               Show help message

Subcommand: group-by-backfill
  -c, --conf-path  <arg>   Path to conf
  -e, --end-date  <arg>    End date to compute as of, start date is taken from
                           conf.
  -s, --step-days  <arg>   Runs backfill in steps, step-days at a time. Default
                           is 30 days
  -h, --help               Show help message

Subcommand: staging-query-backfill
  -c, --conf-path  <arg>   Path to conf
  -e, --end-date  <arg>    End date to compute as of, start date is taken from
                           conf.
  -s, --step-days  <arg>   Runs backfill in steps, step-days at a time. Default
                           is 30 days
  -h, --help               Show help message

Subcommand: group-by-upload
  -c, --conf-path  <arg>   Path to conf
  -e, --end-date  <arg>    End date to compute as of, start date is taken from
                           conf.
  -h, --help               Show help message

Subcommand: fetch
  -k, --key-json  <arg>        json of the keys to fetch
  -n, --name  <arg>            name of the join/group-by to fetch
      --online-class  <arg>    Fully qualified Online.Api based class. We expect
                               the jar to be on the class path
  -o, --online-jar  <arg>      Path to the jar contain the implementation of
                               Online.Api class
  -t, --type  <arg>            the type of conf to fetch Choices: join, group-by
  -Zkey=value [key=value]...
  -h, --help                   Show help message

Subcommand: metadata-upload
  -c, --conf-path  <arg>       Path to the Zipline config file or directory
      --online-class  <arg>    Fully qualified Online.Api based class. We expect
                               the jar to be on the class path
  -o, --online-jar  <arg>      Path to the jar contain the implementation of
                               Online.Api class
  -Zkey=value [key=value]...
  -h, --help                   Show help message

Subcommand: group-by-streaming
  -c, --conf-path  <arg>         path to groupBy conf
  -d, --debug                    Prints details of data flowing through the
                                 streaming job, skip writing to kv store
  -k, --kafka-bootstrap  <arg>   host:port of a kafka bootstrap server
  -m, --mock-writes              flag - to ignore writing to the underlying kv
                                 store
      --online-class  <arg>      Fully qualified Online.Api based class. We
                                 expect the jar to be on the class path
  -o, --online-jar  <arg>        Path to the jar contain the implementation of
                                 Online.Api class
  -Zkey=value [key=value]...
  -h, --help                     Show help message
  ```