### PR TITLE
Scd gb backfill

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -572,9 +572,9 @@ object GroupBy {
     val isAnySourceCumulative =
       groupByConf.getSources.toScala.exists(s => s.isSetEvents() && s.getEvents().isCumulative)
     val groupByUnfilledRangesOpt =
-      tableUtils.unfilledRages(outputTable,
-                               PartitionRange(groupByConf.backfillStartDate, endPartition)(tableUtils),
-                               if (isAnySourceCumulative) None else Some(inputTables))
+      tableUtils.unfilledRanges(outputTable,
+                                PartitionRange(groupByConf.backfillStartDate, endPartition)(tableUtils),
+                                if (isAnySourceCumulative) None else Some(inputTables))
 
     if (groupByUnfilledRangesOpt.isEmpty) {
       println(s"""Nothing to backfill for $outputTable - given


### PR DESCRIPTION
## Summary
We usually compute the unfilled range based on input table unfilled range - for scd data that doesn't apply.

## Test Plan
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@better365 @hzding621 @SophieYu41 @cenhao 
