### PR TITLE
Update twine command to be more precise

### DIFF
--- a/devnotes.md
+++ b/devnotes.md
@@ -178,7 +178,7 @@ password=<your password>
 2. Install `tox, build, twine`. There are three python requirements for the python build process.
 * tox: Module for testing. To run the tests run tox in the main project directory.
 * build: Module for building. To build run `python -m build` in the main project directory
-* twine: Module for publishing. To upload a distribution run `twine upload dist/<distribution>`
+* twine: Module for publishing. To upload a distribution run `twine upload dist/<distribution>.whl`
 ```
 python3 -m pip install -U tox build twine
 ```


### PR DESCRIPTION
With the new pip resolve, uploading tar balls will cause inconsistency, so we have to upload the wheel only.

In theory twine should throw an error when tar is being uploaded, but instead it silently allows the upload.

## Summary
<!-- Overview of the changes involved in the PR -->


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [x] Documentation update

## Reviewers

