### PR TITLE
Continuous processing in Streaming + topic partition counter util

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val releaseSettings = Seq(
 lazy val supportedVersions = List(scala211, scala212, scala213)
 
 lazy val root = (project in file("."))
-  .aggregate(api, aggregator, online, spark_uber)
+  .aggregate(api, aggregator, online, spark_uber, spark_embedded)
   .settings(
     publish / skip := true,
     crossScalaVersions := Nil,

--- a/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
@@ -16,6 +16,7 @@ import java.time.{Instant, ZoneId, ZoneOffset}
 import java.util.Base64
 import scala.collection.JavaConverters._
 import scala.collection.Seq
+import scala.concurrent.duration.DurationInt
 
 class GroupBy(inputStream: DataFrame,
               session: SparkSession,
@@ -163,9 +164,7 @@ class GroupBy(inputStream: DataFrame,
       }
       .writeStream
       .outputMode("append")
-      // 50ms trigger - continuous trigger forces users
-      // to specify and keep up with partition counts.
-      .trigger(Trigger.ProcessingTime(50))
+      .trigger(Trigger.Continuous(2.minute))
       .foreach(dataWriter)
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/streaming/TopicChecker.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/TopicChecker.scala
@@ -1,14 +1,32 @@
 package ai.chronon.spark.streaming
 
 import ai.chronon.aggregator.base.BottomK
-import ai.chronon.api.UnknownType
+import ai.chronon.api
+import ai.chronon.api.Extensions.{GroupByOps, SourceOps}
+import ai.chronon.api.{ThriftJsonCodec, UnknownType}
+import ai.chronon.spark.Driver
+import ai.chronon.spark.Driver.OnlineSubcommand
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, ListTopicsOptions}
 import ai.chronon.spark.stats.EditDistance
+import org.apache.thrift.TBase
+import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
+
 import java.util
 import java.util.Properties
 import scala.collection.JavaConverters.{asScalaBufferConverter, asScalaIteratorConverter}
+import scala.reflect.ClassTag
+import scala.util.Try
 
 object TopicChecker {
+
+  def getPartitions(topic: String, bootstrap: String): Int = {
+    val props = new Properties()
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap)
+    val adminClient = AdminClient.create(props)
+    val topicDescription = adminClient.describeTopics(util.Arrays.asList(topic)).values().get(topic);
+    topicDescription.get().partitions().size()
+  }
+
   def topicShouldExist(topic: String, bootstrap: String): Unit = {
     val props = new Properties()
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap)
@@ -49,5 +67,30 @@ object TopicChecker {
     }
   }
 
-  def main(args: Array[String]): Unit = topicShouldExist(args(0), args(1))
+  class Args(arguments: Seq[String]) extends ScallopConf(arguments) {
+    val conf: ScallopOption[String] = opt[String](descr = "Conf to pull topic and bootstrap server information")
+    val bootstrap: ScallopOption[String] = opt[String](descr = "Kafka bootstrap server in host:port format")
+    val topic: ScallopOption[String] = opt[String](descr = "kafka topic to check metadata for")
+    verify()
+  }
+
+  // print out number of partitions and exit
+  def main(argSeq: Array[String]) {
+    val args = new Args(argSeq)
+    val (topic, bootstrap) = if (args.conf.isDefined) {
+      val confPath = args.conf()
+      val groupBy = Driver.parseConf[api.GroupBy](confPath)
+      val source = groupBy.streamingSource.get
+      val topic = source.cleanTopic
+      val tokens = source.topicTokens
+      lazy val host = tokens.get("host")
+      lazy val port = tokens.get("port")
+      lazy val hostPort = s"${host.get}:${port.get}"
+      topic -> args.bootstrap.getOrElse(hostPort)
+    } else {
+      args.topic() -> args.bootstrap()
+    }
+    println(getPartitions(topic, bootstrap))
+    System.exit(0)
+  }
 }


### PR DESCRIPTION
## Summary
The major caveat of continuous processing is the fact that number of executors should match the number of executor cores in the streaming job. This PR reverts back to continuous processing and adds a utility to print out number of kafka partitions.

The idea is to figure out the number of executors automatically without involving users. 


## Test Plan
This tool can be invoked with conf 
```
java -cp spark_embedded-assembly-streaming_30_success_case-0.0.31-SNAPSHOT.jar ai.chronon.spark.streaming.TopicChecker --conf=zipline/production/group_bys/[REDACTED] 2>/dev/null
```
prints
```
8
```

This tool can also be invoked with topic and bootstrap
```
java -cp spark_embedded-assembly-streaming_30_success_case-0.0.31-SNAPSHOT.jar ai.chronon.spark.streaming.TopicChecker --bootstrap=[REDACTED] --topic=[REDACTED] 2>/dev/null
```
prints
```
4
```

- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested


## Reviewers
@cristianfr @ezvz 
