### PR TITLE
Fix historical backfill default value

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -697,7 +697,11 @@ object Extensions {
     }
 
     def historicalBackfill: Boolean = {
-      Option(join.metaData.historicalBackfill).getOrElse(true)
+      if (join.metaData.isSetHistoricalBackfill) {
+        join.metaData.historicalBackfill
+      } else {
+        true
+      }
     }
 
     def computedFeatureCols: Seq[String] = joinPartOps.flatMap(_.valueColumns)

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -85,7 +85,7 @@ object JoinUtils {
     val overrideStart = if (historicalBackfill) {
       overrideStartPartition
     } else {
-      println(s"Historical backfill is set to false. Backfill single partition only: $endPartition")
+      println(s"Historical backfill is set to false. Backfill latest single partition only: $endPartition")
       Some(endPartition)
     }
     lazy val defaultLeftStart = Option(leftSource.query.startPartition)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Default bool value when not present will be false. Update to check if flag is set or not instead. Default to be true if not. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Make sure default flag value is true instead of false. 


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
Tested on gateway. Default value is True. 

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @better365 