### PR TITLE
allow lag by hour in Join per JoinPart

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -6,6 +6,7 @@ object Constants {
   val TimeColumn: String = "ts"
   val PartitionColumn: String = "ds"
   val TimePartitionColumn: String = "ts_ds"
+  val JoinTimePartitionColumn: String = "join_ts_ds"
   val ReversalColumn: String = "is_before"
   val MutationTimeColumn: String = "mutation_ts"
   val ReservedColumns: Seq[String] =

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -415,6 +415,7 @@ object Extensions {
   implicit class JoinPartOps(joinPart: JoinPart) extends JoinPart(joinPart) {
     lazy val fullPrefix = (Option(prefix) ++ Some(groupBy.getMetaData.cleanName)).mkString("_")
     lazy val leftToRight: Map[String, String] = rightToLeft.map { case (key, value) => value -> key }
+    val lagHour = 24
 
     def rightToLeft: Map[String, String] = {
       val rightToRight = ScalaVersionSpecificCollectionsConverter
@@ -439,6 +440,12 @@ object Extensions {
       newJoinPart.setGroupBy(newJoinPart.groupBy.copyForVersioningComparison)
       newJoinPart
     }
+
+    def isJoinShiftByDays: Boolean = { lagHour % 24 == 0 }
+    def joinShiftDays: Int = { lagHour / 24 }
+    def joinShiftSeconds: Int = { lagHour * 3600 }
+    def joinShiftMinDays: Int = { Math.floor(lagHour / 24.0).toInt }
+    def joinShiftMaxDays: Int = { Math.ceil(lagHour / 24.0).toInt }
   }
 
   implicit class JoinOps(val join: Join) extends Serializable {

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -90,6 +90,6 @@ case class PartitionRange(start: String, end: String) extends DataRange {
       .takeWhile(_ <= end)
   }
 
-  def shift(days: Int): PartitionRange =
-    PartitionRange(Constants.Partition.shift(start, days), Constants.Partition.shift(end, days))
+  def shift(days: Int, endShiftDays: Option[Int] = None): PartitionRange =
+    PartitionRange(Constants.Partition.shift(start, days), Constants.Partition.shift(end, endShiftDays.getOrElse(days)))
 }


### PR DESCRIPTION
1. Allow lag by hour in join per JoinPart. It should be straight forward if we need to change to minutes/seconds.
2. Use rightUnfilledRange instead of the whole leftRange in some cases.
3. I didn't add the lag as param in GroupBy config. We need to verify if the lag is stable across different partitions, otherwise setting a lag per GroupBy could be worse than 1 day lag (best case scenario)

@nikhilsimha @better365 @hzding621 