### PR TITLE
[Fetcher] Print exceptions prior to reporting for metrics

### DIFF
--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -18,7 +18,11 @@ public class JavaFetcher {
   Fetcher fetcher;
 
   public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
-    this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry);
+    this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, 0.1, registry);
+  }
+
+  public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, Double exceptionSampleRate, ExternalSourceRegistry registry) {
+    this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, exceptionSampleRate, registry);
   }
 
   public static List<JavaResponse> toJavaResponses(Seq<Response> responseSeq) {

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -145,8 +145,11 @@ abstract class Api(userConf: Map[String, String]) extends Serializable {
   def externalRegistry: ExternalSourceRegistry
 
   private var timeoutMillis: Long = 10000
+  private var exceptionSampleRate: Double = 0.1
 
   def setTimeout(millis: Long): Unit = { timeoutMillis = millis }
+
+  def setExceptionSampleRate(ratio: Double): Unit = { exceptionSampleRate = ratio }
 
   // kafka has built-in support - but one can add support to other types using this method.
   def generateStreamBuilder(streamType: String): StreamBuilder = null
@@ -171,11 +174,17 @@ abstract class Api(userConf: Map[String, String]) extends Serializable {
                 Constants.ChrononMetadataKey,
                 logFunc = responseConsumer,
                 debug = debug,
+                exceptionSampleRate = exceptionSampleRate,
                 externalSourceRegistry = externalRegistry,
                 timeoutMillis = timeoutMillis)
 
   final def buildJavaFetcher(): JavaFetcher =
-    new JavaFetcher(genKvStore, Constants.ChrononMetadataKey, timeoutMillis, responseConsumer, externalRegistry)
+    new JavaFetcher(genKvStore,
+                    Constants.ChrononMetadataKey,
+                    timeoutMillis,
+                    responseConsumer,
+                    exceptionSampleRate,
+                    externalRegistry)
 
   private def responseConsumer: Consumer[LoggableResponse] =
     new Consumer[LoggableResponse] {


### PR DESCRIPTION
## Summary
We now expose exceptionSampleRate via API - default is 0.1 - one among every 10 exceptions will be logged. 


## Why / Goal
Currently we don't log exceptions at all, which makes debugging difficult. This will make it so that by default we print a fraction of exceptions.


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @qiyang0221 
