### PR TITLE
feature stitching log & backfill

### DIFF
--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -177,6 +177,7 @@ struct Join {
     // specifying skew keys will also help us scan less raw data before aggregation & join
     // example: {"zipcode": ["94107", "78934"], "country": ["'US'", "'IN'"]}
     4: optional map<string,list<string>> skewKeys
+    5: optional list<string> rowIdColumns
 }
 
 

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -356,11 +356,11 @@ case class JoinCodec(conf: JoinOps,
                      keyCodec: AvroCodec,
                      valueCodec: AvroCodec)
     extends Serializable {
-  val keys: Array[String] = keySchema.fields.iterator.map(_.name).toArray
-  val values: Array[String] = valueSchema.fields.iterator.map(_.name).toArray
+  lazy val keys: Array[String] = keySchema.fields.iterator.map(_.name).toArray
+  lazy val values: Array[String] = valueSchema.fields.iterator.map(_.name).toArray
 
-  val keyFields: Array[StructField] = keySchema.fields
-  val valueFields: Array[StructField] = valueSchema.fields
+  lazy val keyFields: Array[StructField] = keySchema.fields
+  lazy val valueFields: Array[StructField] = valueSchema.fields
 
   /*
    * Get the serialized string repr. of the logging schema.

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -48,6 +48,8 @@ class ChrononKryoRegistrator extends KryoRegistrator {
     //kryo.setWarnUnregisteredClasses(true)
     val common = Seq(
       "org.apache.spark.sql.execution.joins.UnsafeHashedRelation",
+      "org.apache.spark.sql.execution.joins.LongHashedRelation",
+      "org.apache.spark.sql.execution.joins.LongToUnsafeRowMap",
       "org.apache.spark.internal.io.FileCommitProtocol$TaskCommitMessage",
       "org.apache.spark.sql.execution.datasources.ExecutedWriteSummary",
       "org.apache.spark.sql.execution.datasources.BasicWriteTaskStats",

--- a/spark/src/main/scala/ai/chronon/spark/Extensions.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Extensions.scala
@@ -76,8 +76,13 @@ object Extensions {
 
     def save(tableName: String,
              tableProperties: Map[String, String] = null,
-             partitionColumns: Seq[String] = Seq(Constants.PartitionColumn)): Unit = {
-      TableUtils(df.sparkSession).insertPartitions(df, tableName, tableProperties, partitionColumns)
+             partitionColumns: Seq[String] = Seq(Constants.PartitionColumn),
+             autoExpand: Boolean = false): Unit = {
+      TableUtils(df.sparkSession).insertPartitions(df,
+                                                   tableName,
+                                                   tableProperties,
+                                                   partitionColumns,
+                                                   autoExpand = autoExpand)
     }
 
     def saveUnPartitioned(tableName: String, tableProperties: Map[String, String] = null): Unit = {

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -4,7 +4,7 @@ import ai.chronon.aggregator.base.TimeTuple
 import ai.chronon.aggregator.row.RowAggregator
 import ai.chronon.aggregator.windowing._
 import ai.chronon.api
-import ai.chronon.api.{Constants}
+import ai.chronon.api.Constants
 import ai.chronon.api.DataModel.{Entities, Events}
 import ai.chronon.api.Extensions._
 import ai.chronon.spark.Extensions._


### PR DESCRIPTION
Update Join job to combine logging and backfill. 

Design: 
1. prefer log over backfill: use logging as source of truth to retrieve PITC feature values when it is available in log table (from https://github.com/airbnb/chronon/pull/310); otherwise, run the default offline compute logic to generate feature values. 
2. the join key between left and log table is defined in the join conf. we expect this to be a client-defined "request id" field that is present in both left table and passed to log as a contextual feature. otherwise, this fallbacks to (`keys` + `ts`)
3. reproducibility: because log table is considered immutable (i.e. we should never have a scenario where we run a stitching job first, and then the log table is modified without letting chronon know), reproducibility should be guaranteed. 

Detailed workflow
1. first join left table and flattened log table and save to an intermediate location
5. when computing join parts, we only run offline compute for the rows that do not already have the join part columns populated from the first step. here, we use logging schema to determine whether a feature was present during the logging. because of schema evolution, the filtering is per join part since each group by may be present at different time point. 
6. the final join result is the chained joins between left-log join (step 1) and right dfs (step 2). we keep all columns from flattened log table, even if they don't appear in left or right. 

**testing**

- [x] unit test (updated `JoinTest` and `SchemaEvolutionTest`)
- [x] e2e integration test on gateway (`zipline_test.zipline_test_test_online_join_small_v2`)