### PR TITLE
Fixing link to point to raw file for docker download

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Does not include:
 To get started with the Chronon, all you need to do is download the [docker-compose.yml](docker-compose.yml) file and run it locally:
 
 ```bash
-curl -o docker-compose.yml https://github.com/airbnb/chronon/blob/master/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/airbnb/chronon/master/docker-compose.yml?token=GHSAT0AAAAAACI7NIDGLHTNEECJAZJPUX4UZMB7MWA
 docker-compose up
 ```
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Right now it downloads the HTML, we need it to download the raw docker file.



## Reviewers
@nikhilsimha @hzding621 
