### PR TITLE
use embedded jar for fetch cli

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -402,7 +402,7 @@ if __name__ == "__main__":
     set_runtime_env(pre_parse_args)
     set_defaults(parser)
     args, unknown_args = parser.parse_known_args()
-    jar_type = 'embedded' if args.mode == 'local-streaming' or args.mode == 'fetch' else 'uber'
+    jar_type = 'embedded' if args.mode in ['local-streaming', 'fetch'] else 'uber'
     extra_args = (' ' + args.online_args) if args.mode in ONLINE_MODES else ''
     args.args = ' '.join(unknown_args) + extra_args
     jar_path = args.chronon_jar if args.chronon_jar else download_jar(


### PR DESCRIPTION
## Summary

fetcher now requires access to spark lib (for join with derivations)

```
Exception in thread "pool-1-thread-18" java.lang.NoClassDefFoundError: org/apache/spark/sql/types/DataType
	at ai.chronon.online.CatalystUtil$$anonfun$1.apply(CatalystUtil.scala:40)
	at ai.chronon.online.CatalystUtil$$anonfun$1.apply(CatalystUtil.scala:39)
	at ai.chronon.online.PoolMap$$anon$1.apply(CatalystUtil.scala:53)
	at ai.chronon.online.PoolMap$$anon$1.apply(CatalystUtil.scala:48)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at ai.chronon.online.PoolMap.getPool(CatalystUtil.scala:46)
	at ai.chronon.online.PooledCatalystUtil.<init>(CatalystUtil.scala:78)
	at ai.chronon.online.JoinCodec.valueSchemaAndDeriveFunc$lzycompute(JoinCodec.scala:54)
	at ai.chronon.online.JoinCodec.valueSchemaAndDeriveFunc(JoinCodec.scala:23)
	at ai.chronon.online.JoinCodec.valueSchema$lzycompute(JoinCodec.scala:69)
	at ai.chronon.online.JoinCodec.valueSchema(JoinCodec.scala:68)
	at ai.chronon.online.JoinCodec.<init>(JoinCodec.scala:97)
	at ai.chronon.online.Fetcher$$anonfun$getJoinCodecs$1$$anonfun$apply$1.apply(Fetcher.scala:106)
	at ai.chronon.online.Fetcher$$anonfun$getJoinCodecs$1$$anonfun$apply$1.apply(Fetcher.scala:53)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at ai.chronon.online.Fetcher$$anonfun$getJoinCodecs$1.apply(Fetcher.scala:53)
	at ai.chronon.online.Fetcher$$anonfun$getJoinCodecs$1.apply(Fetcher.scala:49)
	at ai.chronon.online.TTLCache$$anon$1.apply(TTLCache.scala:27)
	at ai.chronon.online.TTLCache$$anon$1.apply(TTLCache.scala:23)
	at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1853)
	at ai.chronon.online.TTLCache.asyncUpdateOnExpiry(TTLCache.scala:41)
	at ai.chronon.online.TTLCache.apply(TTLCache.scala:66)
	at ai.chronon.online.Fetcher$$anonfun$3$$anonfun$apply$13.apply(Fetcher.scala:149)
	at ai.chronon.online.Fetcher$$anonfun$3$$anonfun$apply$13.apply(Fetcher.scala:126)
	at scala.collection.immutable.Stream.map(Stream.scala:418)
	at ai.chronon.online.Fetcher$$anonfun$3.apply(Fetcher.scala:126)
	at ai.chronon.online.Fetcher$$anonfun$3.apply(Fetcher.scala:124)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:36)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.ClassNotFoundException: org.apache.spark.sql.types.DataType
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 38 more
```

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
bug fix

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->

- [x] Integration tested


## Reviewers
@cristianfr @cenhao 
