### PR TITLE
[Stats][Fetcher] Fetch Stats

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/StatsGenerator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/StatsGenerator.scala
@@ -1,0 +1,170 @@
+package ai.chronon.aggregator.row
+
+import ai.chronon.api
+import ai.chronon.api.Extensions._
+import com.yahoo.memory.Memory
+import com.yahoo.sketches.kll.KllFloatsSketch
+
+import scala.collection.Seq
+import scala.util.ScalaVersionSpecificCollectionsConverter
+import java.util
+
+/**
+  * Module managing FeatureStats Schema, Aggregations to be used by type and aggregator construction.
+  *
+  * Stats Aggregation has an offline/ batch component and an online component.
+  * The metrics defined for stats depend on the schema of the join. The dataTypes and column names.
+  * For the online side, we obtain this information from the JoinCodec/valueSchema
+  * For the offline side, we obtain this information directly from the outputTable.
+  * To keep the schemas consistent we sort the metrics in the schema by name. (one column can have multiple metrics).
+  */
+object StatsGenerator {
+
+  val nullSuffix = "__null"
+  val nullRateSuffix = "__null_rate"
+  val totalColumn = "total"
+  // Leveraged to build a CDF. Consider using native KLLSketch CDF/PMF methods.
+  val finalizedPercentilesMerged: Array[Double] = Array(0.01) ++ (5 until 100 by 5).map(_.toDouble / 100) ++ Array(0.99)
+  // Leveraged to build candlestick time series.
+  val finalizedPercentilesSeries: Array[Double] = Array(0.05, 0.25, 0.5, 0.75, 0.95)
+  val ignoreColumns = Seq(api.Constants.TimeColumn, api.Constants.PartitionColumn)
+
+  /**
+    * InputTransform acts as a signal of how to process the metric.
+    *
+    * IsNull: Check if the input is null.
+    *
+    * Raw: Operate in the input column.
+    *
+    * One: lit(true) in spark. Used for row counts leveraged to obtain null rate values.
+    * */
+  object InputTransform extends Enumeration {
+    type InputTransform = Value
+    val IsNull, Raw, One = Value
+  }
+  import InputTransform._
+
+  /**
+    * MetricTransform represents a single statistic built on top of an input column.
+    */
+  case class MetricTransform(name: String,
+                             expression: InputTransform,
+                             operation: api.Operation,
+                             suffix: String = "",
+                             argMap: util.Map[String, String] = null)
+
+  /**
+    * A valueSchema (for join) and Metric list define uniquely the IRSchema to be used for the statistics.
+    * In order to support custom storage for statistic percentiles this method would need to be modified.
+    * IR Schemas are used to decode streaming partial aggregations as well as KvStore partial stats.
+    */
+  def statsIrSchema(valueSchema: api.StructType): api.StructType = {
+    val metrics: Seq[MetricTransform] = buildMetrics(valueSchema.unpack)
+    val schemaMap = valueSchema.unpack.map { v =>
+      v._1 -> v._2
+    }.toMap
+    api.StructType.from(
+      "IrSchema",
+      metrics.map { m =>
+        m.expression match {
+          case InputTransform.IsNull =>
+            (s"${m.name}${m.suffix}_sum", api.LongType)
+          case InputTransform.One =>
+            (s"${m.name}${m.suffix}_count", api.LongType)
+          case InputTransform.Raw =>
+            val aggPart = buildAggPart(m)
+            val colAggregator = ColumnAggregator.construct(schemaMap(m.name), aggPart, ColumnIndices(1, 1), None)
+            (s"${m.name}_${aggPart.operation.name().toLowerCase()}", colAggregator.irType)
+        }
+
+      }.toArray
+    )
+  }
+
+  /**
+    * Post processing for IRs when generating a time series of stats.
+    * In the case of percentiles for examples we reduce to 5 values in order to generate candlesticks.
+    */
+  def SeriesFinalizer(key: String, value: AnyRef): AnyRef = {
+    if (key.endsWith("percentile") && value != null) {
+      val sketch = KllFloatsSketch.heapify(Memory.wrap(value.asInstanceOf[Array[Byte]]))
+      return sketch.getQuantiles(finalizedPercentilesSeries).asInstanceOf[AnyRef]
+    }
+    value
+  }
+
+  /**
+    * Input schema is the data required to update partial aggregations / stats.
+    *
+    * Given a valueSchema and a metric transform list, defines the schema expected by the Stats aggregator (online and offline)
+    */
+  def statsInputSchema(valueSchema: api.StructType): api.StructType = {
+    val metrics = buildMetrics(valueSchema.unpack)
+    val schemaMap = valueSchema.unpack.map { v =>
+      v._1 -> v._2
+    }.toMap
+    api.StructType.from(
+      "IrSchema",
+      metrics.map { m =>
+        m.expression match {
+          case InputTransform.IsNull =>
+            (s"${m.name}${m.suffix}", api.LongType)
+          case InputTransform.One =>
+            (s"${m.name}${m.suffix}", api.LongType)
+          case InputTransform.Raw =>
+            (m.name, schemaMap(m.name))
+        }
+      }.toArray
+    )
+  }
+
+  def buildAggPart(m: MetricTransform): api.AggregationPart = {
+    val aggPart = new api.AggregationPart()
+    aggPart.setInputColumn(s"${m.name}${m.suffix}")
+    aggPart.setOperation(m.operation)
+    if (m.argMap != null)
+      aggPart.setArgMap(m.argMap)
+    aggPart.setWindow(WindowUtils.Unbounded)
+    aggPart
+  }
+
+  /** Build RowAggregator to use for computing stats on a dataframe based on metrics */
+  def buildAggregator(metrics: Seq[MetricTransform], selectedSchema: api.StructType): RowAggregator = {
+    val aggParts = metrics.flatMap { m => Seq(buildAggPart(m)) }
+    new RowAggregator(selectedSchema.unpack, aggParts)
+  }
+
+  /** Stats applied to any column */
+  def anyTransforms(column: String): Seq[MetricTransform] =
+    Seq(MetricTransform(column, InputTransform.IsNull, operation = api.Operation.SUM, suffix = nullSuffix))
+
+  /** Stats applied to numeric columns */
+  def numericTransforms(column: String): Seq[MetricTransform] =
+    anyTransforms(column) ++ Seq(
+      MetricTransform(
+        column,
+        InputTransform.Raw,
+        operation = api.Operation.APPROX_PERCENTILE,
+        argMap = ScalaVersionSpecificCollectionsConverter.convertScalaMapToJava(
+          Map("percentiles" -> s"[${finalizedPercentilesMerged.mkString(", ")}]"))
+      ))
+
+  /** For the schema of the data define metrics to be aggregated */
+  def buildMetrics(fields: Seq[(String, api.DataType)]): Seq[MetricTransform] = {
+    val metrics = fields
+      .flatMap {
+        case (name, dataType) =>
+          if (ignoreColumns.contains(name)) {
+            Seq.empty
+          } else if (api.DataType.isNumeric(dataType) && dataType != api.ByteType) {
+            // ByteTypes are not supported due to Avro Encodings and limited support on aggregators.
+            // Needs to be casted on source if required.
+            numericTransforms(name)
+          } else {
+            anyTransforms(name)
+          }
+      }
+      .sortBy(_.name)
+    metrics :+ MetricTransform(totalColumn, InputTransform.One, api.Operation.COUNT)
+  }
+}

--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -28,11 +28,11 @@ object Constants {
   val StreamingInputTable = "input_table"
   val ChrononMetadataKey = "ZIPLINE_METADATA"
   val SchemaPublishEvent = "SCHEMA_PUBLISH_EVENT"
-  val StatsKeySchemaKey = "key_schema"
-  val StatsValueSchemaKey = "value_schema"
+  val StatsBatchDataset = "CHRONON_STATS_BATCH"
   val TimeField: StructField = StructField(TimeColumn, LongType)
   val ReversalField: StructField = StructField(ReversalColumn, BooleanType)
   val MutationTimeField: StructField = StructField(MutationTimeColumn, LongType)
+  val StatsKeySchema: StructType = StructType("keySchema", Array(StructField("JoinPath", StringType)))
   val MutationFields: Seq[StructField] = Seq(MutationTimeField, ReversalField)
   val ExternalPrefix: String = "ext"
   val ContextualSourceName: String = "contextual"

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -94,6 +94,8 @@ object Extensions {
     def consistencyTable = s"${outputTable}_consistency"
 
     def uploadTable = s"${outputTable}_upload"
+    def dailyStatsOutputTable = s"${outputTable}_daily_stats"
+    def dailyStatsUploadTable = s"${dailyStatsOutputTable}_upload"
 
     def copyForVersioningComparison: MetaData = {
       // Changing name results in column rename, therefore schema change, other metadata changes don't effect output table
@@ -670,6 +672,8 @@ object Extensions {
         .toSet
         .toArray
     }
+
+    def computedFeatureCols: Seq[String] = joinPartOps.flatMap(_.valueColumns)
 
     def partOutputTable(jp: JoinPart): String =
       (Seq(join.metaData.outputTable) ++ Option(jp.prefix) :+ jp.groupBy.metaData.cleanName).mkString("_")

--- a/online/src/main/java/ai/chronon/online/JavaMergedStatsResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaMergedStatsResponse.java
@@ -1,0 +1,28 @@
+package ai.chronon.online;
+
+import scala.util.ScalaVersionSpecificCollectionsConverter;
+
+import java.util.Map;
+
+public class JavaMergedStatsResponse {
+    public JavaStatsRequest request;
+    public JTry<Map<String, Object>> values;
+
+    public JavaMergedStatsResponse(JavaStatsRequest request, JTry<Map<String, Object>> values) {
+        this.request = request;
+        this.values = values;
+    }
+
+    public JavaMergedStatsResponse(Fetcher.MergedStatsResponse scalaResponse){
+        this.request = new JavaStatsRequest(scalaResponse.request());
+        this.values = JTry
+                .fromScala(scalaResponse.values())
+                .map(ScalaVersionSpecificCollectionsConverter::convertScalaMapToJava);
+    }
+
+    public Fetcher.MergedStatsResponse toScala() {
+        return new Fetcher.MergedStatsResponse(
+                request.toScalaRequest(),
+                values.map(ScalaVersionSpecificCollectionsConverter::convertJavaMapToScala).toScala());
+    }
+}

--- a/online/src/main/java/ai/chronon/online/JavaSeriesStatsResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaSeriesStatsResponse.java
@@ -1,0 +1,28 @@
+package ai.chronon.online;
+
+import scala.util.ScalaVersionSpecificCollectionsConverter;
+
+import java.util.Map;
+
+public class JavaSeriesStatsResponse {
+    public JavaStatsRequest request;
+    public JTry<Map<String, Object>> values;
+
+    public JavaSeriesStatsResponse(JavaStatsRequest request, JTry<Map<String, Object>> series) {
+        this.request = request;
+        this.values = series;
+    }
+
+    public JavaSeriesStatsResponse(Fetcher.SeriesStatsResponse scalaResponse){
+        this.request = new JavaStatsRequest(scalaResponse.request());
+        this.values = JTry
+                .fromScala(scalaResponse.values())
+                .map(ScalaVersionSpecificCollectionsConverter::convertScalaMapToJava);
+    }
+
+    public Fetcher.SeriesStatsResponse toScala() {
+        return new Fetcher.SeriesStatsResponse(
+                request.toScalaRequest(),
+                values.map(ScalaVersionSpecificCollectionsConverter::convertJavaMapToScala).toScala());
+    }
+}

--- a/online/src/main/java/ai/chronon/online/JavaStatsRequest.java
+++ b/online/src/main/java/ai/chronon/online/JavaStatsRequest.java
@@ -1,0 +1,52 @@
+package ai.chronon.online;
+
+import scala.Option;
+import scala.util.ScalaVersionSpecificCollectionsConverter;
+
+import java.util.Map;
+
+public class JavaStatsRequest {
+  public String name;
+  public Long startTs;
+  public Long endTs;
+
+  public JavaStatsRequest(String name) {
+    this(name, null, null);
+  }
+  public JavaStatsRequest(String name, Long startTs) {
+    this.name = name;
+    this.startTs = startTs;
+    this.endTs =  null;
+  }
+
+  public JavaStatsRequest(String name, Long startTs, Long endTs) {
+    this.name = name;
+    this.startTs = startTs;
+    this.endTs = endTs;
+  }
+
+  public JavaStatsRequest(Fetcher.StatsRequest scalaRequest) {
+    this.name = scalaRequest.name();
+    Option<Object> startTsOpt = scalaRequest.startTs();
+    Option<Object> endTsOpt = scalaRequest.endTs();
+    if (startTsOpt.isDefined()) {
+      this.startTs = (Long) startTsOpt.get();
+    }
+    if (endTsOpt.isDefined()) {
+      this.endTs = (Long) endTsOpt.get();
+    }
+  }
+
+  public static JavaStatsRequest fromScalaRequest(Fetcher.StatsRequest scalaRequest) {
+    return new JavaStatsRequest(scalaRequest);
+  }
+
+  public Fetcher.StatsRequest toScalaRequest() {
+    return new Fetcher.StatsRequest(
+        this.name,
+        Option.apply(this.startTs),
+        Option.apply(this.endTs));
+  }
+}
+
+

--- a/online/src/main/java/ai/chronon/online/JavaStatsResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaStatsResponse.java
@@ -1,0 +1,33 @@
+package ai.chronon.online;
+
+import scala.util.ScalaVersionSpecificCollectionsConverter;
+
+import java.util.Map;
+
+
+public class JavaStatsResponse {
+    public JavaStatsRequest request;
+    public JTry<Map<String, Object>> values;
+    public Long millis;
+
+    public JavaStatsResponse(JavaStatsRequest request, JTry<Map<String, Object>> values) {
+        this.request = request;
+        this.values = values;
+        this.millis = null;
+    }
+
+    public JavaStatsResponse(JavaStatsRequest request, JTry<Map<String, Object>> values, Long millis) {
+        this.request = request;
+        this.values = values;
+        this.millis = millis;
+    }
+
+    public JavaStatsResponse(Fetcher.StatsResponse scalaResponse){
+        this.request = new JavaStatsRequest(scalaResponse.request());
+        this.values = JTry
+                .fromScala(scalaResponse.values())
+                .map(ScalaVersionSpecificCollectionsConverter::convertScalaMapToJava);
+        this.millis = scalaResponse.millis();
+    }
+
+}

--- a/online/src/main/scala/ai/chronon/online/JoinCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/JoinCodec.scala
@@ -1,7 +1,8 @@
 package ai.chronon.online
 
 import ai.chronon.api.Extensions.{JoinOps, MetadataOps}
-import ai.chronon.api.{DataType, HashUtils, LongType, StringType, StructField, StructType}
+import ai.chronon.api.{DataType, HashUtils, LongType, StringType, StructField, StructType, Constants}
+import ai.chronon.aggregator.row.StatsGenerator
 import com.google.gson.Gson
 
 import scala.collection.Seq
@@ -99,6 +100,11 @@ case class JoinCodec(conf: JoinOps,
   val valueFields: Array[StructField] = valueSchema.fields
   lazy val keyIndices: Map[StructField, Int] = keySchema.zipWithIndex.toMap
   lazy val valueIndices: Map[StructField, Int] = valueSchema.zipWithIndex.toMap
+  @transient lazy val statsKeyCodec: AvroCodec =
+    AvroCodec.of(AvroConversions.fromChrononSchema(Constants.StatsKeySchema).toString)
+  val statsInputSchema: StructType = StatsGenerator.statsInputSchema(valueSchema)
+  val statsIrSchema: StructType = StatsGenerator.statsIrSchema(valueSchema)
+  val statsIrCodec: AvroCodec = AvroCodec.of(AvroConversions.fromChrononSchema(statsIrSchema).toString)
 
 }
 

--- a/spark/src/main/scala/ai/chronon/spark/KvRdd.scala
+++ b/spark/src/main/scala/ai/chronon/spark/KvRdd.scala
@@ -6,7 +6,7 @@ import ai.chronon.spark.Extensions._
 import org.apache.avro.generic.GenericData
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, GenericRowWithSchema}
-import org.apache.spark.sql.types.{BinaryType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{BinaryType, LongType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 object GenericRowHandler {
@@ -18,37 +18,43 @@ object GenericRowHandler {
   }
 }
 
-case class KvRdd(data: RDD[(Array[Any], Array[Any])], keySchema: StructType, valueSchema: StructType)(implicit
-    sparkSession: SparkSession) {
+sealed trait BaseKvRdd {
 
+  def keySchema: StructType
+  def valueSchema: StructType
+  def withTime: Boolean
+  val timeField: StructField = StructField(api.Constants.TimeColumn, LongType)
   val keyZSchema: api.StructType = keySchema.toChrononSchema("Key")
   val valueZSchema: api.StructType = valueSchema.toChrononSchema("Value")
-  val flatSchema: StructType = StructType(keySchema ++ valueSchema)
-  val flatZSchema: api.StructType = flatSchema.toChrononSchema("Flat")
-
-  def toAvroDf: DataFrame = {
-    val rowSchema = StructType(
-      Seq(
-        StructField("key_bytes", BinaryType),
-        StructField("value_bytes", BinaryType),
-        StructField("key_json", StringType),
-        StructField("value_json", StringType)
-      )
+  val baseFlatSchema: StructType = StructType(keySchema ++ valueSchema)
+  def flatSchema: StructType = if (withTime) StructType(baseFlatSchema :+ timeField) else baseFlatSchema
+  def flatZSchema: api.StructType = flatSchema.toChrononSchema("Flat")
+  val keyToBytes = AvroConversions.encodeBytes(keyZSchema, GenericRowHandler.func)
+  val valueToBytes = AvroConversions.encodeBytes(valueZSchema, GenericRowHandler.func)
+  val keyToJson = AvroConversions.encodeJson(keyZSchema, GenericRowHandler.func)
+  val valueToJson = AvroConversions.encodeJson(valueZSchema, GenericRowHandler.func)
+  val baseRowSchema = StructType(
+    Seq(
+      StructField("key_bytes", BinaryType),
+      StructField("value_bytes", BinaryType),
+      StructField("key_json", StringType),
+      StructField("value_json", StringType)
     )
+  )
+  def rowSchema = if (withTime) StructType(baseRowSchema :+ timeField) else baseRowSchema
 
-    println(s"""
-         |key schema: 
-         |  ${AvroConversions.fromChrononSchema(keyZSchema).toString(true)}
-         |value schema: 
-         |  ${AvroConversions.fromChrononSchema(valueZSchema).toString(true)}
-         |""".stripMargin)
-    val keyToBytes = AvroConversions.encodeBytes(keyZSchema, GenericRowHandler.func)
-    val valueToBytes = AvroConversions.encodeBytes(valueZSchema, GenericRowHandler.func)
-    val keyToJson = AvroConversions.encodeJson(keyZSchema, GenericRowHandler.func)
-    val valueToJson = AvroConversions.encodeJson(valueZSchema, GenericRowHandler.func)
+  def toAvroDf: DataFrame
 
-    val rowRdd: RDD[Row] = data.map {
-      case (keys, values) =>
+  def toFlatDf: DataFrame
+}
+
+case class KvRdd(data: RDD[(Array[Any], Array[Any])], keySchema: StructType, valueSchema: StructType)(implicit sparkSession: SparkSession)
+extends BaseKvRdd {
+  val withTime = false
+
+  override def toAvroDf: DataFrame = {
+    val avroRdd: RDD[Row] = data.map {
+      case (keys: Array[Any], values: Array[Any]) =>
         // json encoding is very expensive (50% of entire job).
         // Only do it for a small fraction to retain debuggability.
         val (keyJson, valueJson) = if (math.random < 0.01) {
@@ -59,17 +65,62 @@ case class KvRdd(data: RDD[(Array[Any], Array[Any])], keySchema: StructType, val
         val result: Array[Any] = Array(keyToBytes(keys), valueToBytes(values), keyJson, valueJson)
         new GenericRow(result)
     }
-    sparkSession.createDataFrame(rowRdd, rowSchema)
-  }
+    println(
+      s"""
+          |key schema:
+          |  ${AvroConversions.fromChrononSchema(keyZSchema).toString(true)}
+          |value schema:
+          |  ${AvroConversions.fromChrononSchema(valueZSchema).toString(true)}
+          |""".stripMargin)
+      sparkSession.createDataFrame(avroRdd, rowSchema)
+    }
 
-  def toFlatDf: DataFrame = {
-    val rowRdd: RDD[Row] = data.map {
-      case (keys, values) =>
+  override def toFlatDf: DataFrame = {
+    val flatRdd: RDD[Row] = data.map {
+      case (keys: Array[Any], values: Array[Any]) =>
         val result = new Array[Any](keys.length + values.length)
         System.arraycopy(keys, 0, result, 0, keys.length)
         System.arraycopy(values, 0, result, keys.length, values.length)
         SparkConversions.toSparkRow(result, flatZSchema, GenericRowHandler.func).asInstanceOf[GenericRow]
     }
-    sparkSession.createDataFrame(rowRdd, flatSchema)
+    sparkSession.createDataFrame(flatRdd, flatSchema)
+  }
+}
+
+case class TimedKvRdd(data: RDD[(Array[Any], Array[Any], Long)], keySchema: StructType, valueSchema: StructType)(implicit sparkSession: SparkSession)
+extends BaseKvRdd {
+  val withTime = true
+
+  override def toAvroDf: DataFrame = {
+    val avroRdd: RDD[Row] = data.map {
+      case (keys, values, ts) =>
+        val (keyJson, valueJson) = if (math.random < 0.01) {
+          (keyToJson(keys), valueToJson(values))
+        } else {
+          (null, null)
+        }
+        val result: Array[Any] = Array(keyToBytes(keys), valueToBytes(values), keyJson, valueJson, ts)
+        new GenericRow(result)
+    }
+    println(
+      s"""
+         |key schema:
+         |  ${AvroConversions.fromChrononSchema(keyZSchema).toString(true)}
+         |value schema:
+         |  ${AvroConversions.fromChrononSchema(valueZSchema).toString(true)}
+         |""".stripMargin)
+    sparkSession.createDataFrame(avroRdd, rowSchema)
+  }
+
+  override def toFlatDf: DataFrame = {
+    val flatRdd: RDD[Row] = data.map {
+      case (keys, values, ts) =>
+        val result = new Array[Any](keys.length + values.length + 1)
+        System.arraycopy(keys, 0, result, 0, keys.length)
+        System.arraycopy(values, 0, result, keys.length, values.length)
+        result(result.length - 1) = ts
+        SparkConversions.toSparkRow(result, flatZSchema, GenericRowHandler.func).asInstanceOf[GenericRow]
+    }
+    sparkSession.createDataFrame(flatRdd, flatSchema)
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/stats/StatsCompute.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/StatsCompute.scala
@@ -1,116 +1,44 @@
 package ai.chronon.spark.stats
 
-import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.row.{RowAggregator, StatsGenerator}
 import ai.chronon.api
 import ai.chronon.api.Extensions._
-import ai.chronon.online.SparkConversions
 import ai.chronon.spark.Extensions._
-import ai.chronon.spark.KvRdd
+import ai.chronon.online.SparkConversions
 import com.yahoo.memory.Memory
 import com.yahoo.sketches.kll.KllFloatsSketch
-import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{Column, DataFrame, functions}
 
-import java.util
-import scala.util.{ScalaVersionSpecificCollectionsConverter, Try}
+import scala.util.Try
+import ai.chronon.spark.TimedKvRdd
 
-/**
-  * StatsGenerator takes care of computation of metadata for dataframes as well as
-  * measuring differences between two dataframes.
-  * This applies to drifts as well between two dataframes.
-  */
-object StatsGenerator {
-
-  // TODO: unify with OOC since has the same metric transform.
-  case class MetricTransform(name: String,
-                             expression: Column,
-                             operation: api.Operation,
-                             argMap: util.Map[String, String] = null)
-
-  val nullPrefix = "null__"
-  val nullRatePrefix = "null_rate__"
-  val totalColumn = "total"
-  val ignoreColumns = Seq(api.Constants.TimeColumn, api.Constants.PartitionColumn)
-  val finalizedPercentiles = (5 until 1000 by 5).map(_.toDouble / 1000)
-
-  /** Stats applied to any column */
-  def anyTransforms(column: Column): Seq[MetricTransform] =
-    Seq(
-      MetricTransform(s"$nullPrefix$column", column.isNull, operation = api.Operation.SUM)
-      //, MetricTransform(s"$column", column, operation = api.Operation.APPROX_UNIQUE_COUNT)
-    )
-
-  /** Stats applied to numeric columns */
-  def numericTransforms(column: Column): Seq[MetricTransform] =
-    anyTransforms(column) ++ Seq(
-      MetricTransform(
-        column.toString(),
-        column,
-        operation = api.Operation.APPROX_PERCENTILE,
-        argMap = ScalaVersionSpecificCollectionsConverter.convertScalaMapToJava(
-          Map("percentiles" -> s"[${finalizedPercentiles.mkString(", ")}]"))
-      ))
-
-  /** For the schema of the data define metrics to be aggregated */
-  def buildMetrics(fields: Array[(String, api.DataType)]): Seq[MetricTransform] = {
-    val metrics = fields.flatMap {
-      case (name, dataType) =>
-        if (ignoreColumns.contains(name)) {
-          Seq.empty
-        } else if (api.DataType.isNumeric(dataType) && dataType != api.ByteType) {
-          // ByteTypes are not supported due to Avro Encodings and limited support on aggregators.
-          // Needs to be casted on source if required.
-          numericTransforms(functions.col(name))
-        } else {
-          anyTransforms(functions.col(name))
-        }
-    }
-    metrics :+ MetricTransform(totalColumn, lit(true), api.Operation.COUNT)
-  }
-
-  /** Build RowAggregator to use for computing stats on a dataframe based on metrics */
-  def buildAggregator(metrics: Seq[MetricTransform], inputDf: DataFrame): RowAggregator = {
-    val schema = SparkConversions.toChrononSchema(inputDf.schema)
-    val aggParts = metrics.flatMap { m =>
-      def buildAggPart(name: String): api.AggregationPart = {
-        val aggPart = new api.AggregationPart()
-        aggPart.setInputColumn(name)
-        aggPart.setOperation(m.operation)
-        if (m.argMap != null)
-          aggPart.setArgMap(m.argMap)
-        aggPart.setWindow(WindowUtils.Unbounded)
-        aggPart
-      }
-
-      Seq(buildAggPart(m.name))
-    }
-    new RowAggregator(schema, aggParts)
-  }
-
-}
-
-class StatsCompute(inputDf: DataFrame, keys: Seq[String]) extends Serializable {
+class StatsCompute(inputDf: DataFrame, keys: Seq[String], name: String) extends Serializable {
 
   private val noKeysDf: DataFrame = inputDf.select(
     inputDf.columns
       .filter(colName => !keys.contains(colName))
       .map(colName => new Column(colName)): _*)
 
-  val keyColumns =
+  val timeColumns =
     if (inputDf.columns.contains(api.Constants.TimeColumn)) Seq(api.Constants.TimeColumn, api.Constants.PartitionColumn)
     else Seq(api.Constants.PartitionColumn)
   val metrics = StatsGenerator.buildMetrics(SparkConversions.toChrononSchema(noKeysDf.schema))
-  val selectedDf: DataFrame = noKeysDf
-    .select(keyColumns.map(col) ++ metrics.map(m => m.expression): _*)
-    .toDF(keyColumns ++ metrics.map(m => m.name): _*)
+  lazy val selectedDf: DataFrame = noKeysDf
+    .select(timeColumns.map(col) ++ metrics.map(m =>
+      m.expression match {
+        case StatsGenerator.InputTransform.IsNull => functions.col(m.name).isNull
+        case StatsGenerator.InputTransform.Raw    => functions.col(m.name)
+        case StatsGenerator.InputTransform.One    => functions.lit(true)
+      }): _*)
+    .toDF(timeColumns ++ metrics.map(m => s"${m.name}${m.suffix}"): _*)
 
   /** Given a summary Dataframe that computed the stats. Add derived data (example: null rate, median, etc) */
   def addDerivedMetrics(df: DataFrame, aggregator: RowAggregator): DataFrame = {
-    val nullColumns = df.columns.filter(p => p.startsWith(StatsGenerator.nullPrefix))
+    val nullColumns = df.columns.filter(p => p.startsWith(StatsGenerator.nullSuffix))
     val withNullRatesDF = nullColumns.foldLeft(df) { (tmpDf, column) =>
       tmpDf.withColumn(
-        s"${StatsGenerator.nullRatePrefix}${column.stripPrefix(StatsGenerator.nullPrefix)}",
+        s"${StatsGenerator.nullRateSuffix}${column.stripPrefix(StatsGenerator.nullSuffix)}",
         tmpDf.col(column) / tmpDf.col(Seq(StatsGenerator.totalColumn, api.Operation.COUNT).mkString("_"))
       )
     }
@@ -122,8 +50,8 @@ class StatsCompute(inputDf: DataFrame, keys: Seq[String]) extends Serializable {
       Try(
         KllFloatsSketch
           .heapify(Memory.wrap(s))
-          .getQuantiles(StatsGenerator.finalizedPercentiles.toArray)
-          .zip(StatsGenerator.finalizedPercentiles)
+          .getQuantiles(StatsGenerator.finalizedPercentilesMerged)
+          .zip(StatsGenerator.finalizedPercentilesMerged)
           .map(f => f._2.toString -> f._1.toString)
           .toMap).toOption)
     val addedPercentilesDf = percentileColumns.foldLeft(withNullRatesDF) { (tmpDf, column) =>
@@ -145,29 +73,28 @@ class StatsCompute(inputDf: DataFrame, keys: Seq[String]) extends Serializable {
     * For entity on the left we use daily partition as the key. For events we bucket by timeBucketMinutes (def. 1 hr)
     * Since the stats are mergeable coarser granularities can be obtained through fetcher merging.
     */
-  def dailySummary(aggregator: RowAggregator, sample: Double = 1.0, timeBucketMinutes: Long = 60): KvRdd = {
+  def dailySummary(aggregator: RowAggregator, sample: Double = 1.0, timeBucketMinutes: Long = 60): TimedKvRdd = {
     val partitionIdx = selectedDf.schema.fieldIndex(api.Constants.PartitionColumn)
     val bucketMs = timeBucketMinutes * 1000 * 60
     val tsIdx =
       if (selectedDf.columns.contains(api.Constants.TimeColumn)) selectedDf.schema.fieldIndex(api.Constants.TimeColumn)
       else -1
-    val hourlyCompute = tsIdx >= 0 && timeBucketMinutes > 0
-    val keyField =
-      if (hourlyCompute) StructField(api.Constants.TimeColumn, LongType)
-      else StructField(api.Constants.PartitionColumn, StringType)
+    val isTimeBucketed = tsIdx >= 0 && timeBucketMinutes > 0
+    val keyName: Any = name
     val result = selectedDf
       .sample(sample)
       .rdd
       .map(SparkConversions.toChrononRow(_, tsIdx))
-      .keyBy(row => if (hourlyCompute) ((row.ts / bucketMs) * bucketMs).asInstanceOf[Any] else row.get(partitionIdx))
+      .keyBy(row =>
+        if (isTimeBucketed) (row.ts / bucketMs) * bucketMs
+        else api.Constants.Partition.epochMillis(row.getAs[String](partitionIdx)))
       .aggregateByKey(aggregator.init)(seqOp = aggregator.updateWithReturn, combOp = aggregator.merge)
       .mapValues(aggregator.normalize(_))
-      .map { case (k, v) => (Array(k), v) } // To use KvRdd
-
+      .map { case (k, v) => (Array(keyName), v, k) } // To use KvRdd
     implicit val sparkSession = inputDf.sparkSession
-    KvRdd(
+    TimedKvRdd(
       result,
-      StructType(Array(keyField)),
+      SparkConversions.fromChrononSchema(api.Constants.StatsKeySchema),
       SparkConversions.fromChrononSchema(aggregator.irSchema)
     )
   }

--- a/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
@@ -1,0 +1,135 @@
+package ai.chronon.spark.test
+
+import ai.chronon.aggregator.test.Column
+import ai.chronon.api
+import ai.chronon.api.{Accuracy, Builders, Constants, Operation, TimeUnit, Window}
+import ai.chronon.api.Constants.ChrononMetadataKey
+import ai.chronon.api.Extensions._
+import ai.chronon.online.Fetcher.{SeriesStatsResponse, StatsRequest}
+
+import scala.compat.java8.FutureConverters
+import ai.chronon.online.{JavaStatsRequest, MetadataStore}
+import ai.chronon.spark.Extensions._
+import ai.chronon.spark.{Join, SparkSessionBuilder, TableUtils}
+import com.google.gson.GsonBuilder
+import junit.framework.TestCase
+import org.apache.spark.sql.SparkSession
+
+import java.util.TimeZone
+import java.util.concurrent.Executors
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, ExecutionContext}
+
+/**
+  * For testing of the consumption side of Stats end to end.
+  *
+  * Start by creating a join. Building the output table
+  * Compute and serve stats. (OnlineUtils)
+  * Fetch stats.
+  */
+class FetchStatsTest extends TestCase {
+
+  val spark: SparkSession = SparkSessionBuilder.build("FetchStatsTest", local = true)
+  val tableUtils = TableUtils(spark)
+  val namespace = "fetch_stats"
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+  private val today = Constants.Partition.at(System.currentTimeMillis())
+  private val yesterday = Constants.Partition.before(today)
+
+  def testFetchStats(): Unit = {
+    // Part 1: Build the assets. Join definition, compute and serve stats.
+    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    val nameSuffix = "_fetch_stats_test"
+
+    // LeftDf ->  item, value, ts, ds
+    val itemQueries = List(
+      Column("item", api.StringType, 100),
+      Column("value", api.LongType, 100)
+    )
+    val itemQueriesTable = s"$namespace.item_queries_$nameSuffix"
+    val itemQueriesDf = DataFrameGen
+      .events(spark, itemQueries, 10000, partitions = 30)
+    itemQueriesDf.save(s"${itemQueriesTable}_tmp")
+    val leftDf = tableUtils.sql(s"SELECT item, value, ts, ds FROM ${itemQueriesTable}_tmp")
+    leftDf.save(itemQueriesTable)
+    val start = Constants.Partition.minus(today, new Window(10, TimeUnit.DAYS))
+
+    // RightDf -> user, item, value
+    val viewsSchema = List(
+      Column("user", api.StringType, 10000),
+      Column("item", api.StringType, 100),
+      Column("value", api.LongType, 100)
+    )
+    val viewsTable = s"$namespace.view_$nameSuffix"
+    val rightDf = DataFrameGen.events(spark, viewsSchema, count = 10000, partitions = 30)
+    rightDf.save(viewsTable)
+
+    // Build Group By
+    val gb = Builders.GroupBy(
+      sources = Seq(
+        Builders.Source.events(
+          table = viewsTable,
+          query = Builders.Query(startPartition = start)
+        )),
+      keyColumns = Seq("item"),
+      aggregations = Seq(
+        Builders.Aggregation(operation = Operation.LAST_K, argMap = Map("k" -> "10"), inputColumn = "user"),
+        Builders.Aggregation(operation = Operation.MAX, argMap = Map("k" -> "2"), inputColumn = "value")
+      ),
+      metaData =
+        Builders.MetaData(name = s"ut_fetch_stats.item_views_$nameSuffix", namespace = namespace, team = "item_team"),
+      accuracy = Accuracy.SNAPSHOT
+    )
+
+    val joinConf = Builders.Join(
+      left = Builders.Source.events(Builders.Query(startPartition = start), table = itemQueriesTable),
+      joinParts = Seq(Builders.JoinPart(groupBy = gb, prefix = "user")),
+      metaData = Builders.MetaData(name = s"ut_fetch_stats.item_temporal_features.$nameSuffix",
+                                   namespace = namespace,
+                                   team = "item_team",
+                                   online = true)
+    )
+
+    // Compute daily join.
+    val joinJob = new Join(joinConf, today, tableUtils)
+    joinJob.computeJoin()
+    // Load some data.
+    implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
+    val kvStoreFunc = () => OnlineUtils.buildInMemoryKVStore("FetchStatsTest")
+    val inMemoryKvStore = kvStoreFunc()
+    val metadataStore = new MetadataStore(inMemoryKvStore, timeoutMillis = 10000)
+    inMemoryKvStore.create(ChrononMetadataKey)
+    metadataStore.putJoinConf(joinConf)
+    OnlineUtils.serveStats(tableUtils, inMemoryKvStore, yesterday, joinConf)
+    joinConf.joinParts.asScala.foreach(jp =>
+      OnlineUtils.serve(tableUtils, inMemoryKvStore, kvStoreFunc, namespace, yesterday, jp.groupBy))
+
+    // Part 2: Fetch. Build requests, and fetch.
+    val request = StatsRequest(joinConf.metaData.nameToFilePath, None, None)
+    val mockApi = new MockApi(kvStoreFunc, namespace)
+    val gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create()
+    val javaFetchedSeries = fetchStatsSeries(request, mockApi, false)
+    val fetchedSeries = fetchStatsSeries(request, mockApi, true)
+    println(gson.toJson(fetchedSeries.values.get))
+
+    // Appendix: Incremental run to check incremental updates for summary job.
+    OnlineUtils.serveStats(tableUtils, inMemoryKvStore, today, joinConf)
+  }
+
+  def fetchStatsSeries(request: StatsRequest,
+                       mockApi: MockApi,
+                       useJavaFetcher: Boolean = false,
+                       debug: Boolean = false)(implicit ec: ExecutionContext): SeriesStatsResponse = {
+    @transient lazy val fetcher = mockApi.buildFetcher(debug)
+    @transient lazy val javaFetcher = mockApi.buildJavaFetcher()
+    val results = if (useJavaFetcher) {
+      val javaRequest = new JavaStatsRequest(request)
+      val javaResponse = javaFetcher.fetchStatsTimeseries(javaRequest)
+      FutureConverters.toScala(javaResponse).map(_.toScala)
+    } else {
+      fetcher.fetchStatsTimeseries(request)
+    }
+    Await.result(results, Duration(10000, SECONDS))
+  }
+}

--- a/spark/src/test/scala/ai/chronon/spark/test/InMemoryKvStore.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/InMemoryKvStore.scala
@@ -67,16 +67,19 @@ class InMemoryKvStore(tableUtils: () => TableUtils) extends KVStore {
     }
   }
 
+  // For the case of group by batch uploads.
   // the table is assumed to be encoded with two columns - `key` and `value` as Array[Bytes]
   // one of the keys should be "group_by_serving_info" as bytes with value as TSimpleJsonEncoded String
   override def bulkPut(sourceOfflineTable: String, destinationOnlineDataSet: String, partition: String): Unit = {
     val tableUtilInst = tableUtils()
     val partitionFilter =
       Option(partition).map { part => s"WHERE ${Constants.PartitionColumn} = '$part'" }.getOrElse("")
-    tableUtilInst.sql(s"SELECT * FROM $sourceOfflineTable").show(false)
+    val offlineDf = tableUtilInst.sql(s"SELECT * FROM $sourceOfflineTable")
+    val tsColumn =
+      if (offlineDf.columns.contains(Constants.TimeColumn)) Constants.TimeColumn
+      else s"(unix_timestamp(ds, 'yyyy-MM-dd') * 1000 + ${Constants.Partition.spanMillis})"
     val df =
-      tableUtilInst.sql(
-        s"""SELECT key_bytes, value_bytes, (unix_timestamp(ds, 'yyyy-MM-dd') * 1000 + ${Constants.Partition.spanMillis}) as ts
+      tableUtilInst.sql(s"""SELECT key_bytes, value_bytes, $tsColumn as ts
          |FROM $sourceOfflineTable
          |$partitionFilter""".stripMargin)
     val requests = df.rdd
@@ -87,7 +90,6 @@ class InMemoryKvStore(tableUtils: () => TableUtils) extends KVStore {
         val timestamp = row.get(2).asInstanceOf[Long]
         KVStore.PutRequest(key, value, destinationOnlineDataSet, Option(timestamp))
       }
-
     create(destinationOnlineDataSet)
     multiPut(requests)
   }

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -458,7 +458,7 @@ class JoinTest {
 
     //run analyzer and validate output schema
     val analyzer = new Analyzer(tableUtils, joinConf, monthAgo, today, enableHitter = true)
-    val analyzerSchema = analyzer.analyzeJoin(joinConf)._1.map{ case(k,v) => s"${k} => ${v}" }.toList.sorted
+    val analyzerSchema = analyzer.analyzeJoin(joinConf)._1.map { case (k, v) => s"${k} => ${v}" }.toList.sorted
     val join = new Join(joinConf = joinConf, endPartition = monthAgo, tableUtils)
     val computed = join.computeJoin()
     val expectedSchema = computed.schema.fields.map(field => s"${field.name} => ${field.dataType}").sorted
@@ -765,14 +765,15 @@ class JoinTest {
     oldJoin.computeJoin(Some(100))
 
     // Make sure that there is no versioning-detected changes at this phase
-    val joinPartsToRecomputeNoChange = oldJoin.tablesToRecompute()
+    val joinPartsToRecomputeNoChange = JoinUtils.tablesToRecompute(joinConf, joinConf.metaData.outputTable, tableUtils)
     assertEquals(joinPartsToRecomputeNoChange.size, 0)
 
     // First test changing the left side table - this should trigger a full recompute
     val leftChangeJoinConf = joinConf.deepCopy()
     leftChangeJoinConf.getLeft.getEvents.setTable("some_other_table_name")
     val leftChangeJoin = new Join(joinConf = leftChangeJoinConf, endPartition = dayAndMonthBefore, tableUtils)
-    val leftChangeRecompute = leftChangeJoin.tablesToRecompute()
+    val leftChangeRecompute =
+      JoinUtils.tablesToRecompute(leftChangeJoinConf, leftChangeJoinConf.metaData.outputTable, tableUtils)
     println(leftChangeRecompute)
     assertEquals(leftChangeRecompute.size, 3)
     val partTable = s"${leftChangeJoinConf.metaData.outputTable}_user_unit_test_item_views"
@@ -785,7 +786,8 @@ class JoinTest {
     val newJoinPart = Builders.JoinPart(groupBy = getViewsGroupBy(suffix = "versioning"), prefix = "user_2")
     addPartJoinConf.setJoinParts(Seq(existingJoinPart, newJoinPart).asJava)
     val addPartJoin = new Join(joinConf = addPartJoinConf, endPartition = dayAndMonthBefore, tableUtils)
-    val addPartRecompute = addPartJoin.tablesToRecompute()
+    val addPartRecompute =
+      JoinUtils.tablesToRecompute(addPartJoinConf, addPartJoinConf.metaData.outputTable, tableUtils)
     assertEquals(addPartRecompute.size, 1)
     assertEquals(addPartRecompute, Seq(addPartJoinConf.metaData.outputTable))
     // Compute to ensure that it works and to set the stage for the next assertion
@@ -795,7 +797,8 @@ class JoinTest {
     val rightModJoinConf = addPartJoinConf.deepCopy()
     rightModJoinConf.getJoinParts.get(1).setPrefix("user_3")
     val rightModJoin = new Join(joinConf = rightModJoinConf, endPartition = dayAndMonthBefore, tableUtils)
-    val rightModRecompute = rightModJoin.tablesToRecompute()
+    val rightModRecompute =
+      JoinUtils.tablesToRecompute(rightModJoinConf, rightModJoinConf.metaData.outputTable, tableUtils)
     assertEquals(rightModRecompute.size, 2)
     val rightModPartTable = s"${addPartJoinConf.metaData.outputTable}_user_2_unit_test_item_views"
     assertEquals(rightModRecompute, Seq(rightModPartTable, addPartJoinConf.metaData.outputTable))

--- a/spark/src/test/scala/ai/chronon/spark/test/OnlineUtils.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/OnlineUtils.scala
@@ -5,8 +5,9 @@ import ai.chronon.api.{Accuracy, Constants, DataModel, StructType}
 import ai.chronon.online.{SparkConversions, KVStore}
 import ai.chronon.spark.{GroupByUpload, SparkSessionBuilder, TableUtils}
 import ai.chronon.spark.streaming.GroupBy
+import ai.chronon.spark.stats.SummaryJob
 import org.apache.spark.sql.streaming.Trigger
-import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, SourceOps}
+import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, SourceOps, JoinOps}
 import org.apache.spark.sql.SparkSession
 
 object OnlineUtils {
@@ -50,6 +51,12 @@ object OnlineUtils {
       inMemoryKvStore.create(groupByConf.streamingDataset)
       OnlineUtils.putStreaming(tableUtils.sparkSession, groupByConf, kvStoreGen, tableUtils, endDs, namespace)
     }
+  }
+
+  def serveStats(tableUtils: TableUtils, inMemoryKvStore: InMemoryKvStore, endDs: String, joinConf: api.Join): Unit = {
+    val statsJob = new SummaryJob(tableUtils.sparkSession, joinConf, endDs)
+    statsJob.dailyRun()
+    inMemoryKvStore.bulkPut(joinConf.metaData.dailyStatsUploadTable, Constants.StatsBatchDataset, null)
   }
 
   def buildInMemoryKVStore(sessionName: String): InMemoryKvStore = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
The main goal of the PR is set the skeleton for fetching stats. Good enough to work for cli and basic integration with visualizations.

In this PR:
* **Tests:**
  * End to end tests that runs the SummaryJob, uploads to InMemoryKVStore and fetch stats from there.
* What was done:
  * **StatsGenerator was moved from spark module to aggregator.**: We are going to need to aggregate stats in the fetcher as well as in batch upload (as well as in streaming eventually).
  * **Stats computed depend on schema, so for online expanded JoinCodec**. In order to not depend on the uploaded schemas to a specific key, we depend on building an aggregator based on the join definition and types (similar to how it was done to offline). We sort the metrics by name to make sure the order of the aggregator depends only on schema and not on the select order.
  * **No more stats on left inputs**. In order to have online values we define the KvRDD only on IR available online, (else messes the AvroSchema) so we drop left inputs in StatsCompute. Because there is no way to filter the left columns expanded the JoinOps to provide valueColumns.
  * **FetchStatsBetween(StartTime, EndTime)** Endpoint in fetcher for getting stats as a `Map<statistic_name: String, AnyRef>`
  * **Changed KV Storage of stats**: Rather than have multiple entries key'd by time. Now we key by config_name (in the future dimensional cut as well) and use the stored TimedValues in there as the data. This means that for the upload task we no longer provide a single time, so defined a TimedKvRDD that allows for key_bytes, value_bytes and ts.
  * **ADDED LATER BASED ON END TO END DEMO W/ GRAFANA**
  * StatsRequest and StatsResponse as arguments and outputs of the fetcher stats method.
  * FetchTimeseries for time series data. (Add a finalizer for percentiles for candlesticks visualizations)
  * FetchMerged for distribution data between ts_start and ts_end or other time aggregated stats.
  * Java counterparts and transformations to leverage a Java Dropwizard service IDL.
  * Driver for fetcher leveraging mapper w/ DefaultScalaMapper


The PR is much smaller than it seems as 25% is test code but the relevant part is understand the flow of FetchStatsTest. Another 25% is moving StatsGenerator code from stats module to aggregator.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Build a feature observability endpoint that will work for batch and streaming as a source for alerting. This takes care of the batch part and online consumption.

![Stats Store Compute (3)](https://user-images.githubusercontent.com/4719506/225394658-cbfa0211-c5a1-4e6c-af10-646f89c61d23.png)


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
Stats Merged output:
```json
{
  "user_unit_test_fetcher_stats_item_views__fetch_stats_test_user_last10__null_sum" : 104,
  "user_unit_test_fetcher_stats_item_views__fetch_stats_test_value_max__null_sum" : 105,
  "user_unit_test_fetcher_stats_item_views__fetch_stats_test_value_max_approx_percentile" : [ 43.0, 45.0, 52.0, 52.0, 52.0, 59.0, 59.0, 59.0, 59.0, 62.0, 62.0, 62.0, 62.0, 67.0, 72.0, 72.0, 77.0, 77.0, 77.0, 77.0, 78.0, 78.0, 79.0, 79.0, 79.0, 79.0, 79.0, 80.0, 82.0, 82.0, 82.0, 82.0, 82.0, 82.0, 82.0, 82.0, 83.0, 83.0, 83.0, 84.0, 84.0, 84.0, 84.0, 85.0, 85.0, 85.0, 85.0, 85.0, 85.0, 86.0, 87.0, 87.0, 88.0, 88.0, 88.0, 88.0, 88.0, 88.0, 88.0, 89.0, 89.0, 89.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 91.0, 91.0, 91.0, 91.0, 91.0, 91.0, 91.0, 91.0, 92.0, 92.0, 92.0, 92.0, 92.0, 93.0, 93.0, 93.0, 93.0, 93.0, 93.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 95.0, 95.0, 95.0, 95.0, 95.0, 95.0, 95.0, 95.0, 95.0, 95.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 97.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 98.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ],
  "total_count" : 306
}
```
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @vamseeyarla 
