### PR TITLE
[PyApi] Allow addtional arguments to join to be passed to custom json

### DIFF
--- a/api/py/ai/chronon/join.py
+++ b/api/py/ai/chronon/join.py
@@ -56,7 +56,8 @@ def Join(left: api.Source,
          env: Dict[str, Dict[str, str]] = None,
          lag: int = 0,
          skew_keys: Dict[str, List[str]] = None,
-         sample_percent: float = None  # will sample all the requests based on sample percent
+         sample_percent: float = None,  # will sample all the requests based on sample percent
+         **kwargs
          ) -> api.Join:
     # create a deep copy for case: multiple LeftOuterJoin use the same left,
     # validation will fail after the first iteration
@@ -98,6 +99,7 @@ def Join(left: api.Source,
 
     if additional_env:
         custom_json["additional_env"] = additional_env
+    custom_json.update(kwargs)
 
     metadata = api.MetaData(
         online=online,

--- a/api/py/test/test_join.py
+++ b/api/py/test/test_join.py
@@ -2,6 +2,7 @@ from ai.chronon.join import Join
 from ai.chronon.api import ttypes as api
 
 import pytest
+import json
 
 
 def event_source(table):
@@ -51,3 +52,12 @@ def test_deduped_dependencies():
         left=event_source("sample_namespace.sample_table"),
         right_parts=[right_part(event_source("sample_namespace.sample_table"))])
     assert len(join.metaData.dependencies) == 1
+
+
+def test_additional_args_to_custom_json():
+    join = Join(
+        left=event_source("sample_namespace.sample_table"),
+        right_parts=[right_part(event_source("sample_namespace.sample_table"))],
+        team_override="some_other_team_value"
+    )
+    assert json.loads(join.metaData.customJson)['team_override'] == "some_other_team_value"


### PR DESCRIPTION
### What

Expand the join python api so that if additional arbitrary arguments are passed these are received and stored in customJson

ai.chronon.group_by already has this.

### Why

This can be used for company specific overrides or settings. The specific case in mind is add an override to a field in the teams.json for cost attribution purposes.

### Who

@nikhilsimha @better365 