### PR TITLE
Switch to AnyRef for ColumnSpec in fetchColumns API

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -35,7 +35,7 @@ object Fetcher {
                                  baseValues: Map[String, AnyRef]) {
     def combinedValues: Map[String, AnyRef] = baseValues ++ derivedValues
   }
-  case class ColumnSpec(groupByName: String, columnName: String, prefix: Option[String], keyMapping: Option[Map[String, String]])
+  case class ColumnSpec(groupByName: String, columnName: String, prefix: Option[String], keyMapping: Option[Map[String, AnyRef]])
 }
 
 private[online] case class FetcherResponseWithTs(responses: scala.collection.Seq[Response], endTs: Long)

--- a/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
@@ -19,7 +19,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers {
   val Column = "pdp_view_count_14d"
   val GuestKey = "guest"
   val HostKey = "host"
-  val GuestId = "123"
+  val GuestId: AnyRef = 123.asInstanceOf[AnyRef]
   val HostId = "456"
   var fetcherBase: FetcherBase = _
   var kvStore: KVStore = _


### PR DESCRIPTION
## Summary
Was sanity checking what happens when `Map[String, String]` is used for the key map and  _technically_ this works because any class cast exceptions would get caught (for example String int) and re-casted explicitly in `fetchGroupBys`.

But once I messed around with this, it felt a little weird to have this be different than the other APIs when integrating in our client service on Trust Platform. This updates to use `AnyRef` as key value instead.

## Why / Goal
Consistency with existing APIs and avoid exceptions as control flow

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @SophieYu41 

