### PR TITLE
Fix 2.11 CI and build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
                       conda activate zipline_py
                       # Increase if we see OOM.
                       export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-                      sbt test
+                      sbt "++ 2.11.12 test"
             - store_test_results:
                   path: /zipline/spark/target/test-reports
             - store_test_results:

--- a/online/src/main/scala-2.11/ai/chronon/online/ScalaVersionSpecificCatalystHelper.scala
+++ b/online/src/main/scala-2.11/ai/chronon/online/ScalaVersionSpecificCatalystHelper.scala
@@ -1,0 +1,14 @@
+package ai.chronon.online
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, InterpretedPredicate}
+
+object ScalaVersionSpecificCatalystHelper {
+
+  def evalFilterExec(row: InternalRow, condition: Expression, attributes: Seq[Attribute]): Boolean = {
+    val predicate = InterpretedPredicate.create(condition, attributes)
+    predicate.initialize(0)
+    val r = predicate.eval(row)
+    r
+  }
+}

--- a/online/src/main/scala-2.12/ai/chronon/online/ScalaVersionSpecificCatalystHelper.scala
+++ b/online/src/main/scala-2.12/ai/chronon/online/ScalaVersionSpecificCatalystHelper.scala
@@ -1,0 +1,14 @@
+package ai.chronon.online
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Predicate}
+
+object ScalaVersionSpecificCatalystHelper {
+
+  def evalFilterExec(row: InternalRow, condition: Expression, attributes: Seq[Attribute]): Boolean = {
+    val predicate = Predicate.create(condition, attributes)
+    predicate.initialize(0)
+    val r = predicate.eval(row)
+    r
+  }
+}

--- a/online/src/main/scala-2.13/ai/chronon/online/ScalaVersionSpecificCatalystHelper.scala
+++ b/online/src/main/scala-2.13/ai/chronon/online/ScalaVersionSpecificCatalystHelper.scala
@@ -1,0 +1,16 @@
+package ai.chronon.online
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Predicate}
+
+import scala.collection.Seq
+
+object ScalaVersionSpecificCatalystHelper {
+
+  def evalFilterExec(row: InternalRow, condition: Expression, attributes: Seq[Attribute]): Boolean = {
+    val predicate = Predicate.create(condition, attributes.toSeq)
+    predicate.initialize(0)
+    val r = predicate.eval(row)
+    r
+  }
+}

--- a/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
@@ -43,8 +43,8 @@ class FeatureWithLabelJoinTest {
     featureDf.show()
     val computed = tableUtils.sql(s"select * from ${joinConf.metaData.outputFinalView}")
     val expectedFinal = featureDf.join(prefixColumnName(labelDf, exceptions = labelJoinConf.rowIdentifier()),
-      labelJoinConf.rowIdentifier(),
-      "left_outer")
+                                       labelJoinConf.rowIdentifier(),
+                                       "left_outer")
     assertResult(computed, expectedFinal)
 
     // add another label version
@@ -55,21 +55,28 @@ class FeatureWithLabelJoinTest {
     val view = tableUtils.sql(s"select * from ${joinConf.metaData.outputFinalView} order by label_ds")
     view.show()
     // listing 4 should not have any 2022-11-11 version labels
-    assertEquals(null, view.where(view("label_ds") === "2022-11-11" && view("listing") === "4")
-      .select("label_listing_labels_dim_room_type").first().get(0))
+    assertEquals(null,
+                 view
+                   .where(view("label_ds") === "2022-11-11" && view("listing") === "4")
+                   .select("label_listing_labels_dim_room_type")
+                   .first()
+                   .get(0))
     // 11-11 label record number should be same as 10-30 label version record number
     assertEquals(view.where(view("label_ds") === "2022-10-30").count(),
-      view.where(view("label_ds") === "2022-11-11").count())
+                 view.where(view("label_ds") === "2022-11-11").count())
     // listing 5 should not not have any label
-    assertEquals(null, view.where(view("listing") === "5")
-      .select("label_ds").first().get(0))
+    assertEquals(null,
+                 view
+                   .where(view("listing") === "5")
+                   .select("label_ds")
+                   .first()
+                   .get(0))
 
     //validate the latest label view
     val latest = tableUtils.sql(s"select * from ${joinConf.metaData.outputLatestLabelView} order by label_ds")
     latest.show()
     // latest label should be all same "2022-11-11"
-    assertEquals(latest.agg(max("label_ds")).first().getString(0),
-                 latest.agg(min("label_ds")).first().getString(0))
+    assertEquals(latest.agg(max("label_ds")).first().getString(0), latest.agg(min("label_ds")).first().getString(0))
     assertEquals("2022-11-11", latest.agg(max("label_ds")).first().getString(0))
   }
 
@@ -94,9 +101,13 @@ class FeatureWithLabelJoinTest {
       Row(3L, 10L, "2022-10-02 11:00:00", "2022-10-02"),
       Row(1L, 20L, "2022-10-03 11:00:00", "2022-10-03"),
       Row(2L, 35L, "2022-10-03 11:00:00", "2022-10-03"),
-      Row(3L, 15L, "2022-10-03 11:00:00", "2022-10-03"))
-    val leftSource = TestUtils.createViewsGroupBy(namespace, spark, tableName = "listing_view_agg", customRows = rows)
-      .groupByConf.sources.get(0)
+      Row(3L, 15L, "2022-10-03 11:00:00", "2022-10-03")
+    )
+    val leftSource = TestUtils
+      .createViewsGroupBy(namespace, spark, tableName = "listing_view_agg", customRows = rows)
+      .groupByConf
+      .sources
+      .get(0)
     val labelJoinConf = createTestAggLabelJoin(5, "listing_labels_agg")
     val joinConf = Builders.Join(
       Builders.MetaData(name = tableName, namespace = namespace, team = "chronon"),
@@ -114,15 +125,15 @@ class FeatureWithLabelJoinTest {
     featureDf.show()
     val computed = tableUtils.sql(s"select * from ${joinConf.metaData.outputFinalView}")
     val expectedFinal = featureDf.join(prefixColumnName(labelDf, exceptions = labelJoinConf.rowIdentifier()),
-      labelJoinConf.rowIdentifier(),
-      "left_outer")
+                                       labelJoinConf.rowIdentifier(),
+                                       "left_outer")
     assertResult(computed, expectedFinal)
 
     // add new labels
     val newLabelRows = List(
       Row(1L, 0, "2022-10-07", "2022-10-07 11:00:00"),
       Row(2L, 2, "2022-10-07", "2022-10-07 11:00:00"),
-      Row(3L, 2, "2022-10-07", "2022-10-07 11:00:00"),
+      Row(3L, 2, "2022-10-07", "2022-10-07 11:00:00")
     )
     TestUtils.createOrUpdateLabelGroupByWithAgg(namespace, spark, 5, "listing_labels_agg", newLabelRows)
     val runner2 = new LabelJoin(joinConf, tableUtils, "2022-10-07")
@@ -132,10 +143,18 @@ class FeatureWithLabelJoinTest {
     //validate the label view
     val latest = tableUtils.sql(s"select * from ${joinConf.metaData.outputLatestLabelView} order by label_ds")
     latest.show()
-    assertEquals(2, latest.where(latest("listing") === "3" && latest("ds") === "2022-10-03")
-      .select("label_listing_labels_agg_is_active_max_5d").first().get(0))
-    assertEquals("2022-10-07", latest.where(latest("listing") === "1" && latest("ds") === "2022-10-03")
-      .select("label_ds").first().get(0))
+    assertEquals(2,
+                 latest
+                   .where(latest("listing") === "3" && latest("ds") === "2022-10-03")
+                   .select("label_listing_labels_agg_is_active_max_5d")
+                   .first()
+                   .get(0))
+    assertEquals("2022-10-07",
+                 latest
+                   .where(latest("listing") === "1" && latest("ds") === "2022-10-03")
+                   .select("label_ds")
+                   .first()
+                   .get(0))
   }
 
   private def assertResult(computed: DataFrame, expected: DataFrame): Unit = {
@@ -143,11 +162,7 @@ class FeatureWithLabelJoinTest {
     computed.show()
     println(" == Expected == ")
     expected.show()
-    val diff = Comparison.sideBySide(computed,
-      expected,
-      List("listing",
-        "ds",
-        "label_ds"))
+    val diff = Comparison.sideBySide(computed, expected, List("listing", "ds", "label_ds"))
     if (diff.count() > 0) {
       println(s"Actual count: ${computed.count()}")
       println(s"Expected count: ${expected.count()}")
@@ -165,7 +180,7 @@ class FeatureWithLabelJoinTest {
     println(exceptions.mkString(", "))
     val renamedColumns = df.columns
       .map(col => {
-        if(exceptions.contains(col) || col.startsWith(prefix)) {
+        if (exceptions.contains(col) || col.startsWith(prefix)) {
           df(col)
         } else {
           df(col).as(s"$prefix$col")
@@ -187,11 +202,12 @@ class FeatureWithLabelJoinTest {
     )
   }
 
-  def createTestAggLabelJoin(windowSize: Int, groupByTableName: String = "listing_labels_agg"): ai.chronon.api.LabelPart = {
+  def createTestAggLabelJoin(windowSize: Int,
+                             groupByTableName: String = "listing_labels_agg"): ai.chronon.api.LabelPart = {
     val labelGroupBy = TestUtils.createOrUpdateLabelGroupByWithAgg(namespace, spark, windowSize, groupByTableName)
     Builders.LabelPart(
       labels = Seq(
-        Builders.JoinPart(groupBy = labelGroupBy.groupByConf),
+        Builders.JoinPart(groupBy = labelGroupBy.groupByConf)
       ),
       leftStartOffset = windowSize,
       leftEndOffset = windowSize

--- a/spark/src/test/scala/ai/chronon/spark/test/TestUtils.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TestUtils.scala
@@ -24,15 +24,17 @@ object TestUtils {
         StructField("ds", StringType)
       )
     )
-    val rows = if (customRows.isEmpty)
-      List(
-        Row(1L, 20L, "2022-10-01 10:00:00", "2022-10-01"),
-        Row(2L, 30L, "2022-10-02 10:00:00", "2022-10-02"),
-        Row(3L, 10L, "2022-10-01 10:00:00", "2022-10-01"),
-        Row(4L, 20L, "2022-10-02 10:00:00", "2022-10-02"),
-        Row(5L, 35L, "2022-10-03 10:00:00", "2022-10-03"),
-        Row(1L, 15L, "2022-10-03 10:00:00", "2022-10-03")
-      ) else customRows
+    val rows =
+      if (customRows.isEmpty)
+        List(
+          Row(1L, 20L, "2022-10-01 10:00:00", "2022-10-01"),
+          Row(2L, 30L, "2022-10-02 10:00:00", "2022-10-02"),
+          Row(3L, 10L, "2022-10-01 10:00:00", "2022-10-01"),
+          Row(4L, 20L, "2022-10-02 10:00:00", "2022-10-02"),
+          Row(5L, 35L, "2022-10-03 10:00:00", "2022-10-03"),
+          Row(1L, 15L, "2022-10-03 10:00:00", "2022-10-03")
+        )
+      else customRows
     val source = Builders.Source.events(
       query = Builders.Query(
         selects = Map(
@@ -116,8 +118,8 @@ object TestUtils {
   }
 
   def createReservationGroupBy(namespace: String,
-                            spark: SparkSession,
-                            tableName: String = "listing_attributes_reservation"): GroupByTestSuite = {
+                               spark: SparkSession,
+                               tableName: String = "listing_attributes_reservation"): GroupByTestSuite = {
     val schema = StructType(
       tableName,
       Array(
@@ -140,7 +142,7 @@ object TestUtils {
       query = Builders.Query(
         selects = Map(
           "listing" -> "listing_id",
-          "dim_reservations" -> "dim_reservations",
+          "dim_reservations" -> "dim_reservations"
         )
       ),
       snapshotTable = s"${namespace}.${tableName}"
@@ -238,14 +240,14 @@ object TestUtils {
         Row(1L, 0, "2022-10-06", "2022-10-06 11:00:00"),
         Row(2L, 1, "2022-10-06", "2022-10-06 11:00:00"),
         Row(3L, 0, "2022-10-06", "2022-10-06 11:00:00"),
-        Row(1L, 2, "2022-10-07", "2022-10-07 11:00:00"), // not included in agg window
+        Row(1L, 2, "2022-10-07", "2022-10-07 11:00:00") // not included in agg window
       )
     } else customRows
     val source = Builders.Source.events(
       query = Builders.Query(
         selects = Map(
           "listing" -> "listing_id",
-          "is_active" -> "is_active",
+          "is_active" -> "is_active"
         ),
         timeColumn = "UNIX_TIMESTAMP(ts) * 1000"
       ),
@@ -254,11 +256,12 @@ object TestUtils {
     val conf = Builders.GroupBy(
       sources = Seq(source),
       keyColumns = Seq("listing"),
-      aggregations = Seq(Builders.Aggregation(
-        inputColumn = "is_active",
-        operation = Operation.MAX,
-        windows = Seq(new Window(windowSize, TimeUnit.DAYS))
-      )),
+      aggregations = Seq(
+        Builders.Aggregation(
+          inputColumn = "is_active",
+          operation = Operation.MAX,
+          windows = Seq(new Window(windowSize, TimeUnit.DAYS))
+        )),
       accuracy = Accuracy.SNAPSHOT,
       metaData = Builders.MetaData(name = s"${tableName}", namespace = namespace, team = "chronon")
     )
@@ -308,8 +311,8 @@ object TestUtils {
       keyColumns = Seq("listing_id"),
       aggregations = Seq(
         Builders.Aggregation(operation = Operation.MAX,
-          inputColumn = "active_status",
-          windows = Seq(new Window(windowSize, TimeUnit.DAYS)))),
+                             inputColumn = "active_status",
+                             windows = Seq(new Window(windowSize, TimeUnit.DAYS)))),
       metaData = Builders.MetaData(name = "listing_label_table", namespace = namespace, team = "chronon")
     )
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

- Fix 2.11 ci: this was incorrectly running 2.13 test after we bumped default version to 2.13
- fix build errors from prior PRs 
   - Move part of catalystUtil that has divergent code across versions to ScalaVersionSpecificCatalystHelper.scala since `Predicate` isn't backward compatible with spark 2.4.0 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Covered by existing CI

## Reviewers

@cristianfr @nikhilsimha cc @piyushn-stripe 