### PR TITLE
Use thread-safe FastDateFormat in TsUtils.scala

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TsUtils.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/TsUtils.scala
@@ -16,12 +16,11 @@
 
 package ai.chronon.aggregator.windowing
 
-import java.text.SimpleDateFormat
+import org.apache.commons.lang3.time.FastDateFormat
 import java.util.{Date, TimeZone}
 
 object TsUtils {
-  val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-  formatter.setTimeZone(TimeZone.getTimeZone("UTC"))
+  val formatter = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("UTC"))
 
   // in millisecond precision
   def toStr(epochMillis: Long): String = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Use FastDateFormat instead of SimpleDateFormat in TsUtils.scala


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
We recently introduced some parallelizations that included [this logging](https://github.com/airbnb/chronon/blob/master/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala#L54-L58) in SawtoothOnlineAggregator.scala. Since SimpleDateFormat is not thread-safe, we ran into some race conditions with these logs. In order to resolve this, we can instead use the thread-safe FastDateFormat


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Covered by existing CI
- [x] Tested in our QA environment 


## Reviewers

