### PR TITLE
Backfill validation: Add table permission check

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -1,7 +1,7 @@
 package ai.chronon.spark
 
 import ai.chronon.api
-import ai.chronon.api.{AggregationPart, Constants, DataType}
+import ai.chronon.api.{AggregationPart, Constants, DataType, TimeUnit, Window}
 import ai.chronon.api.Extensions._
 import ai.chronon.online.SparkConversions
 import ai.chronon.spark.Driver.parseConf
@@ -310,8 +310,10 @@ class Analyzer(tableUtils: TableUtils,
   // return a list of tables that the user doesn't have access to
   def runTablePermissionValidation(sources: Set[String]): Set[String] = {
     println(s"Validating ${sources.size} tables permissions ...")
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val partitionFilter = tableUtils.partitionSpec.minus(today, new Window(2, TimeUnit.DAYS))
     sources.filter { sourceTable =>
-      !tableUtils.checkTablePermission(sourceTable)
+      !tableUtils.checkTablePermission(sourceTable, partitionFilter)
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -151,7 +151,8 @@ case class TableUtils(sparkSession: SparkSession) {
 
   // method to check if a user has access to a table
   def checkTablePermission(tableName: String,
-                           fallbackPartition: String = partitionSpec.before(partitionSpec.at(System.currentTimeMillis()))): Boolean = {
+                           fallbackPartition: String =
+                           partitionSpec.before(partitionSpec.at(System.currentTimeMillis()))): Boolean = {
     println(s"checking permission for table $tableName...")
     try {
       // retrieve one row from the table

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
@@ -201,9 +201,11 @@ class TableUtilsTest {
   @Test
   def ChunkTest(): Unit = {
     val actual = tableUtils.chunk(Set("2021-01-01", "2021-01-02", "2021-01-05", "2021-01-07"))
-    val expected = Seq(PartitionRange("2021-01-01", "2021-01-02")(tableUtils),
-                       PartitionRange("2021-01-05", "2021-01-05")(tableUtils),
-                       PartitionRange("2021-01-07", "2021-01-07")(tableUtils))
+    val expected = Seq(
+      PartitionRange("2021-01-01", "2021-01-02")(tableUtils),
+      PartitionRange("2021-01-05", "2021-01-05")(tableUtils),
+      PartitionRange("2021-01-07", "2021-01-07")(tableUtils)
+    )
     assertEquals(expected, actual)
   }
 
@@ -291,7 +293,8 @@ class TableUtilsTest {
     // verify the latest label version
     val labels = JoinUtils.getLatestLabelMapping(tableName, tableUtils)
     assertEquals(labels.get("2022-11-09").get,
-                 List(PartitionRange("2022-10-01", "2022-10-02")(tableUtils), PartitionRange("2022-10-05", "2022-10-05")(tableUtils)))
+                 List(PartitionRange("2022-10-01", "2022-10-02")(tableUtils),
+                      PartitionRange("2022-10-05", "2022-10-05")(tableUtils)))
   }
 
   private def prepareTestDataWithSubPartitions(tableName: String): Unit = {
@@ -364,5 +367,12 @@ class TableUtilsTest {
       104L,
       tableUtils.columnSizeEstimator(sparkType)
     )
+  }
+
+  @Test
+  def testCheckTablePermission(): Unit = {
+    val tableName = "db.test_check_table_permission"
+    prepareTestDataWithSubPartitions(tableName)
+    assertTrue(tableUtils.checkTablePermission(tableName))
   }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adding table permission check to analyzer. 

- Schema mismatch check (#510)
- Table permission check (This PR)
- Data availability (coming) 

```
----- Validations for join/payments_user_risk_model_v1 -----
----- Schema validation completed. Found 0 errors

---- No permissions to access following 6 tables ----
payments_compliance.graph_user_user_strong_asset_connections_dim
jitney_pii.sessionactivities_sessionactivity_v2
trust.session_activity__dim_signups
db_exports.fraud_db_production_government_id_results_v02
payments_ml.fct_payin_reservation_labels
payments.instrument__dim_instruments
```

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

Tested on gateway with user conf - 
`python3 ~/.local/bin/run.py --mode=analyze --conf=production/joins/trust_v21/pikorua.v3.aircover_eval --chronon-jar=chronon-permission.jar`
`python3 ~/.local/bin/run.py --mode=analyze --conf=production/joins/payments/user_risk_model.v1 --chronon-jar=chronon-permission.jar`

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @cenhao @better365 
