### PR TITLE
Deprecate spark 2_11 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,6 @@ workflows:
     build_test_deploy:
         jobs:
             - "Docker Base Build"
-            - "Scala 11 -- Spark 2 Tests":
-                  requires:
-                      - "Docker Base Build"
             - "Scala 12 -- Spark 3 Tests":
                   requires:
                       - "Docker Base Build"


### PR DESCRIPTION
## Summary
we want to deprecate support for older spark versions and scala versions and in the process also make our CI faster and cheaper

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Reviewers
@cristianfr @ezvz 
