### PR TITLE
[Fetcher] Throw exception fast when no join metadata is found.

### DIFF
--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -50,9 +50,12 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     val context =
       if (result.isSuccess) Metrics.Context(Metrics.Environment.MetaDataFetching, result.get.join)
       else Metrics.Context(Metrics.Environment.MetaDataFetching, join = name)
-    context.withSuffix("join").histogram(Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTimeMs)
     // Throw exception after metrics. No join metadata is bound to be a critical failure.
-    if (result.isFailure) throw result.failed.get
+    if (result.isFailure) {
+      context.withSuffix("join").increment(Metrics.Name.Exception)
+      throw result.failed.get
+    }
+    context.withSuffix("join").histogram(Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTimeMs)
     result
   })
 


### PR DESCRIPTION
### What

Throwing exception early for no join metadata.
The current state is we operate on a Failure try and leads to rare exceptions in the downstream KV store which are hard to debug.

### How

Threw an exception and it's much nicer.

Now:
```
python ~/venv/lib/python3.7/site-packages/ai/chronon/repo/run.py --chronon-jar ~/spark_uber-assembly-local.jar --mode=fetch --key-json '{"some_key":"0"}' --name 'non-existing'

Building new stats cache for Context(metadata.fetch,non-existing,null,null,false,null,null,null,null,join)
Exception in thread "main" java.lang.RuntimeException: Couldn't fetch ai.chronon.api.Join for key joins/non-existing. Perhaps metadata upload wasn't successful.
	at ai.chronon.online.MetadataStore$$anonfun$getConf$1.applyOrElse(MetadataStore.scala:33)
	at ai.chronon.online.MetadataStore$$anonfun$getConf$1.applyOrElse(MetadataStore.scala:30)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36)
	at scala.util.Failure.recoverWith(Try.scala:203)
	at ai.chronon.online.MetadataStore.getConf(MetadataStore.scala:30)
	at ai.chronon.online.MetadataStore$$anonfun$getJoinConf$1.apply(MetadataStore.scala:42)
	at ai.chronon.online.MetadataStore$$anonfun$getJoinConf$1.apply(MetadataStore.scala:40)
	at ai.chronon.online.TTLCache$$anon$1.apply(TTLCache.scala:14)
	at ai.chronon.online.TTLCache$$anon$1.apply(TTLCache.scala:10)
	at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1853)
	at ai.chronon.online.TTLCache.apply(TTLCache.scala:22)
	at ai.chronon.online.BaseFetcher$$anonfun$30.apply(Fetcher.scala:271)
	at ai.chronon.online.BaseFetcher$$anonfun$30.apply(Fetcher.scala:270)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	at scala.collection.immutable.List.map(List.scala:296)
	at ai.chronon.online.BaseFetcher.fetchJoin(Fetcher.scala:270)
	at ai.chronon.online.Fetcher.fetchJoin(Fetcher.scala:422)
	at ai.chronon.spark.Driver$FetcherCli$.run(Driver.scala:163)
	at ai.chronon.spark.Driver$.main(Driver.scala:355)
	at ai.chronon.spark.Driver.main(Driver.scala)
Caused by: java.lang.RuntimeException: Request for key joins/non-existing in dataset <redacted>_METADATA failed
	at ai.chronon.online.KVStore$class.getString(Api.scala:52)
	at <onlineImpl class>
	at ai.chronon.online.MetadataStore.getConf(MetadataStore.scala:28)
	... 18 more
Caused by: <Underlying onlineImpl KV Store Trace>
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:36)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	```
	
	Before:
	```
	Building new stats cache for Context(metadata.fetch,non-existing,null,null,false,null,null,null,null,join)
KV multiGet request failed for keys: ArrayBuffer()
Original Requests:
<Stacktrace from onlineImplClass
	... 6 more
	```
	
	