### PR TITLE
Group by snapshot - filter out null IRs

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -667,7 +667,7 @@ object GroupBy {
           stepRanges.zipWithIndex.foreach {
             case (range, index) =>
               println(s"Computing group by for range: $range [${index + 1}/${stepRanges.size}]")
-              val groupByBackfill = from(groupByConf, range, tableUtils, computeDependency = true, showDf = true)
+              val groupByBackfill = from(groupByConf, range, tableUtils, computeDependency = true)
               val outputDf = groupByConf.dataModel match {
                 // group by backfills have to be snapshot only
                 case Entities => groupByBackfill.snapshotEntities


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We observed that the group by snapshot will insert null values for future keys. This PR will filter out the null IRs.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
This is a data quality bug. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

