### PR TITLE
Adding schedule interval to group_by.py

### DIFF
--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -371,6 +371,14 @@ def GroupBy(sources: Union[List[_ANY_SOURCE_TYPE], _ANY_SOURCE_TYPE],
         Param that goes into customJson. You can pull this out of the json at path "metaData.customJson.lag"
         This is used by airflow integration to pick an older hive partition to wait on.
     :type lag: int
+    :param offline_schedule:
+         the offline schedule interval for batch jobs. Below is the equivalent of the cron tab commands
+        '@hourly': '0 * * * *',
+        '@daily': '0 0 * * *',
+        '@weekly': '0 0 * * 0',
+        '@monthly': '0 0 1 * *',
+        '@yearly': '0 0 1 1 *',
+    :type offline_schedule: str
     :param kwargs:
         Additional properties that would be passed to run.py if specified under additional_args property.
         And provides an option to pass custom values to the processing logic.


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adding schedule interval as param to group by 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
easier to schedule jobs 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
```
PYTHONPATH=/Users/pengyu_hou/workspace/chronon/api/py:/Users/pengyu_hou/workspace/ml_models/zipline:$fPYTHONPATH python3  /Users/pengyu_hou/workspace/chronon/api/py/ai/chronon/repo/compile.py --chronon_root=/Users/pengyu_hou/workspace/ml_models/zipline/ --input_path=group_bys/xxx.py
```
## Checklist
- [x] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
