### PR TITLE
[GB] Leverage inferred accuracy

### DIFF
--- a/spark/src/main/scala/ai/zipline/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/zipline/spark/GroupBy.scala
@@ -392,7 +392,7 @@ object GroupBy {
     val mutationSources = groupByConf.sources.asScala.filter { _.isSetEntities }
     val mutationsColumnOrder = inputDf.columns ++ Constants.MutationFields.map(_.name)
     val mutationDf =
-      if (groupByConf.accuracy == Accuracy.TEMPORAL && mutationSources.nonEmpty)
+      if (groupByConf.inferredAccuracy == Accuracy.TEMPORAL && mutationSources.nonEmpty)
         mutationSources
           .map {
             renderDataSourceQuery(_,
@@ -400,7 +400,7 @@ object GroupBy {
                                   queryRange.shift(1),
                                   tableUtils,
                                   groupByConf.maxWindow,
-                                  groupByConf.accuracy,
+                                  groupByConf.inferredAccuracy,
                                   mutations = true)
           }
           .map { tableUtils.sql }


### PR DESCRIPTION
### What

Add consistency between joinPart matching for generated group bys and the data the generated group by needs to generate.

https://github.com/airbnb/zipline/blob/master/spark/src/main/scala/ai/zipline/spark/Join.scala#L145-L160

```
    (joinConf.left.dataModel, joinPart.groupBy.dataModel, joinPart.groupBy.inferredAccuracy) match {
      case (Entities, Events, _)   => partitionRangeGroupBy.snapshotEvents(unfilledRange)
      case (Entities, Entities, _) => partitionRangeGroupBy.snapshotEntities
      case (Events, Events, Accuracy.SNAPSHOT) =>
        genGroupBy(shiftedPartitionRange).snapshotEvents(shiftedPartitionRange)
      case (Events, Events, Accuracy.TEMPORAL) =>
        genGroupBy(unfilledTimeRange.toPartitionRange).temporalEvents(renamedLeftDf, Some(unfilledTimeRange))

      case (Events, Entities, Accuracy.SNAPSHOT) => genGroupBy(shiftedPartitionRange).snapshotEntities

      case (Events, Entities, Accuracy.TEMPORAL) => {
        // Snapshots and mutations are partitioned with ds holding data between <ds 00:00> and ds <23:53>.
        genGroupBy(unfilledTimeRange.toPartitionRange.shift(-1)).entitiesMutations(renamedLeftDf)
      }
    }
  }
  ```