### PR TITLE
improve compile.py error message 

### DIFF
--- a/api/py/ai/chronon/repo/serializer.py
+++ b/api/py/ai/chronon/repo/serializer.py
@@ -65,8 +65,8 @@ def file2thrift(path, thrift_class):
         with open(path, 'r') as file:
             return json2thrift(file.read(), thrift_class)
     except json.decoder.JSONDecodeError as e:
-        raise Exception(f"Production file already exists but does not have proper JSON format: {path}. Try delete it "
-                        f"and rerun compile.py") from e
+        raise Exception(f"Error decoding file into a {thrift_class.__name__}:  {path}. " +
+                        f"Please double check that {path} represents a valid {thrift_class.__name__}.") from e
 
 
 def thrift_json(obj):


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->


Sometimes a production file may already exists but with a bad format (due to user error, or previous failed generation). That will cause following compile to fail without a clear user error message. the change will print out the file path to help debugging. 


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Integration tested


## Reviewers


