### PR TITLE
Use same chronon schema to create codec and encode data

### DIFF
--- a/online/src/main/scala/ai/chronon/online/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/AvroConversions.scala
@@ -160,7 +160,7 @@ object AvroConversions {
   def encodeJson(schema: StructType, extraneousRecord: Any => Array[Any] = null): Any => String = {
     val codec: AvroCodec = new AvroCodec(fromChrononSchema(schema).toString(true));
     { data: Any =>
-      val record = fromChrononRow(data, schema, extraneousRecord).asInstanceOf[GenericData.Record]
+      val record = fromChrononRow(data, codec.chrononSchema, extraneousRecord).asInstanceOf[GenericData.Record]
       val json = codec.encodeJson(record)
       json
     }

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
@@ -103,7 +103,7 @@ class GroupByUploadTest {
 
     val aggregations: Seq[Aggregation] = Seq(
       Builders.Aggregation(Operation.LAST_K, "list_event", Seq(WindowUtils.Unbounded), argMap = Map("k" -> "30")),
-      Builders.Aggregation(Operation.AVERAGE, "views", Seq(WindowUtils.Unbounded, new Window(1, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.AVERAGE, "views", Seq(WindowUtils.Unbounded, new Window(1, TimeUnit.DAYS)))
     )
     val keys = Seq("user").toArray
     val groupByConf =


### PR DESCRIPTION
## Summary
Failing test case provided by @piyushn-stripe in #518 

## Test Plan
- [x] Added Unit Tests

## Reviewers
@piyushn-stripe 
