### PR TITLE
[TimedAggregator] Two step denormalization casting

### DIFF
--- a/aggregator/src/main/scala/ai/zipline/aggregator/base/TimedAggregators.scala
+++ b/aggregator/src/main/scala/ai/zipline/aggregator/base/TimedAggregators.scala
@@ -150,11 +150,11 @@ class OrderByLimitTimed(
   }
 
   override def denormalize(ir: Any): util.ArrayList[TimeTuple.typ] = {
-    val irCast = ir.asInstanceOf[util.ArrayList[Array[Any]]]
-    val result = new util.ArrayList[TimeTuple.typ](irCast.size())
-    val it = irCast.iterator()
+    val irCast = ir.asInstanceOf[Array[Any]]
+    val result = new util.ArrayList[TimeTuple.typ](irCast.length)
+    val it = irCast.iterator
     while (it.hasNext) {
-      result.add(ArrayUtils.fromArray(it.next()))
+      result.add(ArrayUtils.fromArray(it.next().asInstanceOf[Array[Any]]))
     }
     result
   }


### PR DESCRIPTION
### What

Change the denormalization to a two step array casting.
When receiving the values of Avro and denormalizing for the fetcher ran into casting issue for
`[[long (time), long(value)],....,[long, long]]`

When separating the casting to a two step process it worked.