### PR TITLE
drop table when archiving fails

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -300,6 +300,12 @@ case class TableUtils(sparkSession: SparkSession) {
     }
   }
 
+  def dropTableIfExists(tableName: String): Unit = {
+    val command = s"DROP TABLE IF EXISTS $tableName"
+    println(s"Dropping table with command: $command")
+    sql(command)
+  }
+
   def archiveTableIfExists(tableName: String, timestamp: Instant): Unit = {
     if (sparkSession.catalog.tableExists(tableName)) {
       val humanReadableTimestamp = archiveTimestampFormatter.format(timestamp)


### PR DESCRIPTION
for tables to recompute in join, first attempt to archive the table by running the renames. if it fails due to any issues (due to airbnb internal dwi restrictions), try dropping the tables. 

@SophieYu41 @yunfeng-hao 