### PR TITLE
Update run.py to take maven mirror url

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -112,12 +112,11 @@ def download_only_once(url, path):
 
 
 @retry_decorator(retries=3, backoff=50)
-def download_jar(version, jar_type='uber', release_tag=None, spark_version="2.4.0", repo=""):
+def download_jar(version, jar_type='uber', release_tag=None, spark_version="2.4.0"):
     assert spark_version in SUPPORTED_SPARK, (
         f"Received unsupported spark version {spark_version}. Supported spark versions are {SUPPORTED_SPARK}")
     scala_version = SCALA_VERSION_FOR_SPARK[spark_version]
-    # maven_mirror_prefix example "https://artifactory.d.musta.ch/artifactory/maven-mirror"
-    maven_url_prefix = get_maven_mirror_prefix(repo)
+    maven_url_prefix = os.environ.get('CHRONON_MAVEN_MIRROR_PREFIX', None)
     default_url_prefix = "https://s01.oss.sonatype.org/service/local/repositories/public/content"
     url_prefix = maven_url_prefix if maven_url_prefix else default_url_prefix
     base_url = "{}/ai/chronon/spark_{}_{}".format(
@@ -165,21 +164,6 @@ def set_common_env(repo):
             teams_json = json.load(teams_file)
             env = teams_json.get('default', {}).get("common_env", {})
             set_env_dict(env)
-    except FileNotFoundError as e:
-        logging.error(
-            "Invalid working directory: {}, please ensure to run the command inside the zipline/ folder"
-            .format(os.path.abspath(repo)))
-        raise e
-
-
-def get_maven_mirror_prefix(repo):
-    if not repo:
-        return None
-    try:
-        with open(os.path.join(repo, 'teams.json'), 'r') as teams_file:
-            teams_json = json.load(teams_file)
-            maven_mirror_prefix = teams_json.get('default', {}).get("maven_mirror_prefix", {})
-            return maven_mirror_prefix.strip("/") if maven_mirror_prefix else maven_mirror_prefix
     except FileNotFoundError as e:
         logging.error(
             "Invalid working directory: {}, please ensure to run the command inside the zipline/ folder"
@@ -332,6 +316,5 @@ if __name__ == "__main__":
     jar_path = args.chronon_jar if args.chronon_jar else download_jar(
         args.version, jar_type=jar_type,
         release_tag=args.release_tag,
-        spark_version=args.spark_version,
-        repo=chronon_repo_path)
+        spark_version=args.spark_version)
     Runner(args, jar_path).run()


### PR DESCRIPTION
Allow user set `CHRONON_MAVEN_MIRROR_PREFIX` in common_env for maven releasing. 
Ref - https://airbnb.slack.com/archives/GHZA25NH2/p1664917799700469

Next step : update ml_model repo team.json to add the prefix variable 

Tested in `ml_model` repo and able to download jar from maven path if specified : 
```
Downloading jar from url: https://artifactory.d.musta.ch/artifactory/maven-mirror/ai/chronon/spark_uber_2.11
Running command: curl -s https://artifactory.d.musta.ch/artifactory/maven-mirror/ai/chronon/spark_uber_2.11/maven-metadata.xml
No file at: /tmp/spark_uber_2.11-0.0.9-assembly.jar. Downloading..
Running command: curl https://artifactory.d.musta.ch/artifactory/maven-mirror/ai/chronon/spark_uber_2.11/0.0.9/spark_uber_2.11-0.0.9-assembly.jar -o /tmp/spark_uber_2.11-0.0.9-assembly.jar --connect-timeout 10
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24.3M  100 24.3M    0     0  9559k      0  0:00:02  0:00:02 --:--:-- 9592k
```

@nikhilsimha @cristianfr  @vamseeyarla 