### PR TITLE
Make branches more permissive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,15 +46,15 @@ jobs:
                 name: Build docker image
                 command: |
                     set +o pipefail
-                    docker build -t houpy0829/chronon-ci:base--${CIRCLE_PR_NUMBER} --build-arg base_image="cimg/base:2020.01" -f .circleci/Dockerfile .
+                    docker build -t houpy0829/chronon-ci:base--pr-${CIRCLE_PULL_REQUEST##*/} --build-arg base_image="cimg/base:2020.01" -f .circleci/Dockerfile .
             - deploy:
                 name: Push docker image
                 command: |
-                    set +o pipefail
+                    set +euxo pipefail
                     docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
-                    docker push houpy0829/chronon-ci:base--${CIRCLE_PR_NUMBER}
+                    docker push houpy0829/chronon-ci:base--${CIRCLE_PULL_REQUEST##*/}
                     if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                        docker tag houpy0829/chronon-ci:base--${CIRCLE_PR_NUMBER} houpy0829/chronon-ci:base
+                        docker tag houpy0829/chronon-ci:base--${CIRCLE_PULL_REQUEST##*/} houpy0829/chronon-ci:base
                         docker push houpy0829/chronon-ci:base
                     fi
 


### PR DESCRIPTION
## Summary
If user branches have a "/" in them the docker build fails. It happens commonly when folks raise a PR from their forks.

So we replace the branch in docker command with pr number


## Test Plan
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@piyushn-stripe @hzding621 
