### PR TITLE
Update Chronon to default to Spark 3 & clean up warehouse directory in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val spark3_2_1 = "3.2.1"
 
 ThisBuild / organization := "ai.chronon"
 ThisBuild / organizationName := "chronon"
-ThisBuild / scalaVersion := scala211
+ThisBuild / scalaVersion := scala212
 ThisBuild / description := "Chronon is a feature engineering platform"
 ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / scmInfo := Some(
@@ -218,7 +218,7 @@ lazy val spark_embedded = (project in file("spark"))
   .dependsOn(aggregator.%("compile->compile;test->test"), online)
   .settings(
     sparkBaseSettings,
-    libraryDependencies ++= sparkLibs("2.4.0"),
+    libraryDependencies ++= sparkLibs(spark3_1_1),
     target := target.value.toPath.resolveSibling("target-embedded").toFile,
     embeddedAssemblyStrategy,
     Test / test := {}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Default to Spark 3.x for tests (allows us to sidestep - [SPARK-26839](https://issues.apache.org/jira/browse/SPARK-26839) while working in IntelliJ)
- Clean up the hive warehouse directory on JVM exit. Else we end up hitting issues on test re-runs as the warehouse directory already exists. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
While trying to get Chronon's tests running locally on our Stripe dev laptops, we've hit some issues. We had to make a couple of changes to get things working on our local machine setup (things work great in CI). 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha / @ezvz 
