### PR TITLE
Filter out external feature columns in consistency job comparison

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
@@ -98,7 +98,8 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
       val loggedDf =
         tableUtils.sql(unfilled.genScanQuery(null, joinConf.metaData.loggedTable)).drop(Constants.SchemaHash)
       // there could be external columns that are logged during online env, therefore they could not be used for computing OOC
-      val loggedDfNoExternalCols = loggedDf.select(comparisonDfNoExternalCols.columns.map(org.apache.spark.sql.functions.col): _*)
+      val loggedDfNoExternalCols =
+        loggedDf.select(comparisonDfNoExternalCols.columns.map(org.apache.spark.sql.functions.col): _*)
       println("Starting compare job for stats")
       val joinKeys = if (joinConf.isSetRowIds) {
         joinConf.rowIds.toScala


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Filters out contextual features from external parts from the comparison dataframe before computing consistency metrics with the logged data.


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
The logged data from the online chronon system does not include the contextual features and the consistency job will fail if you don't filter out these features first.


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

