### PR TITLE
Repro of Avro ser issue with multiple average counters

### DIFF
--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
@@ -45,8 +45,8 @@ class GroupByUploadTest {
 
   @Test
   def multipleAvgCountersTest(): Unit = {
-    val today = Constants.Partition.at(System.currentTimeMillis())
-    val yesterday = Constants.Partition.before(today)
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val yesterday = tableUtils.partitionSpec.before(today)
     tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
     tableUtils.sql(s"USE $namespace")
     val eventsTable = "my_events"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We've been working through some serialization issues while trying to serialize pre-aggregated intermediate results to Avro in our streaming jobs (similar to what is being done today in the GroupByUpload). This issue seems to crop up when we have a counter (like average) with different time windows. The reference schema generated using AvroConversions.fromChrononSchema(..) includes the field names with "_REPEATED_NAME_" in them. This field name format seems to be missing when we generate the schemas on the fly while calling AvroConversions.encodeBytes. Due to this we seem to hit errors on the lines of:

```
org.apache.avro.UnresolvedUnionException: Not in union ["null",{"type":"record","name":"WindowedIr","namespace":"ai.chronon.data","doc":"","fields":[{"name":"views_average_1d","type":["null",{"type":"record","name":"AvgIr","doc":"","fields":[{"name":"sum","type":["null","double"],"doc":""},{"name":"count","type":["null","int"],"doc":""}]}],"doc":""},{"name":"rating_average_1d","type":["null",{"type":"record","name":"AvgIr_REPEATED_NAME_0","doc":"","fields":[{"name":"sum_REPEATED_NAME_0","type":["null","double"],"doc":""},{"name":"count_REPEATED_NAME_0","type":["null","int"],"doc":""}]}],"doc":""}]}]: 

{"views_average_1d": {"sum": 48.0, "count": 3}, "rating_average_1d": {"sum": 12.0, "count": 3}} (field=collapsedIr)
      at org.apache.avro.generic.GenericDatumWriter.writeField(GenericDatumWriter.java:247)
      at org.apache.avro.generic.GenericDatumWriter.writeRecord(GenericDatumWriter.java:234)
      at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:145)
      at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:95)
      at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:82)
      at ai.chronon.online.AvroCodec.encodeRecord(AvroCodec.scala:62)
      at ai.chronon.online.AvroCodec.encodeBinary(AvroCodec.scala:57)
      at ai.chronon.online.AvroConversions$.$anonfun$encodeBytes$1(AvroConversions.scala:155)
...
```

I'd imagine that this should already be solved in the GroupByUpload side as we write out the intermediate results as the 'collapsedIr' field (and we have multiple feature groups with average counters with different windows). I wrote up a small unit test which includes an average aggregations over two time windows. I seem to see my GroupByUploadTest failing with the same error as above ^^. I'm confused as to why this is the case given that we have similar group by upload jobs running in prod on Spark batch. Am I doing something incorrect in my test code?

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests - You can see the [test failures in CI](https://circleci.com/api/v1.1/project/github/airbnb/chronon/14559/output/103/0?file=true&allocation-id=64ac95a47b192431de970319-0-build%2F5ABC38E6)
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
cc @nikhilsimha / @cristianfr 
