### PR TITLE
Add local env runtime variables override for local testing

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -238,7 +238,7 @@ def set_runtime_env(args):
         - conf.metaData.modeToEnvMap for the mode (set on config)
         - team environment per context and mode set on teams.json
         - production team environment per mode set on teams.json
-        - default production team environment per context and mode set on teams.json
+        - default team environment per context and mode set on teams.json
         - Common Environment set in teams.json
     """
     environment = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Currently Chronon set the runtime environment variables from several sources based on the below priority order:
        - Environment variables existing already.
        - Environment variables derived from args (like app_name)
        - conf.metaData.modeToEnvMap for the mode (set on config)
        - team environment per context and mode set on teams.json
        - default team environment per context and mode set on teams.json
        - Common Environment set in teams.json

The team environment per context mode set is a team level environment setting which defined in the json file teams.json. Team could put the environment settings(like EMR clusters and queue) based on their need, and these settings will be applied to all the jobs within the team folder. 

However, sometimes our users may want to test their new job locally, the local tests may use different environment settings comparing with the prod run on airflow. Currently they need to add their job config into a different folder(like the test folder) other than the production folder(which will be parsed as context), and add context specific environment variables, but this may bring new complexity to the testing process since they still have to copy their changes to the production config to make it work in production environment. 

This PR is trying to solve this problem by introducing a new arg env whose default value is **dev**. Users can define runtime environment variables for different environment in teams.json file, for example, for production environment and dev environment:

```
"production": {
    "backfill": {
        "EMR_CLUSTER": "backfill-shared-prod",
        "EMR_QUEUE": "backfill"
    },
    "upload": {
        "EMR_CLUSTER": "backfill-shared-prod",
        "EMR_QUEUE": "backfill"
    }
},
"dev": {
    "backfill": {
        "EMR_CLUSTER": "homes-shared-prod-ap",
        "EMR_QUEUE": "staging"
    }
},
```
1. For production run on airflow, the job will be scheduled with `--env=production`, so the production environment will be used.
2. For local testing, the default env is dev, so if the dev environment is provided in teams.json file, dev environment will be used, otherwise production environment will be used.


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

1. dev environment is provided in teams.json, env=production
Local tests with  
`python3 scripts/run.py --mode=backfill --conf=production/joins/zipline_test/test_online_join_small.v2  --ds=2024-02-20 --env=production`
<img width="476" alt="image" src="https://github.com/airbnb/chronon/assets/31667422/9e6905ab-90dd-4e1f-b44a-cd15cbdd689e">

2. dev environment is provided in teams.json, env=dev
Local tests with  
`python3 scripts/run.py --mode=backfill --conf=production/joins/zipline_test/test_online_join_small.v2  --ds=2024-02-20 --env=dev`
<img width="463" alt="image" src="https://github.com/airbnb/chronon/assets/31667422/fef283de-9f15-432f-a2a5-53c75097842f">

3. dev environment is provided in teams.json, env is not used
Local tests with
`python3 scripts/run.py --mode=backfill --conf=production/joins/zipline_test/test_online_join_small.v2  --ds=2024-02-20`
<img width="464" alt="image" src="https://github.com/airbnb/chronon/assets/31667422/0c4a5f81-87ab-4ce5-97b2-b62e540f4f95">

4. dev environment is not provided in teams.json, env = dev
Local tests with
`python3 scripts/run.py --mode=backfill --conf=production/joins/zipline_test/test_online_join_small.v2  --ds=2024-02-20 --env=dev`
<img width="554" alt="image" src="https://github.com/airbnb/chronon/assets/31667422/42831f88-bcdc-4ecc-8eec-9975b7066413">


## Checklist
- [ ] Documentation update

## Reviewers
@better365 
