### PR TITLE
[Join] Remove parallel for coveering sets

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -164,7 +164,7 @@ class Join(joinConf: api.Join, endPartition: String, tableUtils: TableUtils, ski
     // we do this by utilizing the per-record metadata computed during the bootstrap process.
     // then for each GB, we compute a join_part table that contains aggregated feature values for the required key space
     // the required key space is a slight superset of key space of the left, due to the nature of using bloom-filter.
-    val rightResults = bootstrapCoveringSets.parallel
+    val rightResults = bootstrapCoveringSets
       .flatMap {
         case (partMetadata, coveringSets) =>
           val unfilledLeftDf = findUnfilledRecords(bootstrapDf, coveringSets.filter(_.isCovering))


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
An issue in spark 3.1.1 when there's too many join parts.
Apparently the threading runs into trouble processing what needs to be processed and the jobs hangs without any physical progress (no data is written) even though stages keep getting completed.

What ends up happening are some exceptions in event logging, however setting event log listener to false did not help. Related SO: https://stackoverflow.com/questions/40286001/spark-listener-eventlogginglistener-threw-an-exception-concurrentmodificatione 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Increase reliability for spark 3.1.1

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested - Tested with a job that hangs in 3.1.1 but not on spark 2.4.0

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @hzding621 
