### PR TITLE
Handle exceptions without stack trace

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -134,11 +134,16 @@ object Metrics {
 
     def increment(metric: String): Unit = stats.increment(metric)
     def incrementException(exception: Throwable): Unit = {
-      val stackRoot = exception.getStackTrace.apply(0)
-      val file = stackRoot.getFileName
-      val line = stackRoot.getLineNumber
-      val method = stackRoot.getMethodName
-      val exceptionSignature = s"[$method@$file:$line]${exception.getClass.toString}"
+      val stackTrace = exception.getStackTrace
+      val exceptionSignature = if (stackTrace.isEmpty) {
+        exception.getClass.toString
+      } else {
+        val stackRoot = stackTrace.apply(0)
+        val file = stackRoot.getFileName
+        val line = stackRoot.getLineNumber
+        val method = stackRoot.getMethodName
+        s"[$method@$file:$line]${exception.getClass.toString}"
+      }
       stats.increment(Name.Exception, s"${Metrics.Name.Exception}:${exceptionSignature}")
     }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

We encounter exceptions without stack trace info (it was a `java.lang.NullPointerException`), which is in turn throwing the following: 

```
java.lang.ArrayIndexOutOfBoundsException: 0
	at ai.chronon.online.Metrics$Context.incrementException(Metrics.scala:141)
	at ai.chronon.spark.streaming.GroupBy$$anonfun$7.apply(GroupBy.scala:89)
	at ai.chronon.spark.streaming.GroupBy$$anonfun$7.apply(GroupBy.scala:81)
	at org.apache.spark.sql.execution.MapElementsExec$$anonfun$7$$anonfun$apply$1.apply(objects.scala:236)
	at org.apache.spark.sql.execution.MapElementsExec$$anonfun$7$$anonfun$apply$1.apply(objects.scala:236)
	at scala.collection.Iterator$$anon$11.next(Iterator.scala:410)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:463)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage2.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$11$$anon$1.hasNext(WholeStageCodegenExec.scala:619)
	at org.apache.spark.sql.execution.streaming.continuous.ContinuousWriteRDD$$anonfun$compute$1.apply$mcV$sp(ContinuousWriteRDD.scala:57)
	at org.apache.spark.sql.execution.streaming.continuous.ContinuousWriteRDD$$anonfun$compute$1.apply(ContinuousWriteRDD.scala:51)
	at org.apache.spark.sql.execution.streaming.continuous.ContinuousWriteRDD$$anonfun$compute$1.apply(ContinuousWriteRDD.scala:51)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1394)
	at org.apache.spark.sql.execution.streaming.continuous.ContinuousWriteRDD.compute(ContinuousWriteRDD.scala:76)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:121)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:402)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:408)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested


## Reviewers

