### PR TITLE
[small fix] unify naming format for join metrics 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -168,7 +168,7 @@ object Metrics {
     def gauge(metric: String, value: Long): Unit = stats.gauge(prefix(metric), value, tags)
 
     def toTags: Array[String] = {
-      val joinNames: Array[String] = Option(join).map(_.split(",")).getOrElse(Array.empty[String])
+      val joinNames: Array[String] = Option(join).map(_.split(",")).getOrElse(Array.empty[String]).map(_.sanitize)
       assert(
         environment != null,
         "Environment needs to be set - group_by.upload, group_by.streaming, join.fetching, group_by.fetching, group_by.offline etc")
@@ -183,7 +183,10 @@ object Metrics {
       }
 
       joinNames.foreach(addTag(Tag.Join, _))
-      addTag(Tag.GroupBy, groupBy)
+
+      val groupByName = Option(groupBy).map(_.sanitize)
+      groupByName.foreach(addTag(Tag.GroupBy, _))
+
       addTag(Tag.StagingQuery, stagingQuery)
       addTag(Tag.Production, production.toString)
       addTag(Tag.Team, team)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

use `.sanitize` format for join & group by metric tags 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

currently there are 3 different naming format for join/group bys and it's super confusing to people 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested


## Reviewers

@nikhilsimha 
