### PR TITLE
[api] add offline_schedule to join py api

### DIFF
--- a/api/py/ai/chronon/join.py
+++ b/api/py/ai/chronon/join.py
@@ -326,8 +326,7 @@ def Join(left: api.Source,
 
     custom_json = {
         "check_consistency": check_consistency,
-        "lag": lag,
-        "offline_schedule": offline_schedule
+        "lag": lag
     }
 
     if additional_args:
@@ -345,7 +344,8 @@ def Join(left: api.Source,
         outputNamespace=output_namespace,
         tableProperties=table_properties,
         modeToEnvMap=env,
-        samplePercent=sample_percent
+        samplePercent=sample_percent,
+        offlineSchedule=offline_schedule
     )
 
     # external parts need to be unique on (prefix, part.source.metaData.name)

--- a/api/py/test/sample/production/joins/sample_team/sample_backfill_mutation_join.v0
+++ b/api/py/test/sample/production/joins/sample_team/sample_backfill_mutation_join.v0
@@ -3,7 +3,7 @@
     "name": "sample_team.sample_backfill_mutation_join.v0",
     "online": 0,
     "production": 0,
-    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"offline_schedule\": \"@daily\"}",
+    "customJson": "{\"check_consistency\": false, \"lag\": 0}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}",
       "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
@@ -13,7 +13,8 @@
       "source": "chronon"
     },
     "outputNamespace": "# TODO: output namespace of hive tables that chronon produces",
-    "team": "sample_team"
+    "team": "sample_team",
+    "offlineSchedule": "@daily"
   },
   "left": {
     "events": {

--- a/api/py/test/sample/production/joins/sample_team/sample_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.v1
@@ -3,7 +3,7 @@
     "name": "sample_team.sample_join.v1",
     "online": 0,
     "production": 0,
-    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"offline_schedule\": \"@daily\"}",
+    "customJson": "{\"check_consistency\": false, \"lag\": 0}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
     ],
@@ -11,7 +11,8 @@
       "config_json": "{\"sample_key\": \"sample_value\"}"
     },
     "outputNamespace": "sample_namespace",
-    "team": "sample_team"
+    "team": "sample_team",
+    "offlineSchedule": "@daily"
   },
   "left": {
     "entities": {

--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
@@ -3,7 +3,7 @@
     "name": "sample_team.sample_join_from_module.v1",
     "online": 0,
     "production": 0,
-    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"offline_schedule\": \"@daily\", \"additional_args\": {\"custom_arg\": \"custom_value\"}, \"additional_env\": {\"custom_env\": \"custom_env_value\"}}",
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"additional_args\": {\"custom_arg\": \"custom_value\"}, \"additional_env\": {\"custom_env\": \"custom_env_value\"}}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
       "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
@@ -15,7 +15,8 @@
       "source": "chronon"
     },
     "outputNamespace": "# TODO: output namespace of hive tables that chronon produces",
-    "team": "sample_team"
+    "team": "sample_team",
+    "offlineSchedule": "@daily"
   },
   "left": {
     "entities": {

--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_shorthand.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_shorthand.v1
@@ -3,7 +3,7 @@
     "name": "sample_team.sample_join_from_shorthand.v1",
     "online": 0,
     "production": 0,
-    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"offline_schedule\": \"@daily\"}",
+    "customJson": "{\"check_consistency\": false, \"lag\": 0}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
       "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
@@ -12,7 +12,8 @@
       "source": "chronon"
     },
     "outputNamespace": "# TODO: output namespace of hive tables that chronon produces",
-    "team": "sample_team"
+    "team": "sample_team",
+    "offlineSchedule": "@daily"
   },
   "left": {
     "entities": {

--- a/api/py/test/sample/production/joins/sample_team/sample_online_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_online_join.v1
@@ -3,7 +3,7 @@
     "name": "sample_team.sample_online_join.v1",
     "online": 1,
     "production": 0,
-    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"offline_schedule\": \"@daily\", \"additional_args\": {\"custom_arg\": \"custom_value\"}, \"additional_env\": {\"custom_env\": \"custom_env_value\"}}",
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"additional_args\": {\"custom_arg\": \"custom_value\"}, \"additional_env\": {\"custom_env\": \"custom_env_value\"}}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}",
       "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
@@ -15,7 +15,8 @@
       "source": "chronon"
     },
     "outputNamespace": "# TODO: output namespace of hive tables that chronon produces",
-    "team": "sample_team"
+    "team": "sample_team",
+    "offlineSchedule": "@daily"
   },
   "left": {
     "events": {

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -211,6 +211,8 @@ struct MetaData {
     9: optional map<string, map<string, string>> modeToEnvMap
     10: optional bool consistencyCheck
     11: optional double samplePercent
+    // cron expression for airflow DAG schedule
+    12: optional string offlineSchedule
 }
 
 // Equivalent to a FeatureSet in chronon terms


### PR DESCRIPTION
In 2.0 we used to have the frontfill param which allows users to control frontfill behavior, as there is often a delay between commits and airflow deployment. Before that, the workaroud was to wait for deployment and manually turning off the DAG, which was a great UX. 

A more future proof approach is to add offline_schedule which will be a Cron expression that controls the Airflow join DAG scheduling, which brings about much more flexibility, e.g.
- `@daily` for daily inference jobs / log processing
- `@weekly` / `@monthly` for low cadence inference jobs
- `@once` for one-off backfill
- None for join conf that requires no backfill or test confs. 