### PR TITLE
change val-> def for KV store trait 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -24,7 +24,7 @@ object KVStore {
 // the main system level api for key value storage
 // used for streaming writes, batch bulk uploads & fetching
 trait KVStore {
-   val kvStoreExecutor = new ThreadPoolExecutor(2, // corePoolSize
+  private def kvStoreExecutor: ThreadPoolExecutor = new ThreadPoolExecutor(2, // corePoolSize
     1000, // maxPoolSize
     60, // keepAliveTime
     TimeUnit.SECONDS, // keep alive time units


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
`def` will work more friendly with trait in Scala than `val`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Fix the error below:
```
Exception in thread "main" java.lang.AbstractMethodError: Receiver class com.airbnb.bighead.zipline.online.MusselZiplineKvStore does not define or inherit an implementation of the resolved method 'abstract void ai$chronon$online$KVStore$_setter_$kvStoreExecutor_$eq(java.util.concurrent.ThreadPoolExecutor)' of interface ai.chronon.online.KVStore.
        at ai.chronon.online.KVStore$class.$init$(Api.scala:27)
        at com.airbnb.bighead.zipline.online.MusselZiplineKvStore.<init>(MusselZiplineKvStore.scala:22)
        at com.airbnb.bighead.zipline.online.MusselZiplineKvStore$$anon$1.apply(MusselZiplineKvStore.scala:210)
        at com.airbnb.bighead.zipline.online.MusselZiplineKvStore$$anon$1.apply(MusselZiplineKvStore.scala:209)
        at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
        at com.airbnb.bighead.zipline.online.MusselZiplineKvStore$.apply(MusselZiplineKvStore.scala:207)
        at com.airbnb.bighead.zipline.online.MusselZiplineOnlineImpl.genKvStore(MusselZiplineOnlineImpl.scala:67)
        at ai.chronon.online.Api.buildFetcher(Api.scala:165)
        at ai.chronon.spark.Driver$FetcherCli$.run(Driver.scala:340)
        at ai.chronon.spark.Driver$.main(Driver.scala:569)
        at ai.chronon.spark.Driver.main(Driver.scala)
```

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [x] tested with treehouse 

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
