### PR TITLE
Set full name default to false for get_join_output_table_name

### DIFF
--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -221,7 +221,7 @@ def get_staging_query_output_table_name(staging_query: api.StagingQuery, full_na
     return output_table_name(staging_query, full_name=full_name)
 
 
-def get_join_output_table_name(join: api.Join, full_name: bool):
+def get_join_output_table_name(join: api.Join, full_name: bool = False):
     """generate output table name for join backfill job"""
     __set_name(join, api.Join, "joins")
     return output_table_name(join, full_name=full_name)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
As titled, so users don't have to specify the extra bool param. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Simplify user experience. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@cristianfr @SophieYu41 
