### PR TITLE
Backfill validation : update data availability check

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -232,7 +232,7 @@ class Analyzer(tableUtils: TableUtils,
     // Pair of (table name, group_by name, expected_start) which indicate that the table no not have data available for the required group_by
     val dataAvailabilityErrors: ListBuffer[(String, String, String)] = ListBuffer.empty[(String, String, String)]
 
-    val rangeToFill = JoinUtils.getRangesToFill(joinConf, tableUtils, endDate)
+    val rangeToFill = JoinUtils.getRangesToFill(joinConf.left, tableUtils, endDate)
     println(s"[Analyzer] Join range to fill $rangeToFill")
     val unfilledRanges = tableUtils
       .unfilledRanges(joinConf.metaData.outputTable, rangeToFill, Some(Seq(joinConf.left.table)))
@@ -343,6 +343,7 @@ class Analyzer(tableUtils: TableUtils,
   def runTablePermissionValidation(sources: Set[String]): Set[String] = {
     println(s"Validating ${sources.size} tables permissions ...")
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    //todo: handle offset-by-1 depending on temporal vs snapshot accuracy 
     val partitionFilter = tableUtils.partitionSpec.minus(today, new Window(2, TimeUnit.DAYS))
     sources.filter { sourceTable =>
       !tableUtils.checkTablePermission(sourceTable, partitionFilter)

--- a/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BaseJoin.scala
@@ -288,7 +288,7 @@ abstract class BaseJoin(joinConf: api.Join, endPartition: String, tableUtils: Ta
       tableUtils.archiveOrDropTableIfExists(_, Some(archivedAtTs)))
 
     // detect holes and chunks to fill
-    val rangeToFill = JoinUtils.getRangesToFill(joinConf, tableUtils, endPartition)
+    val rangeToFill = JoinUtils.getRangesToFill(joinConf.left, tableUtils, endPartition)
     println(s"Join range to fill $rangeToFill")
     val unfilledRanges = tableUtils
       .unfilledRanges(outputTable, rangeToFill, Some(Seq(joinConf.left.table)), skipFirstHole = skipFirstHole)

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -74,19 +74,19 @@ object JoinUtils {
       }
     })
 
-  /*
+  /***
    * Compute partition range to be filled for given join conf
    */
-  def getRangesToFill(joinConf: ai.chronon.api.Join,
+  def getRangesToFill(leftSource: ai.chronon.api.Source,
                       tableUtils: TableUtils,
                       endPartition: String): PartitionRange = {
-    val leftStart = Option(joinConf.left.query.startPartition)
-      .getOrElse(tableUtils.firstAvailablePartition(joinConf.left.table, joinConf.left.subPartitionFilters).get)
-    val leftEnd = Option(joinConf.left.query.endPartition).getOrElse(endPartition)
+    val leftStart = Option(leftSource.query.startPartition)
+      .getOrElse(tableUtils.firstAvailablePartition(leftSource.table, leftSource.subPartitionFilters).get)
+    val leftEnd = Option(leftSource.query.endPartition).getOrElse(endPartition)
     PartitionRange(leftStart, leftEnd)(tableUtils)
   }
   
-  /*
+  /***
    * join left and right dataframes, merging any shared columns if exists by the coalesce rule.
    * fails if there is any data type mismatch between shared columns.
    *

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -2,7 +2,6 @@ package ai.chronon.spark.test
 
 import ai.chronon.aggregator.test.Column
 import ai.chronon.api
-import ai.chronon.api.Extensions.MetadataOps
 import ai.chronon.api.{Accuracy, Builders, Operation, TimeUnit, Window}
 import ai.chronon.spark.{Analyzer, Join, SparkSessionBuilder, TableUtils}
 import ai.chronon.spark.Extensions._

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
@@ -1,8 +1,11 @@
 package ai.chronon.spark.test
 
-import ai.chronon.api.Constants
+import ai.chronon.aggregator.test.Column
+import ai.chronon.api
+import ai.chronon.api.{Builders, Constants, TimeUnit, Window}
 import ai.chronon.spark.JoinUtils.{contains_any, set_add}
-import ai.chronon.spark.{JoinUtils, SparkSessionBuilder, TableUtils}
+import ai.chronon.spark.{JoinUtils, PartitionRange, SparkSessionBuilder, TableUtils}
+import ai.chronon.spark.Extensions._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -305,6 +308,23 @@ class JoinUtilsTest {
     val filter = Array("listing", "ds", "feature_review")
     val filteredDf = JoinUtils.filterColumns(testDf, filter)
     assertTrue(filteredDf.schema.fieldNames.sorted sameElements filter.sorted)
+  }
+
+  @Test
+  def testGetRangesToFill(): Unit = {
+    spark.sql("CREATE DATABASE IF NOT EXISTS joinUtil")
+    // left table
+    val itemQueries = List(Column("item", api.StringType, 100))
+    val itemQueriesTable = "joinUtil.item_queries_table"
+    DataFrameGen
+      .events(spark, itemQueries, 1000, partitions = 100)
+      .save(itemQueriesTable)
+
+    val startPartition = "2023-04-15"
+    val endPartition = "2023-08-01"
+    val leftSource = Builders.Source.events(Builders.Query(startPartition = startPartition), table = itemQueriesTable)
+    val range = JoinUtils.getRangesToFill(leftSource, tableUtils, endPartition)
+    assertEquals(range, PartitionRange(startPartition, endPartition)(tableUtils))
   }
 
   import ai.chronon.api.{LongType, StringType, StructField, StructType}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Loose data availability check to use unfilled first partition instead of `startPartition`. This is more accurate and will avoid table retention issues.
- Add group_by start partition information based on user oneBrain [script](https://git.musta.ch/airbnb/one-brain-projects/blob/master/ml/chronon-helper/src/chronon_helper.ipynb). Currently only providing information for user sanity check, can be added to default join validation if needed (force job to fail).

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

```
--mode=analyze --conf=production/joins/trust_v21/pikorua.v3.train

Following Group_Bys contains a startPartition. Please check if any startPartition will conflict with your backfill.
trust_v21.dbx.hostings.v3 : [List(2020-05-13)]
trust_v21.dbx.reservation2s.as_host_no_realtime_v1 : [List(2014-09-22)]
......

---- Data availability check completed. Found issue in 4 tables ----
 Table db_exports.oyster_production_review_deserialized_v03 : Group_By trust_v21.dbx.review.as_reviewee_v4 : Expected start 2017-01-02
 Table jitney.trust_mlfeatures_home_booking_message_clustering_messageclusteringevent_v2 : Group_By trust_v21.offline_risk.online_multilingual_kmeans_clusters.v1 : Expected start 2021-12-11
 Table trust_ml.review__daily_hdbscan_clusters_v1 : Group_By trust_v21.offline_risk.hdbscan_review_clusters.guest_v1 : Expected start 2018-01-01
 Table trust_ml.review__daily_hdbscan_clusters_v1 : Group_By trust_v21.offline_risk.hdbscan_review_clusters.listing_v1 : Expected start 2018-0
```

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @nikhilsimha @better365 
