### PR TITLE
[kyro] add RebaseDateTime$

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -101,6 +101,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.catalyst.expressions.Descending$",
       "org.apache.spark.sql.catalyst.expressions.NullsFirst$",
       "org.apache.spark.sql.catalyst.expressions.NullsLast$",
+      "org.apache.spark.sql.catalyst.util.RebaseDateTime$",
       "scala.collection.IndexedSeqLike$Elements",
       "org.apache.spark.unsafe.types.UTF8String",
       "scala.reflect.ClassTag$GenericClassTag",


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
From the new release, we are seeing 
```
Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class org.apache.spark.sql.catalyst.util.RebaseDateTime$
```
https://airflow-1-10.d.musta.ch/log?task_id=compute_join__fiv__target_features_listing__v1&dag_id=chronon_join_fiv__target_features_listing__v1&execution_date=2023-10-18T00%3A00%3A00%2B00%3A00

Adding this class to see if it can address the issue.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @better365 @hzding621 
