### PR TITLE
Support Scala Map conversion 

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Row.scala
+++ b/api/src/main/scala/ai/chronon/api/Row.scala
@@ -129,6 +129,11 @@ object Row {
               .asScala
               .foreach { entry => newMap.put(edit(entry.getKey, keyType), edit(entry.getValue, valueType)) }
             mapper(newMap)
+          case map: collection.immutable.Map[Any, Any] =>
+            val newMap = new util.HashMap[Any, Any](map.size)
+            map
+              .foreach { entry => newMap.put(edit(entry._1, keyType), edit(entry._2, valueType)) }
+            mapper(newMap)
         }
       case BinaryType => binarizer(value.asInstanceOf[Array[Byte]])
       case IntType => value.asInstanceOf[Number].intValue()


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR will support map conversion for Scala.collection.immutable.map. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Because it fails a reading query with a map struct 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [x] tested on gateway machine 

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
