### PR TITLE
handle nested struct for join source runner - part II 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -256,14 +256,17 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
         .toArray
     )
 
-    val leftColumns = decoded.df.schema.fieldNames.filter(reqColumns.contains).toSeq
-
     val schemas = buildSchemas(leftSchema)
     val joinChrononSchema = SparkConversions.toChrononSchema(schemas.joinSchema)
     val joinEncoder: Encoder[Row] = RowEncoder(schemas.joinSchema)
     val joinFields = schemas.joinSchema.fieldNames
+    val leftColumns = schemas.leftSourceSchema.fieldNames
+    println(s"""
+         |left columns ${leftColumns.mkString(",")}
+         |reqColumns ${reqColumns.mkString(",")}
+         |Fetching upstream join to enrich the stream... Fetching lag time: $lagMillis
+         |""".stripMargin)
 
-    println(s"Fetching upstream join to enrich the stream... Fetching lag time: $lagMillis")
     // todo: add proper timestamp to the fetcher
     // leftTimeIndex = leftColumns.indexWhere(_ == eventTimeColumn)
     val enriched = leftSource.mapPartitions(

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
@@ -7,7 +7,7 @@ import ai.chronon.api.{StructField, _}
 import ai.chronon.online.SparkConversions
 import ai.chronon.spark.{IncompatibleSchemaException, PartitionRange, SparkSessionBuilder, TableUtils}
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession, types}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
 
@@ -41,6 +41,23 @@ class TableUtilsTest {
                        "column_g",
                        "column_nested.first.second").sorted
     assertEquals(expected, columns.sorted)
+  }
+
+  @Test
+  def GetFieldNamesTest(): Unit = {
+    val schema = types.StructType(
+      Seq(
+        types.StructField("name", types.StringType, nullable = true),
+        types.StructField("age", types.IntegerType, nullable = false),
+        types.StructField("address", types.StructType(Seq(
+          types.StructField("street", types.StringType, nullable = true),
+          types.StructField("city", types.StringType, nullable = true)
+        )))
+      )
+    )
+    val expectedFieldNames = Seq("name", "age", "address", "address.street", "address.city")
+    val actualFieldNames = tableUtils.getFieldNames(schema)
+    assertEquals(expectedFieldNames, actualFieldNames)
   }
 
   private def testInsertPartitions(tableName: String,


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This is a follow up PR to https://github.com/airbnb/chronon/pull/582

It will take the queried field names to query the stream data. Without this change, the values would be null due to querying the raw columns. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Enable join source runner to handle nested struct. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [x] tested on gateway machine

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
