### PR TITLE
[ZL][PyApi] Validation for repeated output tables

### DIFF
--- a/api/py/ai/chronon/join.py
+++ b/api/py/ai/chronon/join.py
@@ -3,7 +3,6 @@ import ai.chronon.api.ttypes as api
 import ai.chronon.repo.extract_objects as eo
 import ai.chronon.utils as utils
 import copy
-import re
 import gc
 import importlib
 import json
@@ -368,7 +367,7 @@ def validate_join(join: api.Join) -> List[str]:
     - No joinParts with the same output table.
     """
     errors = []
-    name = join.metaData.name
+
     def joinpart_output_table(joinPart: api.JoinPart):
         components = []
         if join.metaData.name:

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -175,8 +175,8 @@ def _write_obj(full_output_root: str,
         return False
     validation_errors = validator.validate_obj(obj)
     if validation_errors:
-        _print_error(f"Could not write {class_name} {name}",
-                     ', '.join(validation_errors))
+        _print_error(f"Could not write {class_name} {name}\n\t",
+                     '\n\t - '.join(validation_errors))
         return False
     if force_overwrite:
         _print_warning(f"Force overwrite {class_name} {name}")

--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -5,6 +5,7 @@ import logging
 import os
 from ai.chronon.api.ttypes import \
     GroupBy, Join, Source
+from ai.chronon.join import validate_join
 from ai.chronon.logger import get_logger
 from ai.chronon.repo import JOIN_FOLDER_NAME, \
     GROUP_BY_FOLDER_NAME
@@ -155,7 +156,7 @@ class ChrononRepoValidator(object):
         included_group_bys = [rp.groupBy for rp in join.joinParts]
         offline_included_group_bys = [gb.metaData.name for gb in included_group_bys
                                       if not gb.metaData or gb.metaData.online is False]
-        errors = []
+        errors = validate_join(join)
         old_group_bys = [group_by for group_by in included_group_bys
                          if self._get_old_obj(GroupBy, group_by.metaData.name)]
         non_prod_old_group_bys = [group_by.metaData.name for group_by in old_group_bys

--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -248,3 +248,7 @@ def dedupe_in_order(seq):
     seen = set()
     seen_add = seen.add
     return [x for x in seq if not (x in seen or seen_add(x))]
+
+
+def sanitize_name(name):
+    return re.sub("[^a-zA-Z0-9_]", "_", name)

--- a/api/py/test/sample/joins/sample_failures/sample_join.py
+++ b/api/py/test/sample/joins/sample_failures/sample_join.py
@@ -1,0 +1,27 @@
+"""
+Sample Join
+"""
+from sources import test_sources
+from group_bys.sample_team import sample_group_by
+from ai.chronon.join import (
+    Join,
+    JoinPart,
+)
+
+
+v1 = Join(
+    left=test_sources.staging_entities,
+    right_parts=[
+        JoinPart(group_by=sample_group_by.v1, tags={"experimental": True}),
+        JoinPart(group_by=sample_group_by.v1)],
+    table_properties={
+        "config_json": """{"sample_key": "sample_value"}"""
+    },
+    output_namespace="sample_namespace",
+    tags={"business_relevance": "personalization"},
+    env={
+        "backfill": {
+            "EXECUTOR_MEMORY": "9G"
+        },
+    },
+)

--- a/api/py/test/sample/teams.json
+++ b/api/py/test/sample/teams.json
@@ -45,5 +45,9 @@
     "kaggle": {
         "description": "Workspace for kaggle compeitions",
         "namespace": "default"
+    },
+    "sample_failures": {
+        "description": "Failure compilation examples",
+        "namespace": "default"
     }
 }

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -55,3 +55,15 @@ def test_failed_compile_missing_input_column():
         '--debug'
     ])
     assert result.exit_code != 0
+
+
+def test_duplicate_join_parts():
+    """
+    Should raise as it writes to the same join part table.
+    """
+    runner = CliRunner()
+    result = runner.invoke(extract_and_convert, [
+        '--chronon_root=test/sample',
+        '--input_path=joins/sample_failures/sample_join.py'
+    ])
+    assert "Could not write " in result.output and "Repeated joinPart" in result.output

--- a/api/py/test/test_utils.py
+++ b/api/py/test/test_utils.py
@@ -42,3 +42,8 @@ def test_group_by_utils(event_group_by):
 def test_dedupe_in_order():
     assert utils.dedupe_in_order([1, 1, 3, 1, 3, 2]) == [1, 3, 2]
     assert utils.dedupe_in_order([2, 1, 3, 1, 3, 2]) == [2, 1, 3]
+
+
+def test_sanitize_name():
+    assert utils.sanitize_name("testing") == "testing"
+    assert utils.sanitize_name("testing.v1") == "testing_v1"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
There are cases where the same group by will be added to a join but with different key mappings.
If mishandled this would lead to the same output tables in separate joinParts.
There's also the case of a user not noticing they are adding the same joinPart twice.

This check should catch that.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Prevent users from compiling bad confs.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @nikhilsimha 
