### PR TITLE
Make approx unique count lgk configurable

### DIFF
--- a/aggregator/src/main/scala/ai/zipline/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/zipline/aggregator/row/ColumnAggregator.scala
@@ -242,13 +242,13 @@ object ColumnAggregator {
         }
       case Operation.APPROX_UNIQUE_COUNT =>
         inputType match {
-          case IntType    => simple(new ApproxDistinctCount[Long], toLong[Int])
-          case LongType   => simple(new ApproxDistinctCount[Long])
-          case ShortType  => simple(new ApproxDistinctCount[Long], toLong[Short])
-          case DoubleType => simple(new ApproxDistinctCount[Double])
-          case FloatType  => simple(new ApproxDistinctCount[Double], toDouble[Float])
-          case StringType => simple(new ApproxDistinctCount[String])
-          case BinaryType => simple(new ApproxDistinctCount[Array[Byte]])
+          case IntType    => simple(new ApproxDistinctCount[Long](aggregationPart.getInt("k", Some(8))), toLong[Int])
+          case LongType   => simple(new ApproxDistinctCount[Long](aggregationPart.getInt("k", Some(8))))
+          case ShortType  => simple(new ApproxDistinctCount[Long](aggregationPart.getInt("k", Some(8))), toLong[Short])
+          case DoubleType => simple(new ApproxDistinctCount[Double](aggregationPart.getInt("k", Some(8))))
+          case FloatType  => simple(new ApproxDistinctCount[Double](aggregationPart.getInt("k", Some(8))), toDouble[Float])
+          case StringType => simple(new ApproxDistinctCount[String](aggregationPart.getInt("k", Some(8))))
+          case BinaryType => simple(new ApproxDistinctCount[Array[Byte]](aggregationPart.getInt("k", Some(8))))
           case _          => mismatchException
         }
 

--- a/aggregator/src/test/scala/ai/zipline/aggregator/test/RowAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/zipline/aggregator/test/RowAggregatorTest.scala
@@ -76,6 +76,7 @@ class RowAggregatorTest extends TestCase {
       Builders.AggregationPart(Operation.MAX, "title") -> "D",
       Builders.AggregationPart(Operation.MIN, "title") -> "A",
       Builders.AggregationPart(Operation.APPROX_UNIQUE_COUNT, "title") -> 3L,
+      Builders.AggregationPart(Operation.APPROX_UNIQUE_COUNT, "title", argMap = Map("k" -> "10")) -> 3L,
       Builders.AggregationPart(Operation.UNIQUE_COUNT, "title") -> 3L,
       Builders.AggregationPart(Operation.AVERAGE, "session_lengths") -> 8.0,
       Builders.AggregationPart(Operation.AVERAGE, "session_lengths", bucket = "title") -> sessionLengthAvgByTitle,

--- a/api/py/ai/zipline/group_by.py
+++ b/api/py/ai/zipline/group_by.py
@@ -31,6 +31,10 @@ class Operation():
     FIRST = ttypes.Operation.FIRST
     LAST = ttypes.Operation.LAST
     APPROX_UNIQUE_COUNT = ttypes.Operation.APPROX_UNIQUE_COUNT
+    # refer to the chart here to tune your sketch size with lgK
+    # default is 8
+    # https://github.com/apache/incubator-datasketches-java/blob/master/src/main/java/org/apache/datasketches/cpc/CpcSketch.java#L180
+    APPROX_UNIQUE_COUNT_LGK = collector(ttypes.Operation.APPROX_UNIQUE_COUNT)
     UNIQUE_COUNT = ttypes.Operation.UNIQUE_COUNT
     COUNT = ttypes.Operation.COUNT
     SUM = ttypes.Operation.SUM

--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.43"
+__version__ = "0.0.44"
 
 
 setup(


### PR DESCRIPTION
We want to make the CPC sketch algorithm to be configurable for approx unique count operation. This PR will add `APPROX_UNIQUE_COUNT_LGK` to accept a param. 

### Testing plan: 
- [x] added unit testing cases 
- [x] compiled with search's Python config. 