### PR TITLE
[Algo] Two Stack + Hop and Sawtooth + two stack

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/HopsAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/HopsAggregator.scala
@@ -119,8 +119,6 @@ class HopsAggregator(minQueryTs: Long,
       .zip(readableLeftBounds)
       .map { case (hop, left) => s"$hop->$left" }
       .mkString(", ")
-    println(s"""Left bounds: $readableHopsToBoundsMap 
-         |minQueryTs = ${TsUtils.toStr(minQueryTs)}""".stripMargin)
     result
   }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregationBuffer.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregationBuffer.scala
@@ -27,6 +27,12 @@ class TwoStackLiteAggregationBuffer[Input, IR >: Null, Output >: Null](aggregato
     aggBack = if (aggBack == null) ir else aggregator.update(aggBack, input)
   }
 
+  def extend(ir: IR, ts: Long): Unit = {
+    val clone = aggregator.clone(ir)
+    deque.addLast(BankersEntry(clone, ts))
+    aggBack = if (aggBack == null) clone else aggregator.merge(aggBack, clone)
+  }
+
   def pop(): BankersEntry[IR] = {
     if (!deque.isEmpty) {
       if (frontLen == 0) {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregator.scala
@@ -7,130 +7,160 @@ import scala.collection.Seq
 
 // This implements the two-stack-lite algorithm
 // To understand the intuition behind the algorithm I highly recommend reading the intuition text in the end of this file
-class TwoStackLiteAggregator(inputSchema: StructType, aggregations: Seq[Aggregation], resolution: Resolution = FiveMinuteResolution) {
+class TwoStackLiteAggregator(inputSchema: StructType,
+                             aggregations: Seq[Aggregation],
+                             resolution: Resolution = FiveMinuteResolution) {
 
-  private val allParts = aggregations.flatMap(_.unpack)
-  private val outputColumnNames = allParts.map(_.outputColumnName)
+  protected val allParts: Seq[AggregationPart] = aggregations.flatMap(_.unpack)
   // create row aggregator per window - we will loop over data as many times as there are unique windows
   // we will use different row aggregators to do so
   case class PerWindowAggregator(window: Window, agg: RowAggregator, indexMapping: Array[Int]) {
     private val windowLength: Long = window.millis
     private val tailHopSize = resolution.calculateTailHop(window)
-    def tailTs(queryTs: Long): Long = ((queryTs - windowLength)/tailHopSize) * tailHopSize
+    def tailTs(queryTs: Long): Long = TsUtils.round(queryTs - windowLength, tailHopSize)
+    def hopStart(queryTs: Long): Long = TsUtils.round(queryTs, tailHopSize)
     def bankersBuffer(inputSize: Int) = new TwoStackLiteAggregationBuffer[Row, Array[Any], Array[Any]](agg, inputSize)
     def init = new Array[Any](agg.length)
   }
 
   val inputSchemaTuples: Array[(String, DataType)] = inputSchema.fields.map(f => f.name -> f.fieldType)
-  val perWindowAggregators : Array[PerWindowAggregator] = allParts.iterator.zipWithIndex.toArray
+  val perWindowAggregators: Array[PerWindowAggregator] = allParts.iterator.zipWithIndex.toArray
     .filter { case (p, _) => p.window != null }
-    .groupBy { case (p, _)  => p.window }
+    .groupBy { case (p, _) => p.window }
     .map {
       case (w, ps) =>
         val parts = ps.map(_._1)
         val idxs = ps.map(_._2)
         PerWindowAggregator(w, new RowAggregator(inputSchemaTuples, parts), idxs)
-    }.toArray
+    }
+    .toArray
 
   // lifetime aggregations don't need bankers buffer, simple unWindowed sum is good enough
-  private val unWindowedParts = allParts.filter(_.window == null).toArray
-  val unWindowedAggregator: Option[RowAggregator] =  if(unWindowedParts.isEmpty) None else
-    Some(new RowAggregator(inputSchemaTuples, unWindowedParts))
-  val unWindowedIndexMapping: Array[Int] = unWindowedParts.map(c => allParts.indexWhere(c.outputColumnName == _.outputColumnName))
+  protected val unWindowedParts: Array[AggregationPart] = allParts.filter(_.window == null).toArray
+
+  val unWindowedAggregator: Option[RowAggregator] =
+    if (unWindowedParts.isEmpty) None
+    else Some(new RowAggregator(inputSchemaTuples, unWindowedParts))
+
+  val unWindowedIndexMapping: Array[Int] =
+    unWindowedParts.map(c => allParts.indexWhere(c.outputColumnName == _.outputColumnName))
+
+  protected class TwoStackIterator(queries: Iterator[Long],
+                         inputs: Iterator[Row],
+                         inputSize: Int = 1000,
+                         shouldFinalize: Boolean = true)
+      extends Iterator[Array[Any]] {
+
+    protected val inputsBuffered = inputs.buffered
+    protected val buffers = perWindowAggregators.map(_.bankersBuffer(inputSize))
+    protected var unWindowedAgg = if (unWindowedParts.isEmpty) null else new Array[Any](unWindowedParts.length)
+    override def hasNext: Boolean = queries.hasNext
+
+    def evictStaleEntry(idx: Int, queryTs: Long): Unit = {
+      val perWindowAggregator = perWindowAggregators(idx)
+      val buffer = buffers(idx)
+      val queryTail = perWindowAggregator.tailTs(queryTs)
+      while (buffer.peekBack() != null && buffer.peekBack().ts < queryTail) {
+        buffer.pop()
+      }
+    }
+
+    def update(idx: Int, row: Row, queryTs: Long): Unit = {
+      val perWindowAggregator = perWindowAggregators(idx)
+      val buffer = buffers(idx)
+      if (row.ts >= perWindowAggregator.tailTs(queryTs)) {
+        buffer.push(row, row.ts)
+      }
+    }
+
+    def aggregate(idx: Int): Array[Any] = {
+      val perWindowAggregator = perWindowAggregators(idx)
+      val buffer = buffers(idx)
+      val bufferIr = buffer.query
+
+      if (bufferIr == null) {
+        perWindowAggregator.init
+      } else if (shouldFinalize) {
+        perWindowAggregator.agg.finalize(bufferIr)
+      } else {
+        bufferIr
+      }
+    }
+
+    override def next(): Array[Any] = {
+      val queryTs = queries.next()
+
+      var i = 0
+
+      // remove all unwanted entries before adding new entries - to keep memory low
+      while (i < perWindowAggregators.length) {
+        evictStaleEntry(i, queryTs)
+        i += 1
+      }
+
+      // add all new inputs
+      while (inputsBuffered.hasNext && inputsBuffered.head.ts < queryTs) {
+        val row = inputsBuffered.next()
+
+        // add to windowed
+        i = 0
+        while (i < perWindowAggregators.length) { // for each unique window length
+          update(i, row, queryTs)
+          i += 1
+        }
+
+        // add to unWindowed
+        unWindowedAggregator.foreach { agg =>
+          unWindowedAgg = agg.update(unWindowedAgg, row)
+        }
+      }
+
+      // buffer contains only relevant events now - query the buffer and update the result
+      val result = new Array[Any](allParts.length)
+      i = 0
+      while (i < perWindowAggregators.length) {
+        val perWindowOutput = aggregate(i)
+
+        // arrange the perWindowOutput into the indices expected by final output
+        if (perWindowOutput != null) {
+          val perWindowAggregator = perWindowAggregators(i)
+          val indexMapping = perWindowAggregator.indexMapping
+          var j = 0
+          while (j < indexMapping.length) {
+            result.update(indexMapping(j), perWindowOutput(j))
+            j += 1
+          }
+        }
+        i += 1
+      }
+
+      // incorporate unWindowedAggregations
+      unWindowedAggregator.foreach { agg =>
+        val cAgg = if (shouldFinalize) {
+          agg.finalize(unWindowedAgg)
+        } else {
+          unWindowedAgg
+        }
+
+        i = 0
+        while (i < unWindowedIndexMapping.length) {
+          result.update(unWindowedIndexMapping(i), cAgg(i))
+          i += 1
+        }
+      }
+
+      result
+    }
+  }
 
   // inputs and queries are both assumed to be sorted by time in ascending order
   // all timestamps should be in milliseconds
   // iterator api to reduce memory pressure
-  def slidingSawtoothWindow(queries: Iterator[Long], inputs: Iterator[Row], inputSize: Int = 1000, shouldFinalize: Boolean = true): Iterator[Array[Any]] = {
-    val inputsBuffered = inputs.buffered
-    val buffers = perWindowAggregators.map(_.bankersBuffer(inputSize))
-    var unWindowedAgg = if(unWindowedParts.isEmpty) null else new Array[Any](unWindowedParts.length)
-
-    new Iterator[Array[Any]] {
-      override def hasNext: Boolean = queries.hasNext
-
-      override def next(): Array[Any] = {
-        val queryTs = queries.next()
-
-        // remove all unwanted entries before adding new entries - to keep memory low
-        var i = 0
-        while(i < perWindowAggregators.length) {
-          val perWindowAggregator = perWindowAggregators(i)
-          val buffer = buffers(i)
-          val queryTail = perWindowAggregator.tailTs(queryTs)
-          while(buffer.peekBack() != null && buffer.peekBack().ts < queryTail) {
-            buffer.pop()
-          }
-          i += 1
-        }
-
-        // add all new inputs
-        while(inputsBuffered.hasNext && inputsBuffered.head.ts < queryTs) {
-          val row = inputsBuffered.next()
-          
-          // add to windowed
-          i = 0
-          while(i < perWindowAggregators.length) { // for each unique window length
-            val perWindowAggregator = perWindowAggregators(i)
-            val buffer = buffers(i)
-            if(row.ts >= perWindowAggregator.tailTs(queryTs)) {
-              buffer.push(row, row.ts)
-            }
-            i += 1
-          }
-          
-          // add to unWindowed
-          unWindowedAggregator.foreach{ agg =>
-            unWindowedAgg = agg.update(unWindowedAgg, row)
-          }
-        }
-
-        // buffer contains only relevant events now - query the buffer and update the result
-        val result = new Array[Any](allParts.length)
-        i = 0
-        while(i < perWindowAggregators.length) {
-          val perWindowAggregator = perWindowAggregators(i)
-          val buffer = buffers(i)
-          val indexMapping = perWindowAggregator.indexMapping
-          val bufferIr = buffer.query
-
-          val perWindowOutput = if(bufferIr == null) {
-            perWindowAggregator.init
-          } else if(shouldFinalize) {
-            perWindowAggregator.agg.finalize(bufferIr)
-          } else {
-            bufferIr
-          }
-
-          // arrange the perWindowOutput into the indices expected by final output
-          if(perWindowOutput != null) {
-            var j = 0
-            while(j < indexMapping.length) {
-              result.update(indexMapping(j), perWindowOutput(j))
-              j += 1
-            }
-          }
-          i += 1
-        }
-
-        // incorporate unWindowedAggregations
-        unWindowedAggregator.foreach{ agg =>
-          val cAgg = if(shouldFinalize) {
-            agg.finalize(unWindowedAgg)
-          } else {
-            unWindowedAgg
-          }
-
-          i = 0
-          while(i < unWindowedIndexMapping.length) {
-            result.update(unWindowedIndexMapping(i), cAgg(i))
-            i += 1
-          }
-        }
-        
-        result
-      }
-    }
+  def slidingSawtoothWindow(queries: Iterator[Long],
+                            inputs: Iterator[Row],
+                            inputSize: Int = 1000,
+                            shouldFinalize: Boolean = true): Iterator[Array[Any]] = {
+    new TwoStackIterator(queries, inputs.buffered, inputSize, shouldFinalize)
   }
 }
 

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteHopAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteHopAggregator.scala
@@ -1,0 +1,77 @@
+package ai.chronon.aggregator.windowing
+
+import scala.collection.Seq
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.api.Extensions.{AggregationOps, AggregationPartOps, WindowOps}
+import ai.chronon.api._
+
+// This implements the two-stack-lite algorithm
+// To understand the intuition behind the algorithm I highly recommend reading the intuition text in the end of this file
+class TwoStackLiteHopAggregator(inputSchema: StructType,
+                                aggregations: Seq[Aggregation],
+                                resolution: Resolution = FiveMinuteResolution)
+    extends TwoStackLiteAggregator(inputSchema, aggregations, resolution) {
+  private class TwoStackHopIterator(
+      queries: Iterator[Long],
+      inputs: Iterator[Row],
+      inputSize: Int = 1000,
+      shouldFinalize: Boolean = true
+  ) extends TwoStackIterator(queries, inputs, inputSize, shouldFinalize) {
+
+    private val currentHops = new Array[BankersEntry[Array[Any]]](perWindowAggregators.length)
+    override def evictStaleEntry(idx: Int, queryTs: Long): Unit = {
+      super.evictStaleEntry(idx, queryTs)
+
+      val perWindowAggregator = perWindowAggregators(idx)
+      val queryTail = perWindowAggregator.tailTs(queryTs)
+      if (currentHops(idx) != null && queryTail > currentHops(idx).ts) {
+        currentHops(idx) = null
+      }
+    }
+
+    override def update(idx: Int, row: Row, queryTs: Long): Unit = {
+      val perWindowAggregator = perWindowAggregators(idx)
+      val buffer = buffers(idx)
+      if (row.ts >= perWindowAggregator.tailTs(queryTs)) {
+        val hopStart = perWindowAggregator.hopStart(row.ts)
+        if (currentHops(idx) == null) {
+          currentHops(idx) = BankersEntry(perWindowAggregator.agg.prepare(row), hopStart)
+        } else if (hopStart == currentHops(idx).ts) {
+          perWindowAggregator.agg.update(currentHops(idx).value, row)
+        } else {
+          buffer.extend(currentHops(idx).value, currentHops(idx).ts)
+          currentHops(idx) = BankersEntry(perWindowAggregator.agg.prepare(row), hopStart)
+        }
+      }
+    }
+
+    override def aggregate(idx: Int): Array[Any] = {
+      val perWindowAggregator = perWindowAggregators(idx)
+      val buffer = buffers(idx)
+      val bufferIr = buffer.query
+      val finalIr =
+        if (currentHops(idx) == null)
+          bufferIr
+        else
+          perWindowAggregator.agg.merge(bufferIr, currentHops(idx).value)
+
+      if (finalIr == null) {
+        perWindowAggregator.init
+      } else if (shouldFinalize) {
+        perWindowAggregator.agg.finalize(finalIr)
+      } else {
+        finalIr
+      }
+    }
+  }
+  // inputs and queries are both assumed to be sorted by time in ascending order
+  // all timestamps should be in milliseconds
+  // iterator api to reduce memory pressure
+  override def slidingSawtoothWindow(queries: Iterator[Long],
+                                     inputs: Iterator[Row],
+                                     inputSize: Int = 1000,
+                                     shouldFinalize: Boolean = true): Iterator[Array[Any]] = {
+    new TwoStackHopIterator(queries, inputs.buffered, inputSize, shouldFinalize)
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothAggregatorTest.scala
@@ -167,14 +167,15 @@ object SawtoothAggregatorTest {
       queries: Array[Long],
       specs: Seq[Aggregation],
       schema: Seq[(String, DataType)],
-      resolution: Resolution = FiveMinuteResolution
+      resolution: Resolution = FiveMinuteResolution,
+      useTwoStack: Boolean = false
   ): Array[Array[Any]] = {
 
     // STEP-1. build hops
     val hopsAggregator =
       new HopsAggregator(queries.min, specs, schema, resolution)
     val sawtoothAggregator =
-      new SawtoothAggregator(specs, schema, resolution)
+      new SawtoothAggregator(specs, schema, resolution, useTwoStack)
     var hopMaps = hopsAggregator.init()
     for (i <- events.indices)
       hopMaps = hopsAggregator.update(hopMaps, events(i))

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/TwoStackLiteAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/TwoStackLiteAggregatorTest.scala
@@ -1,104 +1,294 @@
 package ai.chronon.aggregator.test
 
-import ai.chronon.aggregator.base.{Sum, TopK}
+import java.util
+
+import ai.chronon.aggregator.base.TopK
 import ai.chronon.aggregator.test.SawtoothAggregatorTest.sawtoothAggregate
-import ai.chronon.aggregator.windowing.{TwoStackLiteAggregator, TwoStackLiteAggregationBuffer, FiveMinuteResolution, SawtoothAggregator}
+import ai.chronon.aggregator.windowing.{FiveMinuteResolution, SawtoothAggregator, TwoStackLiteAggregationBuffer, TwoStackLiteAggregator, TwoStackLiteHopAggregator}
 import ai.chronon.api.{Aggregation, Builders, IntType, LongType, Operation, StructField, StructType, TimeUnit, Window}
 import junit.framework.TestCase
 import org.junit.Assert._
-import ai.chronon.api.Extensions.AggregationOps
 import com.google.gson.Gson
-
 import scala.collection.Seq
 
-class TwoStackLiteAggregatorTest extends TestCase{
+import ai.chronon.aggregator.test.TwoStackLiteAggregatorTest.{benchmarkTesting, multiRunTest, testBuffer}
+import ai.chronon.api.Extensions.AggregationOps
+
+class TwoStackLiteAggregatorTest extends TestCase {
   def testBufferWithTopK(): Unit = {
-    val topK = new TopK[Integer](IntType, 2)
-    val bankersBuffer = new TwoStackLiteAggregationBuffer(topK, 5)
-    assertEquals(null, bankersBuffer.query) // null
-    Seq(7, 8, 9).map(x => new Integer(x)).foreach(i => bankersBuffer.push(i))
-    def assertBufferEquals(a: Seq[Int], b: java.util.ArrayList[Integer]): Unit = {
-      if(a==null || b == null) {
-        assertEquals(a, b)
-      } else {
-        assertArrayEquals(
-          Option(a).map(_.map(x => new Integer(x).asInstanceOf[AnyRef]).toArray).orNull,
-          Option(b).map(_.toArray).orNull)
-      }
-    }
-    assertBufferEquals(Seq(8, 9), bankersBuffer.query)
-    bankersBuffer.pop()
-    assertBufferEquals(Seq(8, 9),bankersBuffer.query)
-    bankersBuffer.pop()
-    assertBufferEquals(Seq(9), bankersBuffer.query)
-    bankersBuffer.pop()
-    assertBufferEquals(null, bankersBuffer.query)
-    bankersBuffer.push(new Integer(10))
-    assertBufferEquals(Seq(10), bankersBuffer.query)
+    val topK = new TopK[Int](IntType, 2)
+
+    val twoStackBuffer = new TwoStackLiteAggregationBuffer(topK, 5)
+    testBuffer(twoStackBuffer)
   }
 
-  def testAgainstSawtooth(): Unit = {
-    val timer = new Timer
-    val queries = CStream.genTimestamps(new Window(30, TimeUnit.DAYS), 100000, 5 * 60 * 1000)
-
-    val columns = Seq(Column("ts", LongType, 180), Column("num", LongType, 1000))
-    val events = CStream.gen(columns, 10000).rows
-    val schema = columns.map(_.schema)
-
+  def testAgainstSawtoothWithAvg(): Unit = {
     val aggregations: Seq[Aggregation] = Seq(
       Builders.Aggregation(
         Operation.AVERAGE,
         "num",
         Seq(new Window(1, TimeUnit.DAYS), new Window(1, TimeUnit.HOURS), new Window(30, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.AVERAGE, "num")
+    )
+
+    val queryCount = 100000
+    val eventCount = 1000000
+    benchmarkTesting(aggregations, queryCount, eventCount, runNaive = false)
+    println("\n >>>>>> warm up done. <<<<<< \n\n")
+    benchmarkTesting(aggregations, queryCount, eventCount, runNaive = false)
+    println("\n >>>>>> final run. <<<<<< \n\n")
+    benchmarkTesting(aggregations, queryCount, eventCount, runNaive = false)
+  }
+
+  def testAgainstSawtoothWithAvgWithIdependentData(): Unit = {
+    val aggregations: Seq[Aggregation] = Seq(
       Builders.Aggregation(
         Operation.AVERAGE,
-        "num"),
+        "num",
+        Seq(new Window(1, TimeUnit.DAYS), new Window(1, TimeUnit.HOURS), new Window(30, TimeUnit
+          .DAYS))),
+      Builders.Aggregation(Operation.AVERAGE, "num")
+    )
+
+    val queryCount = 10000
+    val eventCount = 100000
+    multiRunTest(aggregations, queryCount, eventCount)
+
+    println("\n >>>>>> warm up done. <<<<<< \n\n")
+
+    multiRunTest(aggregations, queryCount, eventCount)
+
+    println("\n >>>>>> final run. <<<<<< \n\n")
+
+    multiRunTest(aggregations, queryCount, eventCount)
+  }
+
+  def testAgainstSawtoothWithTopK(): Unit = {
+    val aggregations: Seq[Aggregation] = Seq(
       Builders.Aggregation(
         Operation.TOP_K,
         "num",
         Seq(new Window(1, TimeUnit.DAYS), new Window(1, TimeUnit.HOURS), new Window(30, TimeUnit.DAYS)),
         argMap = Map("k" -> "300")),
+      Builders.Aggregation(Operation.TOP_K, "num", argMap = Map("k" -> "300"))
+    )
+    val queryCount = 100000
+    val eventCount = 1000000
+    benchmarkTesting(aggregations, queryCount, eventCount, runNaive = false)
+    println("\n >>>>>> warm up done. <<<<<< \n\n")
+    benchmarkTesting(aggregations, queryCount, eventCount, runNaive = false)
+    println("\n >>>>>> final run. <<<<<< \n\n")
+    benchmarkTesting(aggregations, queryCount, eventCount, runNaive = false)
+  }
+
+  def testAgainstSawtoothWithTopKWithIdependentData(): Unit = {
+    val aggregations: Seq[Aggregation] = Seq(
       Builders.Aggregation(
         Operation.TOP_K,
         "num",
-        argMap = Map("k" -> "300"))
+        Seq(new Window(1, TimeUnit.DAYS), new Window(1, TimeUnit.HOURS), new Window(30, TimeUnit
+          .DAYS)),
+        argMap = Map("k" -> "300")),
+      Builders.Aggregation(Operation.TOP_K, "num", argMap = Map("k" -> "300"))
     )
+    multiRunTest(aggregations, 100000, 1000000)
+
+    println("\n >>>>>> warm up done. <<<<<< \n")
+
+    multiRunTest(aggregations, 10000, 100000)
+  }
+}
+
+object TwoStackLiteAggregatorTest {
+
+  def testBuffer(buffer: TwoStackLiteAggregationBuffer[Int, util.ArrayList[Int], util.ArrayList[Int]]): Unit = {
+    assertEquals(null, buffer.query) // null
+    Seq(7, 8, 9).map(x => new Integer(x)).foreach(i => buffer.push(i, i * 1000))
+
+    def assertBufferEquals(a: Seq[Int], b: util.ArrayList[Int]): Unit = {
+      if (a == null || b == null) {
+        assertEquals(a, b)
+      } else {
+        assertArrayEquals(Option(a).map(_.map(x => new Integer(x).asInstanceOf[AnyRef]).toArray).orNull,
+          Option(b).map(_.toArray).orNull)
+      }
+    }
+
+    assertBufferEquals(Seq(8, 9), buffer.query)
+    buffer.pop()
+    assertBufferEquals(Seq(8, 9), buffer.query)
+    buffer.pop()
+    assertBufferEquals(Seq(9), buffer.query)
+    buffer.pop()
+    assertBufferEquals(null, buffer.query)
+    buffer.push(new Integer(10), 10 * 1000)
+    assertBufferEquals(Seq(10), buffer.query)
+  }
+
+  def benchmarkTesting(aggregations: Seq[Aggregation], queryCount: Int, eventCount: Int, runNaive: Boolean): Unit = {
+    val timer = new Timer
+    val queries = CStream.genTimestamps(new Window(30, TimeUnit.DAYS), queryCount, 5 * 60 * 1000)
+
+    val columns = Seq(Column("ts", LongType, 180), Column("num", LongType, 1000))
+    val events = CStream.gen(columns, eventCount).rows
+    val schema = columns.map(_.schema)
 
     timer.publish("setup")
+
+    val sortedQueries = queries.sorted
+    val sortedEvents = events.sortBy(_.ts)
+
+    timer.publish("sorting")
 
     val sawtoothAggregator =
       new SawtoothAggregator(aggregations, schema, FiveMinuteResolution)
 
-//    val windows = aggregations.flatMap(_.unpack.map(_.window)).toArray
-//    val tailHops = windows.map(FiveMinuteResolution.calculateTailHop)
-//    val naiveAggregator = new NaiveAggregator(
-//      sawtoothAggregator.windowedAggregator,
-//      windows,
-//      tailHops
-//    )
-//    val naiveIrs = naiveAggregator.aggregate(events, queries).map(sawtoothAggregator.windowedAggregator.finalize)
-//    timer.publish("naive")
-    val bankersAggregator = new TwoStackLiteAggregator(
+    def runSawtooth(): Array[Array[Any]] = {
+      sawtoothAggregate(events, queries, aggregations, schema)
+        .map(sawtoothAggregator.windowedAggregator.finalize)
+    }
+
+    def runSawtoothTwoStack(): Array[Array[Any]] = {
+      val sawtoothAggregatorTwoStack =
+        new SawtoothAggregator(aggregations, schema, FiveMinuteResolution, useTwoStack = true)
+      sawtoothAggregate(events, queries, aggregations, schema, useTwoStack = true)
+        .map(sawtoothAggregatorTwoStack.windowedAggregator.finalize)
+    }
+
+    val sawtoothIrs = runSawtooth()
+    timer.publish("sawtooth")
+
+    val sawtoothTwoStackIrs = runSawtoothTwoStack()
+    timer.publish("sawtooth two stack")
+
+    if (runNaive) {
+      val windows = aggregations.flatMap(_.unpack.map(_.window)).toArray
+      val tailHops = windows.map(FiveMinuteResolution.calculateTailHop)
+      val naiveAggregator = new NaiveAggregator(
+        sawtoothAggregator.windowedAggregator,
+        windows,
+        tailHops
+      )
+      naiveAggregator.aggregate(events, queries).map(sawtoothAggregator.windowedAggregator.finalize)
+      timer.publish("naive")
+    }
+
+    val twoStackLiteHopAggregator = new TwoStackLiteHopAggregator(
       StructType("", columns.map(c => StructField(c.name, c.`type`)).toArray),
       aggregations)
 
-    // will finalize by default
-    val bankersIrs = bankersAggregator.slidingSawtoothWindow(queries.sorted.iterator, events.sortBy(_.ts).iterator, events.length).toArray
-    timer.publish("sorting + banker")
+    def runTwoStackHop(): Array[Array[Any]] = {
+      // will finalize by default
+      twoStackLiteHopAggregator.slidingSawtoothWindow(sortedQueries.iterator, sortedEvents.iterator).toArray
+    }
 
-    val sawtoothIrs = sawtoothAggregate(events, queries, aggregations, schema)
-      .map(sawtoothAggregator.windowedAggregator.finalize)
-    timer.publish("sawtooth")
+    val twoStackHopIrs = runTwoStackHop() // for easier profiling
+    timer.publish("two stack hop lite")
 
-    // rough timings below will vary by processor - but at 100k
-    // naive                     256011 ms
-    // sorting + banker          1597 ms
-    // sawtooth                  914 ms
+    val twoStackAggregator = new TwoStackLiteAggregator(
+      StructType("", columns.map(c => StructField(c.name, c.`type`)).toArray),
+      aggregations)
+
+    def runTwoStack(): Array[Array[Any]] = {
+      // will finalize by default
+      twoStackAggregator.slidingSawtoothWindow(sortedQueries.iterator, sortedEvents.iterator).toArray
+    }
+
+    val twoStackIrs = runTwoStack() // for easier profiling
+    timer.publish("two stack lite")
 
     val gson = new Gson()
-    bankersIrs.zip(sawtoothIrs).foreach{case (bankers, sawtooth) =>
-      assertEquals(gson.toJson(sawtooth), gson.toJson(bankers))
+
+    sawtoothTwoStackIrs.zip(sawtoothIrs).foreach {
+      case (daba, sawtooth) =>
+        assertEquals(gson.toJson(sawtooth), gson.toJson(daba))
+    }
+
+    twoStackHopIrs.zip(sawtoothIrs).foreach {
+      case (daba, sawtooth) =>
+        assertEquals(gson.toJson(sawtooth), gson.toJson(daba))
+    }
+
+    twoStackIrs.zip(sawtoothIrs).foreach {
+      case (twoStack, sawtooth) =>
+        assertEquals(gson.toJson(sawtooth), gson.toJson(twoStack))
     }
   }
 
+  def multiRunTest(aggregations: Seq[Aggregation], queryCount: Int, eventCount: Int): Unit = {
+    genAndRun(queryCount, eventCount, (queries, events, cols, timer) => {
+      val schema = cols.map(_.schema)
+      val sawtoothAggregator =
+        new SawtoothAggregator(aggregations, schema, FiveMinuteResolution)
+
+      sawtoothAggregate(events, queries, aggregations, schema)
+        .map(sawtoothAggregator.windowedAggregator.finalize)
+
+      timer.publish(">>>> sawtooth")
+    })
+
+    println()
+
+    genAndRun(queryCount, eventCount, (queries, events, cols, timer) => {
+      val schema = cols.map(_.schema)
+
+      val sawtoothAggregatorTwoStack =
+        new SawtoothAggregator(aggregations, schema, FiveMinuteResolution, useTwoStack = true)
+      sawtoothAggregate(events, queries, aggregations, schema, useTwoStack = true)
+        .map(sawtoothAggregatorTwoStack.windowedAggregator.finalize)
+
+      timer.publish(">>>> sawtooth two stack")
+    })
+
+    println()
+
+    genAndRun(queryCount, eventCount, (queries, events, cols, timer) => {
+      val twoStackLiteHopAggregator = new TwoStackLiteHopAggregator(
+        StructType("", cols.map(c => StructField(c.name, c.`type`)).toArray),
+        aggregations)
+
+      val sortedQueries = queries.sorted
+      val sortedEvents = events.sortBy(_.ts)
+
+      timer.publish("sorting")
+
+      twoStackLiteHopAggregator
+        .slidingSawtoothWindow(sortedQueries.iterator, sortedEvents.iterator).toArray
+
+      timer.publish(">>>> two stack hop")
+    })
+
+    println()
+
+    genAndRun(queryCount, eventCount, (queries, events, cols, timer) => {
+      val twoStackAggregator = new TwoStackLiteAggregator(
+        StructType("", cols.map(c => StructField(c.name, c.`type`)).toArray),
+        aggregations)
+
+      val sortedQueries = queries.sorted
+      val sortedEvents = events.sortBy(_.ts)
+
+      timer.publish("sorting")
+
+      twoStackAggregator.slidingSawtoothWindow(sortedQueries.iterator, sortedEvents.iterator).toArray
+
+      timer.publish(">>>> two stack")
+    })
+  }
+
+  def genAndRun(
+      queryCount: Int,
+      eventCount: Int,
+      runner: (Array[Long], Array[TestRow], Seq[Column], Timer) => Unit): Unit = {
+    val timer = new Timer
+
+    val queries = CStream.genTimestamps(new Window(30, TimeUnit.DAYS), queryCount, 5 * 60 * 1000)
+
+    val columns = Seq(Column("ts", LongType, 180), Column("num", LongType, 1000))
+    val events = CStream.gen(columns, eventCount).rows
+
+    timer.publish("setup")
+
+    runner(queries, events, columns, timer)
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Implementing variants of the two stack algorithms:
- two stack with hopping
- using two stack to replace the hopRangeCache in sawtooth
Test result can be found here.

This PR is meant to be a POC, not intended to be merged.

A new interesting factor was observed: likely due to JVM's JIT, all algorithms ran faster in the second and third runs.

Result:  https://docs.google.com/spreadsheets/d/1Mdh_0sv4H-6Ep6URjnFFI3sJ2oeXK88J4wBY32TwOUw/edit#gid=562347570

Perf tldr: with simple aggregation like average, two stacks + hop perform quite well. Replacing hop range cache with two stacks did not significantly improve perf.

With expensive aggregation like top k, two stack + hops still performs relatively well in smaller query set, but suffers from large query set.

<img width="1437" alt="image" src="https://github.com/airbnb/chronon/assets/2842841/db74e8aa-001f-4ce1-b1e3-a794c3014bd2">


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha 