### PR TITLE
Fix fetcher method not found

### DIFF
--- a/online/src/main/scala/ai/zipline/online/Api.scala
+++ b/online/src/main/scala/ai/zipline/online/Api.scala
@@ -23,9 +23,8 @@ object KVStore {
 // the main system level api for key value storage
 // used for streaming writes, batch bulk uploads & fetching
 trait KVStore {
-  private val processorCount = Runtime.getRuntime.availableProcessors()
   implicit val executionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(processorCount))
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors()))
 
   def create(dataset: String): Unit
   def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]]


### PR DESCRIPTION
There is an error
```
"main" java.lang.AbstractMethodError: com.airbnb.bighead.zipline.online.MusselZiplineKvStore.ai$zipline$online$KVStore$_setter_$ai$zipline$online$KVStore$$processorCount_$eq(I)V
```

I suspect this is due to how implicits are initialized. The fix is to invoke in-place.
```
run.py --mode=fetch -k  <redacted> -n <redacted> -t group-by --version=0.0.79
```
fails

but `--version=0.0.79_fix` works
