### PR TITLE
[Kaggle outbrain example] Dockerized the outbrain Kaggle example

### DIFF
--- a/api/py/test/Dockerfile
+++ b/api/py/test/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        tree \
         python3.7 \
         python3-pip \
         python3.7-dev \

--- a/api/py/test/Dockerfile
+++ b/api/py/test/Dockerfile
@@ -1,0 +1,64 @@
+FROM openjdk:8-jdk-slim-buster
+USER root
+
+ENV JAVA_HOME /usr/local/openjdk-8/
+ENV PYTHONPATH /repos/chronon/api/py/:/repos/chronon/api/py/test/sample/:$PYTHONPATH
+ENV USER chronon_docker
+ENV THRIFT_VERSION 0.13.0
+ENV SPARK_SUBMIT_PATH=/spark-2.4.8-bin-hadoop2.7/bin/spark-submit
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        python3.7 \
+        python3-pip \
+        python3.7-dev \
+        python3-setuptools \
+        python3-wheel \
+        python3-venv \
+        automake \
+        bison \
+        cmake \
+        curl \
+        flex \
+        g++ \
+        git \
+        libboost-dev \
+        libboost-filesystem-dev \
+        libboost-program-options-dev \
+        libboost-system-dev \
+        libboost-test-dev \
+        libevent-dev \
+        libssl-dev \
+        libtool \
+        make \
+        && apt-get clean
+
+
+# Install thrift
+RUN curl -sSL "http://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
+    && mkdir -p /usr/src/thrift \
+    && tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
+    && rm thrift.tar.gz \
+    && cd /usr/src/thrift \
+    && ./configure  --without-python --without-cpp \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /usr/src/thrift
+
+
+# set python3
+RUN mkdir env
+RUN python3 -m venv env
+RUN mkdir repos
+RUN /bin/bash -c "source env/bin/activate && pip install chronon-ai"
+
+# set spark submit
+RUN curl -O https://archive.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
+RUN tar xf spark-2.4.8-bin-hadoop2.7.tgz
+RUN rm -rf /img-build
+WORKDIR repos/chronon/api/py/test/sample/
+
+

--- a/api/py/test/sample/group_bys/kaggle/outbrain.py
+++ b/api/py/test/sample/group_bys/kaggle/outbrain.py
@@ -1,4 +1,3 @@
-
 from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
 from ai.chronon.group_by import (

--- a/api/py/test/sample/scripts/spark_submit.sh
+++ b/api/py/test/sample/scripts/spark_submit.sh
@@ -58,7 +58,7 @@ $SPARK_SUBMIT_PATH \
 --conf spark.task.maxFailures=20 \
 --conf spark.stage.maxConsecutiveAttempts=12 \
 --conf spark.maxRemoteBlockSizeFetchToMem=2G \
---conf spark.network.timeout=230s \
+--conf spark.network.timeout=300s \
 --conf spark.executor.heartbeatInterval=200s \
 --conf spark.local.dir=${CHRONON_WORKING_DIR} \
 --conf spark.jars.ivy=${CHRONON_WORKING_DIR} \

--- a/docs/source/Kaggle_Outbrain.md
+++ b/docs/source/Kaggle_Outbrain.md
@@ -29,7 +29,7 @@ https://www.kaggle.com/competitions/outbrain-click-prediction/data
 To keep this tutorial brief, we'll only use these datasets. However, you could always download more data and experiment with joining it in.
 
 
-#### 2. Pull the [chronon_kaggle](https://hub.docker.com/layers/houpy0829/chronon/chronon_kaggle/images/sha256-c9eed67b2e67da748bfb284c4608f2e18de91e81dd9d31228f071eae1fbff84b?context=repo) Docker image
+#### 2. Pull the [chronon_kaggle](https://hub.docker.com/repository/docker/houpy0829/chronon) Docker image
 We built a Docker image  to reduce the burden for users to set up their machines.  
 ```shell
 cd ~


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR updates the Kaggle example to run it with docker images. It saves the user efforts to setup their local machines. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Simplify the Kaggle example for the public audience. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [x] tested with docker hub and manual testing covered in the doc update

## Checklist
- [x] Documentation update

## Reviewers
@airbnb/zipline-maintainers @nikhilsimha @ezvz @andriiuber 