### PR TITLE
Increase ttl for statsCache

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -92,7 +92,8 @@ object Metrics {
                                     "localhost",
                                     8125,
                                     ctx.toTags: _*)
-      }
+      },
+      ttlMillis = 5 * 24 * 60 * 60 * 1000 // 5 days
     )
   }
 


### PR DESCRIPTION
Current stats cache is maxing out kyoo threads. Making TTL longer to 5 days from previous default 2 hours. 

Reviewers : 
@nikhilsimha @vamseeyarla 