### PR TITLE
[PyApi] More group by validations

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.37"
+__version__ = "0.0.38"
 
 
 setup(


### PR DESCRIPTION
### What

* Move the aggregation validation to group by validation in case aggregations are created using ttypes.
* Validate that input column is part of the selects.
* Allow `Aggregations(<input_column>=Aggregation(operation=...))` syntax
* Add tests.