### PR TITLE
Refactor step-days to offline subcommand

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -199,6 +199,11 @@ object Driver {
         opt[String](required = true, descr = "Path to the Chronon join conf file to compute consistency for")
       val endDate: ScallopOption[String] =
         opt[String](required = false, descr = "End date to compute metrics until.")
+      // todo: implement step day logic for ConsistencyJob.scala
+      val stepDays: ScallopOption[Int] =
+        opt[Int](required = false,
+          descr = "Runs consistency metrics job in steps, step-days at a time. Default is 30 days",
+          default = Option(30))
     }
 
     /**


### PR DESCRIPTION
This PR will refactor the step day into the offline subcommand. 

For a corner case, when user set step days for a join job, online offline consistency check job will error out due to unknown param of step day. It will be addressed with this change. 

### testing plan: 
- [x] tested with the corner case mentioned above 