### PR TITLE
remove version pin for scala211 and 212

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -164,8 +164,8 @@ val VersionMatrix: Map[String, VersionDependency] = Map(
     Seq(
       "io.netty" % "netty-buffer"
     ),
-    Some("4.1.17.Final"),
-    Some("4.1.51.Final"),
+    None,
+    None,
     Some("4.1.68.Final")
   )
 )


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

`netty-buffer` as dependency is introduced by spark321 so we should only include it in scala213 build


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->

- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested


## Reviewers

@cenhao 