### PR TITLE
[aggregation] Two Stack + Hops + Union Sort + Hybrid

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/PerWindowAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/PerWindowAggregator.scala
@@ -1,0 +1,20 @@
+package ai.chronon.aggregator.windowing
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.api.Extensions.WindowOps
+import ai.chronon.api.{Row, Window}
+
+// create row aggregator per window - we will loop over data as many times as there are unique windows
+// we will use different row aggregators to do so
+case class PerWindowAggregator(window: Window, resolution: Resolution, agg: RowAggregator, indexMapping: Array[Int]) {
+  private val windowLength: Long = window.millis
+  private val tailHopSize = resolution.calculateTailHop(window)
+
+  def tailTs(queryTs: Long): Long = TsUtils.round(queryTs - windowLength, tailHopSize)
+
+  def hopStart(queryTs: Long): Long = TsUtils.round(queryTs, tailHopSize)
+
+  def bankersBuffer(inputSize: Int) = new TwoStackLiteAggregationBuffer[Row, Array[Any], Array[Any]](agg, inputSize)
+
+  def init = new Array[Any](agg.length)
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregationBuffer.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteAggregationBuffer.scala
@@ -27,6 +27,12 @@ class TwoStackLiteAggregationBuffer[Input, IR >: Null, Output >: Null](aggregato
     aggBack = if (aggBack == null) ir else aggregator.update(aggBack, input)
   }
 
+  def extend(ir: IR, ts: Long): Unit = {
+    val clone = aggregator.clone(ir)
+    deque.addLast(BankersEntry(clone, ts))
+    aggBack = if (aggBack == null) clone else aggregator.merge(aggBack, clone)
+  }
+
   def pop(): BankersEntry[IR] = {
     if (!deque.isEmpty) {
       if (frontLen == 0) {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteHopAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TwoStackLiteHopAggregator.scala
@@ -1,0 +1,115 @@
+package ai.chronon.aggregator.windowing
+
+import scala.collection.Seq
+
+import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.api.Extensions.AggregationOps
+import ai.chronon.api._
+
+class TwoStackLiteHopAggregator(inputSchema: StructType,
+                                aggregations: Seq[Aggregation],
+                                resolution: Resolution = FiveMinuteResolution,
+                                shouldFinalize: Boolean = true,
+                                inputSize: Int = 1000) {
+
+  // contains unbounded for unwindowed aggregation
+  protected val allParts: Seq[AggregationPart] = aggregations.flatMap(_.unpack)
+  private val inputSchemaTuples: Array[(String, DataType)] = inputSchema.fields.map(f => f.name -> f.fieldType)
+  private val perWindowAggregators: Array[PerWindowAggregator] = allParts.iterator.zipWithIndex.toArray
+    .filter { case (p, _) => p.window != null }
+    .groupBy { case (p, _) => p.window }
+    .map {
+      case (w, ps) =>
+        val parts = ps.map(_._1)
+        val idxs = ps.map(_._2)
+        PerWindowAggregator(w, resolution, new RowAggregator(inputSchemaTuples, parts), idxs)
+    }
+    .toArray
+
+  private val buffers = perWindowAggregators.map(_.bankersBuffer(inputSize))
+  private val currentHops = new Array[BankersEntry[Array[Any]]](perWindowAggregators.length)
+
+  def update(row: Row): Unit = {
+    var i = 0
+
+    // remove all unwanted entries before adding new entries - to keep memory low
+    while (i < perWindowAggregators.length) {
+      evictStaleEntry(i, row.ts)
+      val perWindowAggregator = perWindowAggregators(i)
+      val buffer = buffers(i)
+      val hopStart = perWindowAggregator.hopStart(row.ts)
+
+      if (currentHops(i) == null) {
+        // Nothing buffered in the hop yet
+        currentHops(i) = BankersEntry(perWindowAggregator.agg.prepare(row), hopStart)
+      } else if (hopStart == currentHops(i).ts) {
+        // The new row shares the same hop as the current buffered hop
+        perWindowAggregator.agg.update(currentHops(i).value, row)
+      } else {
+        // The new row is not in the current buffered hop, push the current buffer into the two-stack and start a new
+        // buffer
+        buffer.extend(currentHops(i).value, currentHops(i).ts)
+        currentHops(i) = BankersEntry(perWindowAggregator.agg.prepare(row), hopStart)
+      }
+      i += 1
+    }
+  }
+
+  def query(queryTs: Long): Array[Any] = {
+    // buffer contains only relevant events now - query the buffer and update the result
+    val result = new Array[Any](allParts.length)
+    var i = 0
+    while (i < perWindowAggregators.length) {
+      // remove all unwanted entries before adding new entries - to keep memory low
+      evictStaleEntry(i, queryTs)
+
+      val perWindowOutput = aggregate(i)
+
+      // arrange the perWindowOutput into the indices expected by final output
+      if (perWindowOutput != null) {
+        val perWindowAggregator = perWindowAggregators(i)
+        val indexMapping = perWindowAggregator.indexMapping
+        var j = 0
+        while (j < indexMapping.length) {
+          result.update(indexMapping(j), perWindowOutput(j))
+          j += 1
+        }
+      }
+      i += 1
+    }
+
+    result
+  }
+
+  private def evictStaleEntry(idx: Int, queryTs: Long): Unit = {
+    val perWindowAggregator = perWindowAggregators(idx)
+    val buffer = buffers(idx)
+    val queryTail = perWindowAggregator.tailTs(queryTs)
+    while (buffer.peekBack() != null && buffer.peekBack().ts < queryTail) {
+      buffer.pop()
+    }
+
+    if (currentHops(idx) != null && queryTail > currentHops(idx).ts) {
+      currentHops(idx) = null
+    }
+  }
+
+  private def aggregate(idx: Int): Array[Any] = {
+    val perWindowAggregator = perWindowAggregators(idx)
+    val buffer = buffers(idx)
+    val bufferIr = buffer.query
+    val finalIr =
+      if (currentHops(idx) == null)
+        bufferIr
+      else
+        perWindowAggregator.agg.merge(bufferIr, currentHops(idx).value)
+
+    if (finalIr == null) {
+      perWindowAggregator.init
+    } else if (shouldFinalize) {
+      perWindowAggregator.agg.finalize(finalIr)
+    } else {
+      finalIr
+    }
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/TwoStackLiteAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/TwoStackLiteAggregatorTest.scala
@@ -99,8 +99,9 @@ class TwoStackLiteAggregatorTest extends TestCase{
 
     val eventIter = sortedEvents.iterator.buffered
     val twoStackHopResultIrs = sortedQueries.map { queryTs =>
+      twoStackLiteHopAggregator.evictStaleEntry(queryTs)
       while (eventIter.hasNext && eventIter.head.ts < queryTs) {
-        twoStackLiteHopAggregator.update(eventIter.next())
+        twoStackLiteHopAggregator.update(eventIter.next(), queryTs)
       }
       twoStackLiteHopAggregator.query(queryTs)
     }

--- a/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
@@ -238,7 +238,13 @@ abstract class BaseJoin(joinConf: api.Join, endPartition: String, tableUtils: Ta
       case (Events, Events, Accuracy.SNAPSHOT) =>
         genGroupBy(shiftedPartitionRange).snapshotEvents(shiftedPartitionRange)
       case (Events, Events, Accuracy.TEMPORAL) =>
-        genGroupBy(unfilledTimeRange.toPartitionRange).temporalEvents(renamedLeftDf, Some(unfilledTimeRange))
+        if (tableUtils.useTwoStackForTemporalEvents) {
+          println("Using two stack for temporal events")
+          genGroupBy(unfilledTimeRange.toPartitionRange).twoStackHopTemporalEvents(renamedLeftDf)
+        } else {
+          println("Using sawtooth for temporal events")
+          genGroupBy(unfilledTimeRange.toPartitionRange).temporalEvents(renamedLeftDf, Some(unfilledTimeRange))
+        }
 
       case (Events, Entities, Accuracy.SNAPSHOT) => genGroupBy(shiftedPartitionRange).snapshotEntities
 

--- a/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
@@ -239,8 +239,8 @@ abstract class BaseJoin(joinConf: api.Join, endPartition: String, tableUtils: Ta
         genGroupBy(shiftedPartitionRange).snapshotEvents(shiftedPartitionRange)
       case (Events, Events, Accuracy.TEMPORAL) =>
         if (tableUtils.useTwoStackForTemporalEvents) {
-          println("Using two stack v2 for temporal events")
-          genGroupBy(unfilledTimeRange.toPartitionRange).twoStackHopTemporalEvents(renamedLeftDf)
+          println("Using two stack hybrid for temporal events")
+          genGroupBy(unfilledTimeRange.toPartitionRange).hybridTemporalEvents(renamedLeftDf, Some(unfilledTimeRange))
         } else {
           println("Using sawtooth for temporal events")
           genGroupBy(unfilledTimeRange.toPartitionRange).temporalEvents(renamedLeftDf, Some(unfilledTimeRange))

--- a/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
@@ -239,7 +239,7 @@ abstract class BaseJoin(joinConf: api.Join, endPartition: String, tableUtils: Ta
         genGroupBy(shiftedPartitionRange).snapshotEvents(shiftedPartitionRange)
       case (Events, Events, Accuracy.TEMPORAL) =>
         if (tableUtils.useTwoStackForTemporalEvents) {
-          println("Using two stack for temporal events")
+          println("Using two stack v2 for temporal events")
           genGroupBy(unfilledTimeRange.toPartitionRange).twoStackHopTemporalEvents(renamedLeftDf)
         } else {
           println("Using sawtooth for temporal events")

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -58,6 +58,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.execution.streaming.sources.ForeachWriterCommitMessage$",
       "org.apache.spark.sql.types.Metadata",
       "ai.chronon.api.Row",
+      "ai.chronon.spark.UnionSortKey",
       "ai.chronon.spark.KeyWithHash",
       "ai.chronon.aggregator.windowing.BatchIr",
       "ai.chronon.online.RowWrapper",

--- a/spark/src/main/scala/ai/chronon/spark/SparkConstants.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkConstants.scala
@@ -4,5 +4,6 @@ object SparkConstants {
 
   val ChrononOutputParallelismOverride: String = "spark.chronon.outputParallelismOverride"
   val ChrononRowCountPerPartition: String = "spark.chronon.rowCountPerPartition"
+  val ChrononUseTwoStackAlgorithm: String = "spark.chronon.useTwoStackAlgorithm"
 
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -114,7 +114,7 @@ class GroupByTest {
 
   @Test
   def twoStackTemporalEventsLastKTest(): Unit = {
-    runTemporalEventsLastKTest((gb, df) => gb.twoStackHopTemporalEvents(df))
+    runTemporalEventsLastKTest((gb, df) => gb.hybridTemporalEvents(df))
   }
 
   def runTemporalEventsLastKTest(buildTemporalEvents: (GroupBy, DataFrame) => DataFrame): Unit = {
@@ -210,7 +210,7 @@ class GroupByTest {
     val keys = Seq("user").toArray
     val groupBy = new GroupBy(aggregations, keys, eventDf)
     val resultDf = groupBy.temporalEvents(queryDf)
-    val twoStackResultDf = groupBy.twoStackHopTemporalEvents(queryDf)
+    val hybridResultDf = groupBy.hybridTemporalEvents(queryDf)
 
     val keyBuilder = FastHashing.generateKeyBuilder(keys, eventDf.schema)
     // naive aggregation for equivalence testing
@@ -252,12 +252,12 @@ class GroupByTest {
     }
     assertEquals(0, diff.count())
 
-    val twoStackDiff = Comparison.sideBySide(naiveDf, twoStackResultDf, List("user", Constants.TimeColumn))
-    if (twoStackDiff.count() > 0) {
-      twoStackDiff.show()
-      println("twoStackDiff result rows")
+    val hybridDiff = Comparison.sideBySide(naiveDf, hybridResultDf, List("user", Constants.TimeColumn))
+    if (hybridDiff.count() > 0) {
+      hybridDiff.show()
+      println("hybridDiff result rows")
     }
-    assertEquals(0, twoStackDiff.count())
+    assertEquals(0, hybridDiff.count())
   }
 
   // Test that the output of Group by with Step Days is the same as the output without Steps (full data range)

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -189,6 +189,79 @@ class GroupByTest {
       }
     }
   }
+
+  @Test
+  def temporalEventsTwoStackLastKTest(): Unit = {
+    val eventSchema = List(
+      Column("user", StringType, 10),
+      Column("listing_view", StringType, 100)
+    )
+    val eventDf = DataFrameGen.events(spark, eventSchema, count = 10000, partitions = 180)
+    eventDf.createOrReplaceTempView("events_last_k")
+
+    val querySchema = List(Column("user", StringType, 10))
+    val queryDf = DataFrameGen.events(spark, querySchema, count = 1000, partitions = 180)
+    queryDf.createOrReplaceTempView("queries_last_k")
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.LAST_K, "listing_view", Seq(WindowUtils.Unbounded), argMap = Map("k" -> "30")),
+      Builders.Aggregation(Operation.COUNT, "listing_view", Seq(WindowUtils.Unbounded))
+    )
+    val keys = Seq("user").toArray
+    val groupBy =
+      new GroupBy(aggregations,
+        keys,
+        eventDf.selectExpr("user", "ts", "concat(ts, \" \", listing_view) as listing_view"))
+    val resultDf = groupBy.twoStackHopTemporalEvents(queryDf)
+    val computed = resultDf.select("user", "ts", "listing_view_last30", "listing_view_count")
+    computed.show()
+
+    val expected = eventDf.sqlContext.sql(
+      s"""
+         |SELECT
+         |      events_last_k.user as user,
+         |      queries_last_k.ts as ts,
+         |      COLLECT_LIST(concat(CAST(events_last_k.ts AS STRING), " ", events_last_k.listing_view)) as listing_view_last30,
+         |      SUM(case when events_last_k.listing_view <=> NULL then 0 else 1 end) as listing_view_count
+         |FROM events_last_k CROSS JOIN queries_last_k
+         |ON events_last_k.user = queries_last_k.user
+         |WHERE events_last_k.ts < queries_last_k.ts
+         |GROUP BY events_last_k.user, queries_last_k.ts
+         |""".stripMargin)
+
+    expected.show()
+
+    val diff = Comparison.sideBySide(computed, expected, List("user", "ts"))
+    if (diff.count() > 0) {
+      println(s"Actual count: ${computed.count()}")
+      println(s"Expected count: ${expected.count()}")
+      println(s"Diff count: ${diff.count()}")
+      println(s"diff result rows last_k_test")
+      diff.show()
+      diff.rdd.foreach { row =>
+        val gson = new Gson()
+        val computed =
+          Option(row(4)).map(_.asInstanceOf[mutable.WrappedArray[String]].toArray).getOrElse(Array.empty[String])
+        val expected =
+          Option(row(5))
+            .map(_.asInstanceOf[mutable.WrappedArray[String]].toArray.sorted.reverse.take(30))
+            .getOrElse(Array.empty[String])
+        val computedCount = Option(row(2)).map(_.asInstanceOf[Long]).getOrElse(0)
+        val expectedCount = Option(row(3)).map(_.asInstanceOf[Long]).getOrElse(0)
+        val computedStr = gson.toJson(computed)
+        val expectedStr = gson.toJson(expected)
+        if (computedStr != expectedStr) {
+          println(
+            s"""
+               |computed [$computedCount]: ${gson.toJson(computed)}
+               |expected [$expectedCount]: ${gson.toJson(expected)}
+               |""".stripMargin)
+        }
+        assertEquals(gson.toJson(computed), gson.toJson(expected))
+      }
+    }
+  }
+
   @Test
   def testTemporalEvents(): Unit = {
     val eventSchema = List(
@@ -211,6 +284,7 @@ class GroupByTest {
     val keys = Seq("user").toArray
     val groupBy = new GroupBy(aggregations, keys, eventDf)
     val resultDf = groupBy.temporalEvents(queryDf)
+    val anotherResultDf = groupBy.twoStackHopTemporalEvents(queryDf)
 
     val keyBuilder = FastHashing.generateKeyBuilder(keys, eventDf.schema)
     // naive aggregation for equivalence testing
@@ -251,6 +325,13 @@ class GroupByTest {
       println("diff result rows")
     }
     assertEquals(0, diff.count())
+
+    val diff1 = Comparison.sideBySide(naiveDf, anotherResultDf, List("user", Constants.TimeColumn))
+    if (diff1.count() > 0) {
+      diff1.show()
+      println("diff1 result rows")
+    }
+    assertEquals(0, diff1.count())
   }
 
   // Test that the output of Group by with Step Days is the same as the output without Steps (full data range)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Implement two stack lite + hop aggregate + union sort for temporal events, with the option to turn it on for testing.
Unlike the implementation purposed by stripe (cogroupSorted - which is only available after spark 3.4), the solution uses `repartitionAndSortWithinPartitions` and RDD to enable external sort with RDDs.

Previous bench marking can be found:
https://github.com/airbnb/chronon/pull/485
https://github.com/airbnb/chronon/pull/464

Detailed analysis: https://docs.google.com/document/d/1hlG69A9ih4SJBToTBoGDMmlbRtMmpNoKbFMu-tFUH6w/edit
## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
We want to test the performance of the aforementioned solution and potentially use it in production.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @hzding621 @vamseeyarla 

cc @camweston-stripe 
