### PR TITLE
[StatsFetching] Unify drift computation accross datasets

### DIFF
--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -115,12 +115,6 @@ public class JavaFetcher {
     return new Metrics.Context("group_by.fetch", null, groupByName, null, false, null, null, null, null);
   }
 
-  public CompletableFuture<List<JavaStatsResponse>> fetchStats(JavaStatsRequest request) {
-    Future<Seq<Fetcher.StatsResponse>> responses = this.fetcher.fetchStats(request.toScalaRequest());
-    // Convert responses to CompletableFuture
-    return convertStatsResponses(responses);
-  }
-
   public CompletableFuture<JavaSeriesStatsResponse> fetchStatsTimeseries(JavaStatsRequest request) {
     Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchStatsTimeseries(request.toScalaRequest());
     // Convert responses to CompletableFuture


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Make any method I don't expect to be called private.
Make the drift logic available for logs and ooc.
Add some comments.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 
