### PR TITLE
Update CI config for python lint failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
                   command: |
                       conda activate zipline_py
                       cd /zipline/api/py/ai/chronon
+                      pip install importlib-metadata==4.11.4 #Install importlib-metadata < 5
                       flake8 --extend-ignore=W605,Q000,F631
 
     "Chronon Python Tests":


### PR DESCRIPTION
Python lint is failing  due to - 

`AttributeError: 'EntryPoints' object has no attribute 'get`

Ref - https://airbnb.slack.com/archives/GHZA25NH2/p1665066675286139
