### PR TITLE
[CircleCI] Move to downloads.apache.org

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get -y -q install \
     && apt-get clean
 
 # Install thrift
-RUN curl -sSL "http://apache.mirrors.spacedump.net/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
+RUN curl -sSL "http://downloads.apache.org/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \


### PR DESCRIPTION
Get thrift from downloads.apache.org.

```
(zipline-os) (master)cristian_figueroa@MacBook-Pro: py $ curl -sSLI http://apache.mirrors.spacedump.net/thrift/0.11.0/thrift-0.11.0.tar.gz
curl: (7) Failed to connect to apache.mirrors.spacedump.net port 80: Network is unreachable
(zipline-os) (master)cristian_figueroa@MacBook-Pro: py $ curl -sSLI http://downloads.apache.org/thrift/0.11.0/thrift-0.11.0.tar.gz
HTTP/1.1 302 Found
Date: Wed, 09 Feb 2022 17:18:52 GMT
Server: Apache
Location: https://downloads.apache.org/thrift/0.11.0/thrift-0.11.0.tar.gz
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 200 OK
Date: Wed, 09 Feb 2022 17:18:53 GMT
Server: Apache
Last-Modified: Mon, 06 Jul 2020 14:23:25 GMT
ETag: "37f4d2-5a9c69e2ce520"
Accept-Ranges: bytes
Content-Length: 3667154
Access-Control-Allow-Origin: *
Content-Type: application/x-gzip
```