### PR TITLE
[Stats] Fix byteTypes aggregations + partition column setting

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
@@ -69,7 +69,6 @@ class SummaryJob(session: SparkSession, joinConf: Join, endDate: String) extends
           }
           stats
             .addDerivedMetrics(summaryKvRdd.toFlatDf, aggregator)
-            .withTimeBasedColumn(Constants.PartitionColumn)
             .save(dailyStatsTable, tableProps)
           println(s"Finished range [${index + 1}/${stepRanges.size}].")
       }


### PR DESCRIPTION
### What

Small fixes to stats. 

* ByteType column have limited aggregators possible so skipping them from numeric aggregations.
* Non ts based joins fail at the withTimeBasedPartition ... so as part of addDerivedMetrics setting partition column if necessary (it's kind of derived from ts if hourly).

### How

Added unit tests for both cases. Checked the output.

