### PR TITLE
use python3.7 for tox.ini

### DIFF
--- a/api/py/tox.ini
+++ b/api/py/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # 3.7+ required (dataclass)
-envlist = python3.7
+envlist = py3
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
I am getting releasing errors `ERROR:  py37: InterpreterNotFound: python3.7` with `tox`. 

After changing it to `python3.7`, it works again. 

```
$ pip freeze | grep tox 
tox==3.25.0
$ python --version
Python 3.9.12

```


[reference](https://stackoverflow.com/questions/63180349/error-py37-interpreternotfound-python3-7-when-running-tox-from-github)

