### PR TITLE
Fixed failed UT with sample config to unblock pip package release 

### DIFF
--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
@@ -3,7 +3,7 @@
     "name": "sample_team.sample_join_from_module.v1",
     "online": 0,
     "production": 0,
-    "customJson": "{\"check_consistency\": false, \"additional_args\": {\"custom_arg\": \"custom_value\"}, \"additional_env\": {\"custom_env\": \"custom_env_value\"}, \"lag\": 0}",
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"additional_args\": {\"custom_arg\": \"custom_value\"}, \"additional_env\": {\"custom_env\": \"custom_env_value\"}}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
       "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",


### PR DESCRIPTION
As titled, the PR will fix the releasing error due to the mismatch of this file. 

We probably need a smarter comparison engine. But for now, let's unblock the release process. 