### PR TITLE
[StatsFetch] Ignore bad decodes

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -462,14 +462,16 @@ class Fetcher(val kvStore: KVStore,
     rawResponses.map { responseFuture =>
       val convertedValue = responseFuture
         .flatMap { response =>
-          response.values.get.map {
-            case (key, v) =>
-              key ->
-                Map(
-                  "millis" -> response.millis.asInstanceOf[AnyRef],
-                  "value" -> StatsGenerator.SeriesFinalizer(key, v)
-                ).asJava
-          }
+          response.values
+            .getOrElse(Map.empty[String, AnyRef])
+            .map {
+              case (key, v) =>
+                key ->
+                  Map(
+                    "millis" -> response.millis.asInstanceOf[AnyRef],
+                    "value" -> StatsGenerator.SeriesFinalizer(key, v)
+                  ).asJava
+            }
         }
         .groupBy(_._1)
         .mapValues(_.map(_._2).toList.asJava)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We store the schema in the KVStore, however it's possible for the KVStore to still contain values that are outdated. 
To prevent completely failing the fetch, it's better to just provide nulls when the value schema cannot decode a specific value.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Reliability.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested (pushed a snapshot version and did a fetch that was failing)
```
 }, {
    "millis" : 1706486400000,
    "value" : [ 1.65324518E9, 1.65324518E9, 1.65324518E9, 1.65324518E9, 1.65324518E9 ]
  }, {
    "millis" : 1706382000000,
    "value" : null
  }, {
    "millis" : 1706284800000,
    "value" : null
  }, {
    "millis" : 1706270400000,
    "value" : null
  }, {
    "millis" : 1706223600000,
    "value" : null
  }, {
```

## Checklist
- [ ] Documentation update

## Reviewers

