### PR TITLE
Backfill validation: run validation as default for join

### DIFF
--- a/api/py/test/sample/scripts/spark_submit.sh
+++ b/api/py/test/sample/scripts/spark_submit.sh
@@ -68,6 +68,7 @@ $SPARK_SUBMIT_PATH \
 --conf spark.driver.maxResultSize=4G \
 --conf spark.chronon.partition.column="${PARTITION_COLUMN:-ds}" \
 --conf spark.chronon.partition.format="${PARTITION_FORMAT:-yyyy-MM-dd}" \
+--conf spark.chronon.backfill.validation.enabled="${ENABLE_VALIDATION:-false}" \
 --deploy-mode client \
 --master "${JOB_MODE:-yarn}" \
 --executor-memory "${EXECUTOR_MEMORY:-8G}" \

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -275,7 +275,8 @@ class Analyzer(tableUtils: TableUtils,
       println("----- Backfill validation completed. No errors found. -----")
     } else {
       println(s"----- Schema validation completed. Found ${keysWithError.size} errors")
-      println(keysWithError.map { case (key, errorMsg) => s"$key => $errorMsg" }.mkString("\n"))
+      val keyErrorSet: Set[(String, String)] = keysWithError.toSet
+      println(keyErrorSet.map { case (key, errorMsg) => s"$key => $errorMsg" }.mkString("\n"))
       println(s"---- Table permission check completed. Found permission errors in ${noAccessTables.size} tables ----")
       println(noAccessTables.mkString("\n"))
       println(s"---- Data availability check completed. Found issue in ${dataAvailabilityErrors.size} tables ----")

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -206,10 +206,6 @@ object Driver {
         opt[Boolean](required = false,
                      default = Some(false),
                      descr = "Skip the first unfilled partition range if some future partitions have been populated.")
-      val forceRun: ScallopOption[Boolean] =
-        opt[Boolean](required = false,
-          default = Some(false),
-          descr = "Force backfill job to run even regardless of validation failure.")
       lazy val joinConf: api.Join = parseConf[api.Join](confPath())
       override def subcommandName() = s"join_${joinConf.metaData.name}"
     }
@@ -222,7 +218,7 @@ object Driver {
         args.buildTableUtils(),
         !args.runFirstHole()
       )
-      val df = join.computeJoin(args.stepDays.toOption, args.forceRun())
+      val df = join.computeJoin(args.stepDays.toOption)
 
       if (args.shouldExport()) {
         args.exportTableToLocal(args.joinConf.metaData.outputTable, tableUtils)

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -23,6 +23,8 @@ case class TableUtils(sparkSession: SparkSession) {
   private val partitionFormat: String =
     sparkSession.conf.get("spark.chronon.partition.format", "yyyy-MM-dd")
   val partitionSpec: PartitionSpec = PartitionSpec(partitionFormat, WindowUtils.Day.millis)
+  //TODO: flip to true making it default
+  val backfillValidationEnforced = sparkSession.conf.get("spark.chronon.backfill.validation.enabled", "false").toBoolean
 
   sparkSession.sparkContext.setLogLevel("ERROR")
   // converts String-s like "a=b/c=d" to Map("a" -> "b", "c" -> "d")


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Add validations as default step of join backfill. 
"Soft fail" as first step, only emitting metrics when validation fails. 

Next steps - 
 - Verify existing backfill job validation errors
 - Flip on and force hard fail once step one looks good

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

<img width="1212" alt="Screenshot 2023-07-25 at 4 20 12 PM" src="https://github.com/airbnb/chronon/assets/16948189/deb533cd-0092-491d-aaa2-5691e985e924">

[Metric monitor ](https://app.datadoghq.com/notebook/2918685/sophie-zipline-metrics?fullscreen_end_ts=1690327201869&fullscreen_paused=false&fullscreen_start_ts=1690312801869&fullscreen_widget=h4k201a2)
## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @nikhilsimha @cenhao 
