### PR TITLE
fix publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ val embeddedAssemblyStrategy: Setting[_] = assemblyMergeStrategy in assembly := 
 val sparkProvided = sparkBaseSettings :+ providedLibs
 val sparkEmbedded = sparkBaseSettings :+ embeddedLibs :+ embeddedTarget :+ embeddedAssemblyStrategy
 
-lazy val spark_uber = project
+lazy val spark_uber = (project in file("spark"))
   .dependsOn(aggregator.%("compile->compile;test->test"), online)
   .settings(sparkProvided: _*)
 


### PR DESCRIPTION
So we had to specifically set the project files for publish to work since I renamed the sub module "spark_uber" from "spark"