### PR TITLE
[Run.py] Update cli to separate local from debug streaming

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.30"
+__version__ = "0.0.31"
 
 
 setup(

--- a/spark/src/main/scala/ai/zipline/spark/Driver.scala
+++ b/spark/src/main/scala/ai/zipline/spark/Driver.scala
@@ -227,6 +227,10 @@ object Driver {
         required = false,
         default = Some(false),
         descr = "Prints details of data flowing through the streaming job, skip writing to kv store")
+      val local: ScallopOption[Boolean] = opt[Boolean](
+        required = false,
+        default = Some(false),
+        descr = "Create a dummy group by serving info instead of fetching from kv")
       def parseConf[T <: TBase[_, _]: Manifest: ClassTag]: T =
         ThriftJsonCodec.fromJsonFile[T](confPath(), check = true)
     }
@@ -247,7 +251,7 @@ object Driver {
         dataStream(session, args.kafkaBootstrap.getOrElse(s"${host.get}:${port.get}"), streamingSource.get.cleanTopic)
       val streamingRunner =
         new streaming.GroupBy(inputStream, session, groupByConf, args.impl(args.serializableProps), args.debug())
-      streamingRunner.run(args.debug())
+      streamingRunner.run(args.local())
     }
   }
 


### PR DESCRIPTION
### What

For mutations the schema is stored in the KV store, so it'd be nice to separate local streaming (gb serving info locally + debug) from debug streaming (just debug)