### PR TITLE
[WIP] Fetcher concurrency > available processors

### DIFF
--- a/online/src/main/scala/ai/zipline/online/Api.scala
+++ b/online/src/main/scala/ai/zipline/online/Api.scala
@@ -24,7 +24,7 @@ object KVStore {
 // used for streaming writes, batch bulk uploads & fetching
 trait KVStore {
   implicit val executionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors()))
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(500))
 
   def create(dataset: String): Unit
   def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]]


### PR DESCRIPTION
If fetching is IO bound, which it will usually be, it makes a lot of sense to schedule a lot more parallel fetches than available cores so that we reach full CPU utilization. 

The current approach is dirty, we want to make it less hardcoded.