### PR TITLE
DailyFileCountEstimate: Smooth denominator to avoid being zero

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -322,6 +322,7 @@ case class TableUtils(sparkSession: SparkSession) {
       val totalFileCountEstimate = math.ceil(rowCount * columnSizeEstimate / rowCountPerPartition).toInt
       val dailyFileCountUpperBound = 2000
       val dailyFileCountLowerBound = if (isLocal) 1 else 10
+      // add one to tablePartitionCount to avoid division by zero
       val dailyFileCountEstimate = totalFileCountEstimate / (tablePartitionCount + 1) + 1
       val dailyFileCountBounded =
         math.max(math.min(dailyFileCountEstimate, dailyFileCountUpperBound), dailyFileCountLowerBound)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We observed that some cases the denominator could be zero for daily file count estimate. This PR will add one to smooth the calculation. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [x] tested on GW machine 

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
