### PR TITLE
[Analyze] Run the setups of Joins and GroupBys as part of the Analyzer

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -132,6 +132,7 @@ class Analyzer(tableUtils: TableUtils,
                      prefix: String = "",
                      includeOutputTableName: Boolean = false,
                      enableHitter: Boolean = false): (api.StructType) = {
+    groupByConf.setups.foreach(tableUtils.sql)
     val groupBy = GroupBy.from(groupByConf, range, tableUtils, finalize = true)
     val name = "group_by/" + prefix + groupByConf.metaData.name
     println(s"""|Running GroupBy analysis for $name ...""".stripMargin)
@@ -163,6 +164,7 @@ class Analyzer(tableUtils: TableUtils,
   def analyzeJoin(joinConf: api.Join, enableHitter: Boolean = false): Array[String] = {
     val name = "joins/" + joinConf.metaData.name
     println(s"""|Running join analysis for $name ...""".stripMargin)
+    joinConf.setups.foreach(tableUtils.sql)
     val leftDf = new Join(joinConf, endDate, tableUtils).leftDf(range).get
     val analysis = if(enableHitter) analyze(leftDf, joinConf.leftKeyCols, joinConf.left.table) else ""
     val leftSchema = leftDf.schema.fields.map { field => s"  ${field.name} => ${field.dataType}" }


### PR DESCRIPTION
Currently Analyzer doesn't seem to run the setups defined under
Join and GroupBy conf and this can result in failures when reading
data that needs these properties. This change will ensure that we 
run these in the spark session before starting the Analyzer.