### PR TITLE
Update Chronon Fetcher paths to not throw NPEs on missing entity keys

### DIFF
--- a/online/src/main/java/ai/chronon/online/JTry.java
+++ b/online/src/main/java/ai/chronon/online/JTry.java
@@ -15,7 +15,6 @@ public abstract class JTry<V> {
     }
 
     public static <V> JTry<V> success(V value) {
-        Objects.requireNonNull(value);
         return new Success<>(value);
     }
 

--- a/online/src/main/java/ai/chronon/online/JavaResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaResponse.java
@@ -18,7 +18,12 @@ public class JavaResponse {
         this.request = new JavaRequest(scalaResponse.request());
         this.values = JTry
                 .fromScala(scalaResponse.values())
-                .map(ScalaVersionSpecificCollectionsConverter::convertScalaMapToJava);
+                .map(v -> {
+                    if (v != null)
+                        return ScalaVersionSpecificCollectionsConverter.convertScalaMapToJava(v);
+                    else
+                        return null;
+                });
     }
 
     public Fetcher.Response toScala() {

--- a/online/src/main/scala/ai/chronon/online/BaseFetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/BaseFetcher.scala
@@ -210,7 +210,7 @@ class BaseFetcher(kvStore: KVStore,
           response.request -> response.values
         }.toMap
         val totalResponseValueBytes =
-          responsesMap.iterator.map(_._2).filter(_.isSuccess).flatMap(_.get.map(_.bytes.length)).sum
+          responsesMap.iterator.map(_._2).filter(_.isSuccess).flatMap(_.get.map(v => Option(v.bytes).map(_.length).getOrElse(0))).sum
         val responses: Seq[Response] = groupByRequestToKvRequest.iterator.map {
           case (request, requestMetaTry) =>
             val responseMapTry = requestMetaTry.map { requestMeta =>


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We've been hitting some NPEs when trying to retrieve GroupBys for entity keys with missing data. One of the issues seems to be that we're trying to report metrics (`totalResponseValueBytes`) on the length of the bytes field returned by the batch KV store when that field is null. The other set of issues seem to be that returning null values for the FG's feature map from the contstructGroupByReponse results in NPEs in the Java conversion code. The creation of the Java map and the JTry Success code either expect non-null values or try to call methods on the object and thus hit NPEs.


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Seeing some NPE / EOFExceptions when users try and hit GroupBys which can be confusing

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha || @ezvz 
