### PR TITLE
Changes to allow PRs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
         resource_class: xlarge
         working_directory: /chronon
         docker:
-            - image: "houpy0829/chronon-ci:base--${${CIRCLE_PULL_REQUEST##*/}:-master}"
+            - image: houpy0829/chronon-ci:base--${CIRCLE_SHA1}
 
 jobs:
     "Docker Base Build":
@@ -29,15 +29,15 @@ jobs:
                 name: Build docker image
                 command: |
                     set +o pipefail
-                    docker build -t "houpy0829/chronon-ci:base--${${CIRCLE_PULL_REQUEST##*/}:-master}" --build-arg base_image="cimg/base:2020.01" -f .circleci/Dockerfile .
+                    docker build -t houpy0829/chronon-ci:base--${CIRCLE_SHA1} --build-arg base_image="cimg/base:2020.01" -f .circleci/Dockerfile .
             - deploy:
                 name: Push docker image
                 command: |
                     set +euxo pipefail
                     docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
-                    docker push "houpy0829/chronon-ci:base--${${CIRCLE_PULL_REQUEST##*/}:-master}"
+                    docker push houpy0829/chronon-ci:base--${CIRCLE_SHA1}
                     if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                        docker tag houpy0829/chronon-ci:base--${CIRCLE_BRANCH} houpy0829/chronon-ci:base
+                        docker tag houpy0829/chronon-ci:base--${CIRCLE_SHA1} houpy0829/chronon-ci:base
                         docker push houpy0829/chronon-ci:base
                     fi
 


### PR DESCRIPTION
## Summary
The Circle branch env var from forks looks like `pull/618` where as internally it simply takes the name of the branch. Our docker commands expect this var to be sanitized at all times. This PR switches to using CIRCLE_SHA1 instead of branch. 
This env var is guaranteed to be set regardless of whether it is a PR from for or not. 

## Why / Goal
So the people can create PRs to the main repo from their private forks.


## Test Plan
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Reviewers
@SophieYu41 @cristianfr cc: @hsaputra 
