### PR TITLE
Since 68.x of setuptools local is an invalid version name for pip

### DIFF
--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(current_dir, "requirements/base.in"), "r") as infile:
     basic_requirements = [line for line in infile]
 
 
-__version__ = "local"
+__version__ = "0.dev0"
 __branch__ = "master"
 def get_version():
     version_str = os.environ.get("CHRONON_VERSION_STR", __version__)


### PR DESCRIPTION
## Summary
see: https://peps.python.org/pep-0440/


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Integration tested
refreshed the site with local build api

## Checklist
- [x] Documentation update

## Reviewers
@hzding621 @cristianfr 
