### PR TITLE
[Analyzer] Add default metadata for no aggregation group_bys

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -145,7 +145,7 @@ class Analyzer(tableUtils: TableUtils,
   }
 
   def toAggregationMetadata(columnName: String, columnType: DataType) : AggregationMetadata = {
-    AggregationMetadata(columnName, columnType.toString, "None", "Unbounded", "None")
+    AggregationMetadata(columnName, columnType.toString, "No operation", "Unbounded", columnName)
   }
 
   def analyzeGroupBy(groupByConf: api.GroupBy,


### PR DESCRIPTION
Setting default values for feature metadata in analyzer. when group by don't have any aggregations. 

Current default value is NULL and would need client side customization. 
https://dataportal.airbnb.tools/graph/nodes/afp/groupby/payments.user.host_segment.host_min_ds_booking_v1

@ezvz @nikhilsimha 