### PR TITLE
[Fetcher] type cast for numerical values and added stacktrace for logging failures 

### DIFF
--- a/api/src/main/scala/ai/zipline/api/Row.scala
+++ b/api/src/main/scala/ai/zipline/api/Row.scala
@@ -121,7 +121,15 @@ object Row {
             mapper(newMap)
         }
       case BinaryType => binarizer(value.asInstanceOf[Array[Byte]])
-      case _          => value
+      case IntType => value.asInstanceOf[Number].intValue()
+      case LongType => value.asInstanceOf[Number].longValue()
+      case DoubleType => value.asInstanceOf[Number].doubleValue()
+      case FloatType => value.asInstanceOf[Number].floatValue()
+      case ShortType => value.asInstanceOf[Number].shortValue()
+      case ByteType => value.asInstanceOf[Number].byteValue()
+      case BooleanType => value.asInstanceOf[Boolean]
+      case StringType => value.toString
+      case _ => value
     }
   }
 }

--- a/online/src/main/scala/ai/zipline/online/Fetcher.scala
+++ b/online/src/main/scala/ai/zipline/online/Fetcher.scala
@@ -456,7 +456,7 @@ class Fetcher(kvStore: KVStore,
             }
         }
         if (loggingTry.isFailure && (debug || Math.random() < 0.01)) {
-          loggingTry.failed.get.printStackTrace()
+          println(s"logging failed due to ${loggingTry.failed.get.getStackTrace.mkString("Array(", ", ", ")")}")
         }
         resp
       }.toSeq)


### PR DESCRIPTION
Because json could not distinguish the different types of numbers, it caused `org.apache.avro.UnresolvedUnionException: Not in union ["null","long"]: xxxx` in fetching and logging. 

This PR will cast the data type to java boxed primitive data types and print the stacktrace if logging fails. 

### Testing plan: 

Tested with @EIFY's case. 

Now there is traffic in staging 
<img width="425" alt="image" src="https://user-images.githubusercontent.com/3771747/173471897-6ef99776-b929-471d-89a5-e57d4ad0406a.png">
