### PR TITLE
use team_override when tagging metrics

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -37,4 +37,5 @@ object Constants {
   val ContextualSourceName: String = "contextual"
   val ContextualSourceKeys: String = "contextual_keys"
   val ContextualSourceValues: String = "contextual_values"
+  val TeamOverride: String = "team_override"
 }

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -105,6 +105,11 @@ object Extensions {
       val jMap: java.util.Map[String, Object] = mapper.readValue(metaData.customJson, typeRef)
       ScalaVersionSpecificCollectionsConverter.convertJavaMapToScala(jMap).get(key).orNull
     }
+
+    def owningTeam: String = {
+      val teamOverride = Try(customJsonLookUp(Constants.TeamOverride).asInstanceOf[String]).toOption
+      teamOverride.getOrElse(metaData.team)
+    }
   }
 
   // one per output column - so single window

--- a/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
@@ -15,4 +15,23 @@ class ExtensionsTest {
       source.subPartitionFilters
     )
   }
+
+  @Test
+  def testOwningTeam(): Unit = {
+    val metadata =
+      Builders.MetaData(
+        customJson = "{\"check_consistency\": true, \"lag\": 0, \"team_override\": \"ml_infra\"}",
+        team = "chronon"
+      )
+
+    assertEquals(
+      "ml_infra",
+      metadata.owningTeam
+    )
+
+    assertEquals(
+      "chronon",
+      metadata.team
+    )
+  }
 }

--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -61,7 +61,7 @@ object Metrics {
         environment = environment,
         join = join.metaData.cleanName,
         production = join.metaData.isProduction,
-        team = join.metaData.team
+        team = join.metaData.owningTeam
       )
     }
 
@@ -71,7 +71,7 @@ object Metrics {
         groupBy = groupBy.metaData.cleanName,
         production = groupBy.metaData.isProduction,
         accuracy = groupBy.inferredAccuracy,
-        team = groupBy.metaData.team
+        team = groupBy.metaData.owningTeam
       )
     }
 
@@ -86,7 +86,7 @@ object Metrics {
         environment = environment,
         groupBy = stagingQuery.metaData.cleanName,
         production = stagingQuery.metaData.isProduction,
-        team = stagingQuery.metaData.team
+        team = stagingQuery.metaData.owningTeam
       )
     }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Apply team_override when available when tagging metrics 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

For certain multi-organization stakeholders to properly apply cost attribution. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist

N/A

- [ ] Documentation update

## Reviewers


