### PR TITLE
[chaining] remove wait before fetch

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -736,9 +736,7 @@ object Driver {
         onlineJar.foreach(session.sparkContext.addJar)
       implicit val apiImpl = args.impl(args.serializableProps)
       val query = if (groupByConf.streamingSource.get.isSetJoinSource) {
-        new JoinSourceRunner(groupByConf,
-                             args.serializableProps,
-                             args.debug()).chainedStreamingQuery.start()
+        new JoinSourceRunner(groupByConf, args.serializableProps, args.debug()).chainedStreamingQuery.start()
       } else {
         val streamingSource = groupByConf.streamingSource
         assert(streamingSource.isDefined,

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -22,8 +22,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.util.ScalaJavaConversions.{IteratorOps, JIteratorOps, ListOps, MapOps}
 
-class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map.empty, debug: Boolean)(
-    implicit
+class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map.empty, debug: Boolean)(implicit
     session: SparkSession,
     apiImpl: Api)
     extends Serializable {

--- a/spark/src/test/scala/ai/chronon/spark/test/OnlineUtils.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/OnlineUtils.scala
@@ -76,7 +76,7 @@ object OnlineUtils {
     val groupByConf = originalGroupByConf.deepCopy()
     val source = groupByConf.streamingSource.get
     mutateTopicWithDs(source, ds)
-    val groupByStreaming = new JoinSourceRunner(groupByConf, Map.empty, debug = debug, lagMillis = 0)
+    val groupByStreaming = new JoinSourceRunner(groupByConf, Map.empty, debug = debug)
     val query = groupByStreaming.chainedStreamingQuery.trigger(Trigger.Once()).start()
     // drain work scheduled as futures over the executioncontext
     Thread.sleep(5000)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
[chaining] remove wait before fetch. Attempt to fix data mismatch issues

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Wait does not seem to be necessary since chaining streaming job is consuming `parentJoin.left.topic` while parent gb streaming job is consuming `parentJoinGBSource.topic`. Events from 2 sources happening at different time and no conflict on each other. 

cc @nikhilsimha @better365  to confirm 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

PENDING test on streaming job

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @better365 
