### PR TITLE
[Logs][1liner] Show input tables in backfill log

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -361,6 +361,7 @@ case class TableUtils(sparkSession: SparkSession) {
                |Unfilled range computation:
                |   Output table: $outputTable
                |   Missing output partitions: ${outputMissing.toSeq.sorted.prettyInline}
+               |   Input tables: ${inputTables.getOrElse(Seq("None")).mkString(", ")}
                |   Missing input partitions: ${inputMissing.toSeq.sorted.prettyInline}
                |   Unfilled Partitions: ${missingPartitions.toSeq.sorted.prettyInline}
                |   Unfilled ranges: ${missingChunks.sorted}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
A user run into a "why is chronon existing without computing"
The config relied on get_staging_query output, the issue was the input table didn't have data.
I figured setting the input tables in our partitions checks make it's easier to find this out.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
User experience

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@better365 @cenhao @vamseeyarla 
