### PR TITLE
Add additional tests for checking inputColumn in aggregations

### DIFF
--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_missing_input_column.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_missing_input_column.py
@@ -1,0 +1,23 @@
+from sources import test_sources
+from ai.zipline.group_by import (
+    GroupBy,
+    Aggregation,
+    Operation,
+)
+
+
+v1 = GroupBy(
+    sources=test_sources.staging_entities,
+    keys=["s2CellId", "place_id"],
+    aggregations=[
+        Aggregation(operation=Operation.COUNT),
+        Aggregation(operation=Operation.COUNT),
+    ],
+    production=False,
+    table_properties={
+        "sample_config_json": """{"sample_key": "sample_value"}""",
+        "description": "sample description"
+    },
+    online=True,
+    output_namespace="sample_namespace",
+)

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -43,3 +43,16 @@ def test_failed_compile():
         '--input_path=joins/sample_team/',
     ])
     assert result.exit_code != 0
+
+def test_failed_compile_missing_input_column():
+    """
+    Should raise errors as we are trying to create aggregations without input column.
+    """
+    runner = CliRunner()
+    result = runner.invoke(extract_and_convert, [
+        '--zipline_root=test/sample',
+        '--input_path=group_bys/sample_team/sample_group_by_missing_input_column.py',
+        '--debug'
+    ])
+    assert result.exit_code == 1
+    assert "input_column is required for all operations" in str(result.exception)


### PR DESCRIPTION
It is required that every aggregation has a corresponding input column
and we have already included this check in group_by.py

This commit will add tests for the same.