### PR TITLE
Extend generic input type for Histogram operation

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -224,19 +224,19 @@ class Variance extends SimpleAggregator[Double, Array[Any], Double] {
   override def isDeletable: Boolean = false
 }
 
-class Histogram(k: Int = 0) extends SimpleAggregator[String, util.Map[String, Int], util.Map[String, Int]] {
-  type IrMap = util.Map[String, Int]
+class Histogram[T](k: Int = 0) extends SimpleAggregator[T, util.Map[T, Int], util.Map[T, Int]] {
+  type IrMap = util.Map[T, Int]
   override def outputType: DataType = MapType(StringType, IntType)
 
   override def irType: DataType = outputType
 
-  override def prepare(input: String): IrMap = {
-    val result = new util.HashMap[String, Int]()
+  override def prepare(input: T): IrMap = {
+    val result = new util.HashMap[T, Int]()
     result.put(input, 1)
     result
   }
 
-  def incrementInMap(ir: IrMap, input: String, count: Int = 1): IrMap = {
+  def incrementInMap(ir: IrMap, input: T, count: Int = 1): IrMap = {
     val old = ir.get(input)
     val newVal = if (old == null) count else old + count
     if (newVal == 0) {
@@ -248,7 +248,7 @@ class Histogram(k: Int = 0) extends SimpleAggregator[String, util.Map[String, In
   }
 
   // mutating
-  override def update(ir: IrMap, input: String): IrMap = {
+  override def update(ir: IrMap, input: T): IrMap = {
     incrementInMap(ir, input)
   }
 
@@ -271,7 +271,7 @@ class Histogram(k: Int = 0) extends SimpleAggregator[String, util.Map[String, In
       val heap = new util.ArrayList[Int]()
       while (it.hasNext) { pq.insert(heap, it.next().getValue) }
       val cutOff = pq.sort(heap).get(k - 1)
-      val newResult = new util.HashMap[String, Int]()
+      val newResult = new util.HashMap[T, Int]()
       val itNew = ir.entrySet().iterator()
       while (itNew.hasNext && newResult.size() < k) {
         val entry = itNew.next()
@@ -285,12 +285,12 @@ class Histogram(k: Int = 0) extends SimpleAggregator[String, util.Map[String, In
     }
   }
 
-  override def delete(ir: IrMap, input: String): IrMap = {
+  override def delete(ir: IrMap, input: T): IrMap = {
     incrementInMap(ir, input, -1)
   }
 
   override def clone(ir: IrMap): IrMap = {
-    val result = new util.HashMap[String, Int]();
+    val result = new util.HashMap[T, Int]();
     result.putAll(ir);
     result
   }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/RowAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/RowAggregatorTest.scala
@@ -33,16 +33,16 @@ object TestRow {
 class RowAggregatorTest extends TestCase {
   def testUpdate(): Unit = {
     val rows = List(
-      TestRow(1L, 4, 5.0f, "A", Seq(5, 3, 4), Seq("D", "A", "B", "A")),
-      TestRow(2L, 3, 4.0f, "B", Seq(6, null), Seq()),
-      TestRow(3L, 5, 7.0f, "D", null, null),
-      TestRow(4L, 7, 1.0f, "A", Seq(), Seq("B", "A", "D")),
-      TestRow(5L, 3, 1.0f, "B", Seq(null), Seq("A", "B", "C"))
+      TestRow(1L, 4, 5.0f, "A", Seq(5, 3, 4), Seq("D", "A", "B", "A"), Seq(5, 3, 4)),
+      TestRow(2L, 3, 4.0f, "B", Seq(6, null), Seq(), Seq()),
+      TestRow(3L, 5, 7.0f, "D", null, null, null),
+      TestRow(4L, 7, 1.0f, "A", Seq(), Seq("B", "A", "D"), Seq(5, 3, 4)),
+      TestRow(5L, 3, 1.0f, "B", Seq(null), Seq("A", "B", "C"), Seq())
     )
 
     val rowsToDelete = List(
-      TestRow(4L, 2, 1.0f, "A", Seq(1, null), Seq("B", "C", "D", "H")),
-      TestRow(5L, 1, 2.0f, "H", Seq(1), Seq())
+      TestRow(4L, 2, 1.0f, "A", Seq(1, null), Seq("B", "C", "D", "H"), Seq(5)),
+      TestRow(5L, 1, 2.0f, "H", Seq(1), Seq(), Seq())
     )
 
     val schema = List(
@@ -51,7 +51,8 @@ class RowAggregatorTest extends TestCase {
       "rating" -> FloatType,
       "title" -> StringType,
       "session_lengths" -> ListType(IntType),
-      "hist_input" -> ListType(StringType)
+      "hist_input" -> ListType(StringType),
+      "hist_input_int" -> ListType(IntType)
     )
 
     val sessionLengthAvgByTitle = new java.util.HashMap[String, Double]()
@@ -62,6 +63,10 @@ class RowAggregatorTest extends TestCase {
     val histogram = new java.util.HashMap[String, Int]()
     histogram.put("A", 4)
     histogram.put("B", 2)
+
+    val histogramInt = new java.util.HashMap[Integer, Int]()
+    histogramInt.put(3, 2)
+    histogramInt.put(4, 2)
 
     val specsAndExpected: Array[(AggregationPart, Any)] = Array(
       Builders.AggregationPart(Operation.AVERAGE, "views") -> 19.0 / 3,
@@ -79,7 +84,8 @@ class RowAggregatorTest extends TestCase {
       Builders.AggregationPart(Operation.UNIQUE_COUNT, "title") -> 3L,
       Builders.AggregationPart(Operation.AVERAGE, "session_lengths") -> 8.0,
       Builders.AggregationPart(Operation.AVERAGE, "session_lengths", bucket = "title") -> sessionLengthAvgByTitle,
-      Builders.AggregationPart(Operation.HISTOGRAM, "hist_input", argMap = Map("k" -> "2")) -> histogram
+      Builders.AggregationPart(Operation.HISTOGRAM, "hist_input", argMap = Map("k" -> "2")) -> histogram,
+      Builders.AggregationPart(Operation.HISTOGRAM, "hist_input_int", argMap = Map("k" -> "2")) -> histogramInt
     )
 
     val (specs, expectedVals) = specsAndExpected.unzip


### PR DESCRIPTION
As titled, extend the input type for Histogram to generic. Otherwise, we are seeing type cast errors for non string inputs. 

### Testing plan: 
- [x] Added new unit testing case 