### PR TITLE
Change drop to archive during join definition update

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.util.sketch.BloomFilter
 
 import java.time.Instant
-
+import java.time.format.DateTimeFormatter
 import scala.collection.JavaConverters._
 import scala.collection.parallel.ParMap
 
@@ -265,7 +265,7 @@ class Join(joinConf: api.Join, endPartition: String, tableUtils: TableUtils) {
     }
 
     // First run command to archive tables that have changed semantically since the last run
-    val jobRunTimestamp = Instant.now().toEpochMilli
+    val jobRunTimestamp = Instant.now()
     tablesToRecompute().foreach(_.foreach(tableName => tableUtils.archiveTableIfExists(tableName, jobRunTimestamp)))
 
     joinConf.setups.foreach(tableUtils.sql)


### PR DESCRIPTION
change the behavior of table dropping to archiving (i.e. renaming) when we detect a change in the join definition hash. 

archive table name is suffixed with a timestamp of the job run time. all table archived in this run will have the same timestamp.

**testing**

tested with [example](https://git.musta.ch/airbnb/ml_models/compare/haozhen--zipline-test?expand=1) groupby / join. 
output from log:
```
Comparing Hashes:
New: Map(zipline_test.zipline_test_test_v7_zipline_test_test_v1 -> KZ4LO2/FAy, zipline_test.zipline_test_test_v7_zipline_test_test_v3 -> KeOcTpwlGC, left_source -> 8px32C+aQR),
Old: Map(left_source -> 4/o475eAax, zipline_test.zipline_test_test_v7_zipline_test_test_v3 -> KeOcTpwlGC, zipline_test.zipline_test_test_v7_zipline_test_test_v1 -> KZ4LO2/FAy)
Archiving table with command: ALTER TABLE zipline_test.zipline_test_test_v7_zipline_test_test_v3 RENAME TO zipline_test.zipline_test_test_v7_zipline_test_test_v3_2022_08_24_23_39_24

----[Running query]----
ALTER TABLE zipline_test.zipline_test_test_v7_zipline_test_test_v3 RENAME TO zipline_test.zipline_test_test_v7_zipline_test_test_v3_2022_08_24_23_39_24
----[End of Query]----

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Archiving table with command: ALTER TABLE zipline_test.zipline_test_test_v7_zipline_test_test_v1 RENAME TO zipline_test.zipline_test_test_v7_zipline_test_test_v1_2022_08_24_23_39_24

----[Running query]----
ALTER TABLE zipline_test.zipline_test_test_v7_zipline_test_test_v1 RENAME TO zipline_test.zipline_test_test_v7_zipline_test_test_v1_2022_08_24_23_39_24
----[End of Query]----

Archiving table with command: ALTER TABLE zipline_test.zipline_test_test_v7 RENAME TO zipline_test.zipline_test_test_v7_2022_08_24_23_39_24

----[Running query]----
ALTER TABLE zipline_test.zipline_test_test_v7 RENAME TO zipline_test.zipline_test_test_v7_2022_08_24_23_39_24
----[End of Query]----
```

@nikhilsimha 