### PR TITLE
[CI] Set a time limit for circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,12 @@ jobs:
         steps:
             - checkout
             - run:
+                  name: Background time limit 40 minutes.
+                  command: |
+                    sleep 2400
+                    circleci-agent step halt
+                  background: true
+            - run:
                   name: Run Spark 2.4.0 tests
                   shell: /bin/bash -leuxo pipefail
                   command: |
@@ -72,6 +78,12 @@ jobs:
         steps:
             - checkout
             - run:
+                  name: Background time limit 40 minutes.
+                  command: |
+                    sleep 2400
+                    circleci-agent step halt
+                  background: true
+            - run:
                   name: Run Spark 3.1.1 tests
                   shell: /bin/bash -leuxo pipefail
                   command: |
@@ -97,6 +109,12 @@ jobs:
         executor: docker_baseimg_executor
         steps:
             - checkout
+            - run:
+                  name: Background time limit 40 minutes.
+                  command: |
+                    sleep 2400
+                    circleci-agent step halt
+                  background: true
             - run:
                   name: Run Scala 13 tests
                   shell: /bin/bash -leuxo pipefail


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Setting a time limit of 40 minutes for circle CI as metadata calls can run into a 4hr+ loop of failure
Example: https://app.circleci.com/pipelines/github/airbnb/chronon/3408/workflows/2fdc3dd8-904b-4d90-b062-d5879f4bd686/jobs/17449

From: https://support.circleci.com/hc/en-us/articles/11775183948827-How-to-run-a-job-in-the-background-on-CircleCI

> A job that has background: true set will run while there are other jobs running but once they have finished the background job will also end, it will not run on its own if there are no other jobs.

Pick 40 minutes since both Spark 3.1.1 and 3.2 run in ~10-20minutes. 
Spark 2 can run for 40 minutes but rarely will provide more info than the other two together.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Improve dev experience.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
anyone.