### PR TITLE
Fix online metrics for exception counts

### DIFF
--- a/online/src/main/scala/ai/chronon/online/ExternalSourceRegistry.scala
+++ b/online/src/main/scala/ai/chronon/online/ExternalSourceRegistry.scala
@@ -49,8 +49,8 @@ class ExternalSourceRegistry extends Serializable {
             responses.map { responses =>
               val failures = responses.count(_.values.isFailure)
               ctx.histogram("response.latency", System.currentTimeMillis() - startTime)
-              ctx.histogram("response.failures", failures)
-              ctx.histogram("response.successes", responses.size - failures)
+              ctx.count("response.failures", failures)
+              ctx.count("response.successes", responses.size - failures)
               responses
             }
           } else {

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -327,7 +327,7 @@ class Fetcher(val kvStore: KVStore,
       Metrics.Context(environment = Environment.JoinFetching,
                       join = validRequests.iterator.map(_.name.sanitize).toSeq.distinct.mkString(","))
     context.histogram("response.external_pre_processing.latency", System.currentTimeMillis() - startTime)
-    context.histogram("response.external_invalid_joins.count", invalidCount)
+    context.count("response.external_invalid_joins.count", invalidCount)
     val responseFutures = externalSourceRegistry.fetchRequests(validExternalRequestToJoinRequestMap.keys.toSeq, context)
 
     // step-3 walk the response, find all the joins to update and the result map


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Use `stats.count` instead of `stats.histogram` to publish volume-like metrics such as exception counts. This allows us to know the number of exceptions per 5m/1h/1d etc. instead of the p95 of # exceptions per 5m/1h/1d which doesn't make sense. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


The current Chronon dashboard for external source exceptions are broken because `ai.zipline.join.fetch.response.successes.count`  and `ai.zipline.join.fetch.response.failures.count` are identical. 

<img width="843" alt="Screenshot 2023-10-03 at 4 29 35 PM" src="https://github.com/airbnb/chronon/assets/8077218/4100bd53-ff48-4722-84db-ea2e23b82f2d">

It also wouldn't make sense to use `ai.zipline.join.fetch.response.successes.median` and `ai.zipline.join.fetch.response.failures.median`. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->

Test after deploy. 

## Reviewers

@nikhilsimha @better365 
