### PR TITLE
[Driver] Allow AtMillis on fetch CLI

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -558,6 +558,11 @@ object Driver {
         descr = "file path to json of the keys to fetch",
         short = 'f'
       )
+      val atMillis: ScallopOption[Long] = opt[Long](
+        required = false,
+        descr = "timestamp to fetch the data at",
+        default = None
+      )
       val interval: ScallopOption[Int] = opt[Int](
         required = false,
         descr = "interval between requests in seconds",
@@ -626,7 +631,7 @@ object Driver {
             fetchStats(args, objectMapper, keyMap, fetcher)
           } else {
             val startNs = System.nanoTime
-            val requests = Seq(Fetcher.Request(args.name(), keyMap))
+            val requests = Seq(Fetcher.Request(args.name(), keyMap, args.atMillis.toOption))
             val resultFuture = if (args.`type`() == "join") {
               fetcher.fetchJoin(requests)
             } else {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Allow atMillis on Fetch CLI.

This came useful when building an hourly log table with keys and timestamps that were providing suspicious values. Wanted to fetch the data at the required timestamp.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Works wonders when debugging OOC data and eventual consistency issues in our KV Store.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha @donghanz 
