### PR TITLE
[Chaining] Micro batch interval configuration

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -86,7 +86,7 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
   private val queryShiftMs: Int = getProp("query_shift_ms", "0").toInt
 
   // Micro batch interval - users can tune for lowering latency - or maximizing batch size
-  private val microBatchIntervalMillis: Int = getProp("batch_interval_millis", "5000").toInt
+  private val microBatchIntervalMillis: Int = getProp("batch_interval_millis", "1000").toInt
 
   private case class PutRequestHelper(inputSchema: StructType) extends Serializable {
     private val keyIndices: Array[Int] = keyColumns.map(inputSchema.fieldIndex)


### PR DESCRIPTION
## Summary
Set chaining micro batch interval to be configurable - default is 1 seconds


## Why / Goal
Allows users to tune for latency when they need to. Currently the job server UI gets filled up with too many executor events.


## Test Plan
- [x] Covered by existing CI
- [x] Integration tested

## Reviewers
@better365 @SophieYu41 
