### PR TITLE
[OOC] Adding consistency check arguments to run.py

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -9,7 +9,7 @@ with open("requirements/base.in", "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "0.0.45"
+__version__ = "0.0.46"
 
 
 setup(


### PR DESCRIPTION
- Starting with Zipline v2.1, we support consistency checks from Driver.scala
- This commit will extend run.py to support consistency arguments that can be
  invoked by the Airflow jobs.

- Fix a minor typo in the devnotes.md