### PR TITLE
[ODM] label join fix null label ds

### DIFF
--- a/spark/src/test/scala/ai/chronon/spark/test/LabelJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/LabelJoinTest.scala
@@ -70,6 +70,27 @@ class LabelJoinTest {
   }
 
   @Test
+  def testLabelDsDoesNotExist(): Unit = {
+    val labelJoinConf = createTestLabelJoin(30, 20)
+    val joinConf = Builders.Join(
+      Builders.MetaData(name = "test_null_label_ds", namespace = namespace, team = "chronon"),
+      left,
+      labelPart = labelJoinConf
+    )
+    // label ds does not exist in label table, labels should be null
+    val runner = new LabelJoin(joinConf, tableUtils, "2022-11-01")
+    val computed = runner.computeLabelJoin()
+    println(" == Computed == ")
+    computed.show()
+    assertEquals(computed.select("label_ds").first().get(0), "2022-11-01")
+    assertEquals(computed
+      .select("listing_attributes_dim_room_type")
+      .first()
+      .get(0),
+      null)
+  }
+
+  @Test
   def testLabelRefresh(): Unit = {
     val labelJoinConf = createTestLabelJoin(60, 20)
     val joinConf = Builders.Join(


### PR DESCRIPTION
For cases when label version in particular ds is not available, the label values should be NULL but label_ds should be the ds user specified. 

This change correct the null label_ds to be expected value. 

Tested on gateway
`python3 run.py --mode=label-join  --conf=production/joins/zipline_test/test_label_join.v1 --chronon-jar=chronon-label.jar`

