### PR TITLE
[ZL] Add route for log-summary

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -16,7 +16,7 @@ ONLINE_WRITE_ARGS = '--conf-path={conf_path} ' + ONLINE_ARGS
 ONLINE_OFFLINE_WRITE_ARGS = OFFLINE_ARGS + ONLINE_ARGS
 ONLINE_MODES = ['streaming', 'metadata-upload', 'fetch', 'local-streaming']
 SPARK_MODES = ['backfill', 'upload', 'streaming', 'consistency-metrics-compute',
-               'compare', 'analyze', 'stats-summary',
+               'compare', 'analyze', 'stats-summary', 'log-summary',
                'log-flattener', 'metadata-export', 'label-join']
 MODES_USING_EMBEDDED = ['metadata-upload', 'fetch', 'local-streaming']
 
@@ -32,6 +32,7 @@ MODE_ARGS = {
     'backfill': OFFLINE_ARGS,
     'upload': OFFLINE_ARGS,
     'stats-summary': OFFLINE_ARGS,
+    'log-summary': OFFLINE_ARGS,
     'analyze': OFFLINE_ARGS,
     'streaming': ONLINE_WRITE_ARGS,
     'metadata-upload': ONLINE_WRITE_ARGS,
@@ -62,6 +63,7 @@ ROUTES = {
         'consistency-metrics-compute': 'consistency-metrics-compute',
         'compare': 'compare-join-query',
         'stats-summary': 'stats-summary',
+        'log-summary': 'log-summary',
         'analyze': 'analyze',
         'log-flattener': 'log-flattener',
         'metadata-export': 'metadata-export',


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adding a route on run.py for the driver's log summary.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Missing route that exists on driver.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
`run.py --mode=log-summary --conf production/joins/zipline_test/iceberg_realtime.v0 --version 0.0.51`
```
----[Running query coalesced into at most 4000 partitions]----
ALTER TABLE zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats_upload SET TBLPROPERTIES ('semantic_hash' = '{"zipline_test.zipline_test_iceberg_realtime_v0_zipline_test_iceberg_sample_v0":"/7lpVJCD7n","left_source":"QWtkkUUqS/","zipline_test.zipline_test_iceberg_realtime_v0_bootstrap":"1B2M2Y8Asg"}', 'transient_lastDdlTime' = '1696215133', 'abb_retention_config_json' = '{"policy": "delete_by_last_modified", "days": 1460, "reason": "Zipline default production table"}')
----[End of Query]----

34 rows requested to be written into table zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats_upload
repartitioning data for table zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats_upload by 50 spark tasks into 5 table partitions and 10 files per partition
Finished writing to zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats_upload

----[Running query coalesced into at most 4000 partitions]----
ALTER TABLE zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats SET TBLPROPERTIES ('semantic_hash' = '{"zipline_test.zipline_test_iceberg_realtime_v0_zipline_test_iceberg_sample_v0":"/7lpVJCD7n","left_source":"QWtkkUUqS/","zipline_test.zipline_test_iceberg_realtime_v0_bootstrap":"1B2M2Y8Asg"}', 'transient_lastDdlTime' = '1696215133', 'abb_retention_config_json' = '{"policy": "delete_by_last_modified", "days": 1460, "reason": "Zipline default production table"}')
----[End of Query]----

32 rows requested to be written into table zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats
repartitioning data for table zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats by 40 spark tasks into 4 table partitions and 10 files per partition
Finished writing to zipline_test.zipline_test_iceberg_realtime_v0_logged_daily_stats
Finished range [7/7].
Finished writing stats.
```

## Checklist
- [ ] Documentation update

## Reviewers
@vamseeyarla @SophieYu41 
