### PR TITLE
Type system bridge for py->thrift->scala

### DIFF
--- a/api/src/test/scala/ai/chronon/api/test/DataTypeConversionTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/DataTypeConversionTest.scala
@@ -1,0 +1,38 @@
+package ai.chronon.api.test
+
+import ai.chronon.api._
+import org.apache.thrift.TSerializer
+import org.apache.thrift.protocol.TSimpleJSONProtocol
+import org.junit.Assert._
+import org.junit.Test
+
+class DataTypeConversionTest {
+  @Test
+  def testDataTypeToThriftAndBack(): Unit = {
+    // build some complex type
+    val dType = StructType(
+      "root",
+      Array(
+        StructField("map", MapType(
+          StructType("key", Array(
+            StructField("a", IntType),
+            StructField("b", FloatType)
+          )),
+          StructType("value", Array(
+            StructField("c", StructType("inner",
+              Array(StructField("d", IntType)))))
+            )
+          )
+        )))
+    val thriftType = DataType.toTDataType(dType)
+
+    // serialize with TSimpleJson - this is what python code will do
+    val jsonSerializer = new TSerializer(new TSimpleJSONProtocol.Factory())
+    val json = new String(jsonSerializer.serialize(thriftType))
+    println(json)
+
+    val reversedTType = ThriftJsonCodec.fromJsonStr[TDataType](json, check = true, classOf[TDataType])
+    val reversed = DataType.fromTDataType(reversedTType)
+    assertEquals(dType, reversed)
+  }
+}

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -204,3 +204,37 @@ struct GroupByServingInfo {
     //       2. batch_upload_lag = batch_upload_time - batch_data_time
     5: optional string batchEndDate
 }
+
+// DataKind + TypeParams = DataType
+// for primitive types there is no need for params
+enum DataKind {
+    // non parametric types
+    BOOLEAN = 0,
+    BYTE = 1,
+    SHORT = 2,
+    INT = 3,
+    LONG = 4,
+    FLOAT = 5,
+    DOUBLE = 6,
+    STRING = 7,
+    BINARY = 8,
+    DATE = 9,
+    TIMESTAMP = 10,
+
+    // parametric types
+    MAP = 11,
+    LIST = 12,
+    STRUCT = 13,
+}
+
+struct DataField {
+    1: optional string name
+    2: optional TDataType dataType
+}
+
+// TDataType because DataType has idiomatic implementation in scala and py
+struct TDataType {
+    1: DataKind kind
+    2: optional list<DataField> params
+    3: optional string name // required only for struct types
+}

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ lazy val api = project
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10",
       "org.scala-lang" % "scala-reflect" % "2.11.12",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.9.10",
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0"
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0",
+      "com.novocode" % "junit-interface" % "0.11" % "test"
     ),
     unmanagedSourceDirectories in Compile ++= {
       (unmanagedSourceDirectories in Compile).value.map { dir =>
@@ -70,13 +71,12 @@ lazy val api = project
   )
 
 lazy val aggregator = project
-  .dependsOn(api)
+  .dependsOn(api.%("compile->compile;test->test"))
   .settings(
     publishSettings,
     crossScalaVersions := List("2.11.12", "2.13.6"),
     libraryDependencies ++= Seq(
       "com.yahoo.datasketches" % "sketches-core" % "0.13.4",
-      "com.novocode" % "junit-interface" % "0.11" % "test",
       "com.google.code.gson" % "gson" % "2.8.6"
     )
   )


### PR DESCRIPTION
We want people to be able to specify types in python for data that is coming from external sources.

This PR focuses only on the types itself - we will have other PRs to 
1. add external source w/ external source registry to API
2. corresponding fetcher changes to specify external sources with mock external source along with tests.
3. Log schema version storage in kvstore + Logging support in fetcher
4. Log parsing and flattening.
5. Schema evolution in log processed tables. 