### PR TITLE
Fix CatalystUtil conversions to handle array inputs

### DIFF
--- a/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
@@ -136,8 +136,11 @@ object SparkInternalRowConversions {
         val elementConverter = to(elementType, structToMap)
 
         def arrayConverter(x: Any): Any = {
-          val arrayData = x.asInstanceOf[util.ArrayList[Any]]
-          new GenericArrayData(arrayData.iterator().toScala.map(elementConverter).toArray)
+          val arrayData = x match {
+            case listValue: util.ArrayList[_] => listValue.iterator().toScala.map(elementConverter).toArray
+            case arrayValue: Array[_]         => arrayValue.iterator.map(elementConverter).toArray
+          }
+          new GenericArrayData(arrayData)
         }
 
         arrayConverter


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Fixes a bug in the CatalystUtil Spark conversions while dealing with Array objects (these occur when we layer Derivations on top of a GroupBy that includes an [ApproxPercentile](https://github.com/airbnb/chronon/blob/main/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala#L462) ). As we're trying to cast to a Java ArrayList (and type is an Array), we hit an error:
```
Caused by: java.lang.ClassCastException: class [F cannot be cast to class java.util.ArrayList ([F and java.util.ArrayList are in module java.base of loader 'bootstrap')
	at ai.chronon.online.SparkInternalRowConversions$.arrayConverter$2(SparkInternalRowConversions.scala:123)
	at ai.chronon.online.SparkInternalRowConversions$.$anonfun$to$4(SparkInternalRowConversions.scala:127)
	at ai.chronon.online.SparkInternalRowConversions$.guardedFunc$2(SparkInternalRowConversions.scala:159)
	at ai.chronon.online.SparkInternalRowConversions$.$anonfun$to$14(SparkInternalRowConversions.scala:160)
	at scala.Option.map(Option.scala:230)
	at ai.chronon.online.SparkInternalRowConversions$.$anonfun$to$8(SparkInternalRowConversions.scala:137)
...
	at ai.chronon.online.SparkInternalRowConversions$.mapConverter$3(SparkInternalRowConversions.scala:138)
	at ai.chronon.online.SparkInternalRowConversions$.$anonfun$to$10(SparkInternalRowConversions.scala:152)
	at ai.chronon.online.SparkInternalRowConversions$.guardedFunc$2(SparkInternalRowConversions.scala:159)
	at ai.chronon.online.SparkInternalRowConversions$.$anonfun$to$14(SparkInternalRowConversions.scala:160)
	at ai.chronon.online.CatalystUtil.performSql(CatalystUtil.scala:135)
```

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
We have a user trying to leverage ApproxPercentiles in their GroupBy and they have a Join with a "*" which is failing due to this error at serving time (offline works fine)

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha 
