### PR TITLE
[Driver] Clean streaming logs

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/Driver.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Driver.scala
@@ -10,6 +10,7 @@ import org.apache.thrift.TBase
 import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
 
 import java.io.File
+import java.util.logging.Logger
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.mutable
 import scala.concurrent.Await
@@ -196,7 +197,11 @@ object Driver {
       } else {
         baseBuilder
       }
-      builder.getOrCreate()
+      val spark = builder.getOrCreate()
+      // disable log spam
+      spark.sparkContext.setLogLevel("ERROR")
+      Logger.getLogger("parquet.hadoop").setLevel(java.util.logging.Level.SEVERE)
+      spark
     }
 
     def dataStream(session: SparkSession, host: String, topic: String): DataFrame = {


### PR DESCRIPTION
### What

Moving the same configuration we used for the sparkSessionBuilder logging into the streaming sparkSessionBuilder
ref: https://github.com/airbnb/zipline/blob/master/spark/src/main/scala/ai/zipline/spark/SparkSessionBuilder.scala#L47-L51

### How

Tested with ztool
```
sbt embedded/pack; ztool group-by-streaming -c <redacted> --online-class $ONLINE_CLASS -o $ONLINE_JAR  -k <redacted> -Z...-host=... -Z...-port=... -d
```

@ezvz @nikhilsimha 