### PR TITLE
[bug fix] use mutation time to determine event eligibility

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala
@@ -80,7 +80,7 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
       val row = headRows.next()
       val rowTs = row.ts // unbox long only once
 
-      val shouldSelect = if(hasReversal) {
+      val shouldSelect = if (hasReversal) {
         // mutation case
         val mutationTs = row.mutationTs
         val rowBeforeQuery = queryTs > rowTs && queryTs > mutationTs
@@ -93,7 +93,7 @@ class SawtoothOnlineAggregator(val batchEndTs: Long,
         rowBeforeQuery && rowAfterBatchEnd
       }
 
-      if(shouldSelect) {
+      if (shouldSelect) {
         updateIr(resultIr, row, queryTs, hasReversal)
       }
     }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We use row TS of a mutation entity to determine whether a mutation event should be considered for online agg result, however this approach is problematic. Here is a example:

Goal: count number of non-hidden reviews.
record before mutation: review_id_123, updated_at_2023-07-01 11:11:11, not_hidden.
record after mutation: review_id_123, updated_at_2023-07-21 03:03:03, not_hidden.
batch end time: 2023-07-21 00:00:00, query time 2023-07-21 04:04:04. row TS is the updated_at

In this set up, the record is updated, but the hidden status is not change, so there should not be a change in number of review. ideally the two mutation events should result in -1 & +1, which is 0, cancels out the whole thing.
However, because the before mutation happens before batch end time, only a +1 is generated and caused the double count.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
To fix the bug mentioned above.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @hzding621 @SophieYu41 @cristianfr @vamseeyarla @better365 @ezvz 
