### PR TITLE
Async ttl cache update

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -155,7 +155,9 @@ class Fetcher(val kvStore: KVStore,
       logControlEvent(joinCodec)
       joinCodec
     }
-  })
+  },
+    {join: String => Metrics.Context(environment = "join.codec.fetch", join = join)}
+  )
 
   override def fetchJoin(requests: scala.collection.Seq[Request]): Future[scala.collection.Seq[Response]] = {
     val ts = System.currentTimeMillis()

--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -100,6 +100,7 @@ object Metrics {
                                     statsPort,
                                     ctx.toTags: _*)
       },
+      { ctx => ctx },
       ttlMillis = 5 * 24 * 60 * 60 * 1000 // 5 days
     )
   }
@@ -112,7 +113,6 @@ object Metrics {
                      accuracy: Accuracy = null,
                      team: String = null,
                      joinPartPrefix: String = null,
-                     mode: String = null,
                      suffix: String = null)
       extends Serializable {
 


### PR DESCRIPTION
## Summary
Update TTL cache code to not block the calling thread in the hot path or during ttl expiration. We instead schedule the cache update asynchronously.


## Why / Goal
In high contention services sync update blocks all threads at once for IO - for every key. This could cause latency spikes when the metadata fetch is overloaded.


## Test Plan
- [ ] Integration tested

## Checklist
- [x] Documentation update - not required

## Reviewers
@sup @hzding621 @cristianfr 
