### PR TITLE
Fixing flake8 lint builds on CircleCI

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -73,7 +73,7 @@ RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
 RUN conda create -y -n zipline_py python=3.7
 RUN conda install -y -q -n zipline_py --no-deps virtualenv
 RUN  /opt/conda/envs/zipline_py/bin/pip install \
-   flake8==3.8.3 flake8-quotes==0.13.0 thrift==0.11.0 click==7.0 thrift_json==0.1.0 nose>=1.3.7
+   flake8==5.0.4 flake8-quotes==3.3.1 thrift==0.11.0 click==7.0 thrift_json==0.1.0 nose>=1.3.7
 
 WORKDIR /
 RUN rm -rf /img-build

--- a/api/py/ai/chronon/repo/explore.py
+++ b/api/py/ai/chronon/repo/explore.py
@@ -227,7 +227,7 @@ def prettify_entry(entry, target, modification, show=10, root=CWD, trim_paths=Fa
         name = " "*(15 - len(column)) + column
         if column in FILTER_COLUMNS and len(values) > show:
             values = [value for value in set(values) if target in value]
-            if(len(values) > show):
+            if (len(values) > show):
                 truncated = ', '.join(values[:show])
                 remaining = len(values) - show
                 values = f"[{truncated} ... {GREY}{UNDERLINE}{remaining} more{NORMAL}]"

--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
                         default=os.path.join(chronon_repo_path, 'scripts/spark_streaming.sh'))
     parser.add_argument('--online-jar-fetch',
                         help='Path to script that can pull online jar. ' +
-                             'This will run only when a file doesn\'t exist at location specified by online_jar',
+                             "This will run only when a file doesn't exist at location specified by online_jar",
                         default=os.path.join(chronon_repo_path, 'scripts/fetch_online_jar.py'))
     parser.add_argument('--sub-help', action='store_true', help='print help command of the underlying jar and exit')
     parser.add_argument('--conf-type', default='group_bys',


### PR DESCRIPTION
Flake8 lint builds are failing on CircleCI because of older version use. 
Bumping up versions and also fixing the errors on the related python files.

Verified on CircleCI via SSH that the builds are now working.