### PR TITLE
Improve count() perf for large df

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -3,7 +3,7 @@ package ai.chronon.spark
 import ai.chronon.api.Constants
 import ai.chronon.api.Extensions._
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
-import org.apache.spark.sql.functions.{col, lit, rand, round}
+import org.apache.spark.sql.functions.{col, count, lit, max, min, rand, round}
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
@@ -228,7 +228,12 @@ case class TableUtils(sparkSession: SparkSession) {
   }
 
   private def repartitionAndWrite(df: DataFrame, tableName: String, saveMode: SaveMode): Unit = {
-    val rowCount = df.count()
+
+    val stats = df
+      .select(
+        count(lit(1)))
+      .head()
+    val rowCount = stats.getLong(0)
     println(s"$rowCount rows requested to be written into table $tableName")
     if (rowCount > 0) {
       // at-least a million rows per partition per 100 columns - or there will be too many files.


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
**WIP** 
Trust has a groupby which has huge volume of data. ~28 million records per ds partition
Backfill is failing to get `df.count()` when insertingPartitions. 


User [Thread](https://airbnb.slack.com/archives/C03NX9G22JJ/p1684350043768299)
Airflow log [failure](https://airflow-1-10.d.musta.ch/log?task_id=compute_join__trust_v21__generalized_ato_in_session__v2&dag_id=chronon_join_trust_v21__generalized_ato_in_session__v2&execution_date=2023-05-15T00%3A00%3A00%2B00%3A00) 
Spark SQL [failure](https://jobserver-worker.d.musta.ch/v1/proxy/j-3LWUYJ43IQ6LM/shs/history/application_1681411250683_1992866/SQL/)

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Unblock user backfill failure

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

