### PR TITLE
Support derivation for groupBy online fetch

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -506,7 +506,8 @@ class Fetcher(val kvStore: KVStore,
   }
 
   /**
-    * Given a sequence of stats responses for different time intervals, re arrange it into a map containing the drift for
+    * Given a sequence of stats responses for different time intervals, re arrange it into a map containing the drift
+   * for
     * the approx percentile metrics.
     * TODO: Extend to larger periods of time by merging the Sketches from a larger slice.
     * TODO: Allow for non sequential time intervals. i.e. this week against the same week last year.

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -507,7 +507,7 @@ class Fetcher(val kvStore: KVStore,
 
   /**
     * Given a sequence of stats responses for different time intervals, re arrange it into a map containing the drift
-   * for
+    * for
     * the approx percentile metrics.
     * TODO: Extend to larger periods of time by merging the Sketches from a larger slice.
     * TODO: Allow for non sequential time intervals. i.e. this week against the same week last year.

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -207,7 +207,8 @@ class Fetcher(val kvStore: KVStore,
                   case Failure(exception) =>
                     ctx.incrementException(exception)
                     val renameOnlyDerivedMapTry: Try[Map[String, AnyRef]] = Try {
-                      joinCodec.renameOnlyDeriveFunc(internalResponse.request.keys, baseMap)
+                      joinCodec
+                        .renameOnlyDeriveFunc(internalResponse.request.keys, baseMap)
                         .mapValues(_.asInstanceOf[AnyRef])
                     }
                     val renameOnlyDerivedMap: Map[String, AnyRef] = renameOnlyDerivedMapTry match {
@@ -229,8 +230,8 @@ class Fetcher(val kvStore: KVStore,
                 // more validation logic will be covered in compile.py to avoid this case
                 ctx.incrementException(exception)
                 ResponseWithContext(internalResponse.request,
-                  Map("join_codec_fetch_exception" -> exception.traceString),
-                  Map.empty)
+                                    Map("join_codec_fetch_exception" -> exception.traceString),
+                                    Map.empty)
             }
         }
     }

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -17,10 +17,9 @@
 package ai.chronon.online
 
 import ai.chronon.aggregator.row.{ColumnAggregator, StatsGenerator}
-import ai.chronon.aggregator.windowing.TsUtils
 import ai.chronon.api
 import ai.chronon.api.Constants.UTF8
-import ai.chronon.api.Extensions.{ExternalPartOps, JoinOps, MetadataOps, StringOps, ThrowableOps, DerivationOps}
+import ai.chronon.api.Extensions.{ExternalPartOps, JoinOps, MetadataOps, StringOps, ThrowableOps}
 import ai.chronon.api._
 import ai.chronon.online.Fetcher._
 import ai.chronon.online.KVStore.GetRequest
@@ -32,6 +31,7 @@ import java.util.function.Consumer
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, mutable}
+import scala.collection.immutable.Map
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
@@ -210,6 +210,7 @@ class Fetcher(val kvStore: KVStore,
                       joinCodec
                         .renameOnlyDeriveFunc(internalResponse.request.keys, baseMap)
                         .mapValues(_.asInstanceOf[AnyRef])
+                        .toMap
                     }
                     val renameOnlyDerivedMap: Map[String, AnyRef] = renameOnlyDerivedMapTry match {
                       case Success(renameOnlyDerivedMap) =>

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -105,7 +105,7 @@ class Fetcher(val kvStore: KVStore,
           } else {
             servingInfo.outputChrononSchema
           }
-          val baseValueSchema: StructType = if (servingInfo.groupBy.hasDerivations) {
+          val baseValueSchema: StructType = if (!servingInfo.groupBy.hasDerivations) {
             groupBySchemaBeforeDerivation
           } else {
             val fields =

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -105,7 +105,7 @@ class Fetcher(val kvStore: KVStore,
           } else {
             servingInfo.outputChrononSchema
           }
-          val baseValueSchema: StructType = if (servingInfo.groupBy.derivations == null) {
+          val baseValueSchema: StructType = if (servingInfo.groupBy.hasDerivations) {
             groupBySchemaBeforeDerivation
           } else {
             val fields =

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -316,8 +316,20 @@ class FetcherBase(kvStore: KVStore,
                     throw ex
                 }
               if (groupByServingInfo.groupBy.hasDerivations) {
-                val deriveFunc: DerivationFunc = getGroupByServingInfo(request.name).get.deriveFunc
-                applyDeriveFunc(deriveFunc, request, groupByResponse)
+                val derivedMapTry: Try[Map[String, AnyRef]] = Try{
+                  val deriveFunc: DerivationFunc = getGroupByServingInfo(request.name).get.deriveFunc
+                  applyDeriveFunc(deriveFunc, request, groupByResponse)
+                }
+                val derivedMap = derivedMapTry match {
+                  case Success(derivedMap) =>
+                    derivedMap
+                  case Failure(exception) => {
+                    val derivedExceptionMap =
+                      Map("derivation_fetch_exception" -> exception.traceString.asInstanceOf[AnyRef])
+                    derivedExceptionMap ++ groupByResponse
+                  }
+                }
+                derivedMap
               } else {
                 groupByResponse
               }

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -315,10 +315,7 @@ class FetcherBase(kvStore: KVStore,
                     ex.printStackTrace()
                     throw ex
                 }
-              logger.info(s"[test] groupByServingInfo ${groupByServingInfo}")
-              logger.info(s"[test] groupByServingInfo ${groupByServingInfo.groupBy.derivationsScala}")
               if (groupByServingInfo.groupBy.hasDerivations) {
-                logger.info(s"[test] baseMap ${groupByResponse}")
                 val deriveFunc: DerivationFunc = getGroupByServingInfo(request.name).get.deriveFunc
                 applyDeriveFunc(deriveFunc, request, groupByResponse)
               } else {

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -326,7 +326,8 @@ class FetcherBase(kvStore: KVStore,
                   case Failure(exception) => {
                     val derivedExceptionMap =
                       Map("derivation_fetch_exception" -> exception.traceString.asInstanceOf[AnyRef])
-                    val renameOnlyDeriveFunction = buildRenameOnlyDerivationFunction(groupByServingInfo.groupBy.derivationsScala)
+                    val renameOnlyDeriveFunction =
+                      buildRenameOnlyDerivationFunction(groupByServingInfo.groupBy.derivationsScala)
                     val renameOnlyDerivedMapTry: Try[Map[String, AnyRef]] = Try {
                       renameOnlyDeriveFunction(request.keys, groupByResponse)
                         .mapValues(_.asInstanceOf[AnyRef])

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -323,10 +323,11 @@ class FetcherBase(kvStore: KVStore,
                 val derivedMap = derivedMapTry match {
                   case Success(derivedMap) =>
                     derivedMap
+                  // If the derivation failed we want to return the exception map only
                   case Failure(exception) => {
                     val derivedExceptionMap =
                       Map("derivation_fetch_exception" -> exception.traceString.asInstanceOf[AnyRef])
-                    derivedExceptionMap ++ groupByResponse
+                    derivedExceptionMap
                   }
                 }
                 derivedMap

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -324,6 +324,7 @@ class FetcherBase(kvStore: KVStore,
                     derivedMap
                   // If the derivation failed we want to return the exception map and rename only derivation
                   case Failure(exception) => {
+                    context.incrementException(exception)
                     val derivedExceptionMap =
                       Map("derivation_fetch_exception" -> exception.traceString.asInstanceOf[AnyRef])
                     val renameOnlyDeriveFunction =
@@ -338,6 +339,7 @@ class FetcherBase(kvStore: KVStore,
                       case Success(renameOnlyDerivedMap) =>
                         renameOnlyDerivedMap
                       case Failure(exception) =>
+                        context.incrementException(exception)
                         Map("derivation_rename_exception" -> exception.traceString.asInstanceOf[AnyRef])
                     }
                     renameOnlyDerivedMap ++ derivedExceptionMap

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -316,7 +316,7 @@ class FetcherBase(kvStore: KVStore,
                     throw ex
                 }
               if (groupByServingInfo.groupBy.hasDerivations) {
-                val derivedMapTry: Try[Map[String, AnyRef]] = Try{
+                val derivedMapTry: Try[Map[String, AnyRef]] = Try {
                   val deriveFunc: DerivationFunc = getGroupByServingInfo(request.name).get.deriveFunc
                   applyDeriveFunc(deriveFunc, request, groupByResponse)
                 }

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -33,7 +33,13 @@ import scala.collection.{Seq, mutable}
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-import ai.chronon.online.OnlineDerivationUtil.{DerivationFunc, applyDeriveFunc, buildDerivationFunction, buildRenameOnlyDerivationFunction, timeFields}
+import ai.chronon.online.OnlineDerivationUtil.{
+  DerivationFunc,
+  applyDeriveFunc,
+  buildDerivationFunction,
+  buildRenameOnlyDerivationFunction,
+  timeFields
+}
 
 // Does internal facing fetching
 //   1. takes join request or groupBy requests
@@ -287,27 +293,28 @@ class FetcherBase(kvStore: KVStore,
               val streamingResponsesOpt =
                 streamingRequestOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
               val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
-              val groupByResponse: Map[String, AnyRef] = try {
-                if (debug)
-                  logger.info(
-                    s"Constructing response for groupBy: ${groupByServingInfo.groupByOps.metaData.getName} " +
-                      s"for keys: ${request.keys}")
-                constructGroupByResponse(batchResponseTryAll,
-                                         streamingResponsesOpt,
-                                         groupByServingInfo,
-                                         queryTs,
-                                         startTimeMs,
-                                         multiGetMillis,
-                                         context,
-                                         totalResponseValueBytes)
-              } catch {
-                case ex: Exception =>
-                  // not all exceptions are due to stale schema, so we want to control how often we hit kv store
-                  getGroupByServingInfo.refresh(groupByServingInfo.groupByOps.metaData.name)
-                  context.incrementException(ex)
-                  ex.printStackTrace()
-                  throw ex
-              }
+              val groupByResponse: Map[String, AnyRef] =
+                try {
+                  if (debug)
+                    logger.info(
+                      s"Constructing response for groupBy: ${groupByServingInfo.groupByOps.metaData.getName} " +
+                        s"for keys: ${request.keys}")
+                  constructGroupByResponse(batchResponseTryAll,
+                                           streamingResponsesOpt,
+                                           groupByServingInfo,
+                                           queryTs,
+                                           startTimeMs,
+                                           multiGetMillis,
+                                           context,
+                                           totalResponseValueBytes)
+                } catch {
+                  case ex: Exception =>
+                    // not all exceptions are due to stale schema, so we want to control how often we hit kv store
+                    getGroupByServingInfo.refresh(groupByServingInfo.groupByOps.metaData.name)
+                    context.incrementException(ex)
+                    ex.printStackTrace()
+                    throw ex
+                }
               logger.info(s"[test] groupByServingInfo ${groupByServingInfo}")
               logger.info(s"[test] groupByServingInfo ${groupByServingInfo.groupBy.derivationsScala}")
               if (groupByServingInfo.groupBy.hasDerivations) {

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -25,7 +25,7 @@ import org.apache.avro.Schema
 import org.apache.spark.sql.SparkSession
 import scala.collection.JavaConverters.asScalaBufferConverter
 
-import ai.chronon.online.OnlineDerivationUtil.{DerivationFunc, buildDerivationFunction}
+import ai.chronon.online.OnlineDerivationUtil.{DerivationFunc, buildDerivationFunction, buildDerivedFields, timeFields}
 
 // mixin class - with schema
 class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo, partitionSpec: PartitionSpec)

--- a/online/src/main/scala/ai/chronon/online/JoinCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/JoinCodec.scala
@@ -22,7 +22,7 @@ import com.google.gson.Gson
 import scala.collection.Seq
 import scala.util.ScalaJavaConversions.JMapOps
 
-import ai.chronon.online.OnlineDerivationUtil.{DerivationFunc, buildDerivationFunction, buildRenameOnlyDerivationFunction, timeFields}
+import ai.chronon.online.OnlineDerivationUtil.{DerivationFunc, buildDerivationFunction, buildDerivedFields, buildRenameOnlyDerivationFunction, timeFields}
 
 case class JoinCodec(conf: JoinOps,
                      keySchema: StructType,
@@ -30,74 +30,13 @@ case class JoinCodec(conf: JoinOps,
                      keyCodec: AvroCodec,
                      baseValueCodec: AvroCodec)
     extends Serializable {
-  case class SchemaAndDeriveFunc(valueSchema: StructType,
-                                 derivationFunc: (Map[String, Any], Map[String, Any]) => Map[String, Any])
-
-  // We want the same branch logic to construct both schema and derivation
-  // Conveniently, this also removes branching logic from hot path of derivation
-  @transient lazy private val valueSchemaAndDeriveFunc: SchemaAndDeriveFunc = getValueSchemaAndDeriveFunc()
-
-  @transient lazy private val valueSchemaAndRenameOnlyDeriveFunc: SchemaAndDeriveFunc = getValueSchemaAndDeriveFunc(
-    true)
-
-  private def getValueSchemaAndDeriveFunc(keepRenameOnly: Boolean = false): SchemaAndDeriveFunc = {
-    if (conf.join == null || conf.join.derivations == null || baseValueSchema.fields.isEmpty) {
-      SchemaAndDeriveFunc(baseValueSchema, { case (_: Map[String, Any], values: Map[String, Any]) => values })
+  @transient private def getValueSchema(keepRenameOnly: Boolean = false): StructType = {
+    val fields = if (conf.join == null || conf.join.derivations == null || baseValueSchema.fields.isEmpty) {
+      baseValueSchema
     } else {
-      def build(fields: Seq[StructField], deriveFunc: DerivationFunc) =
-        SchemaAndDeriveFunc(StructType(s"join_derived_${conf.join.metaData.cleanName}", fields.toArray), deriveFunc)
-      // if spark catalyst is not necessary, and all the derivations are just renames, we don't invoke catalyst
-      if (conf.areDerivationsRenameOnly || keepRenameOnly) {
-        val baseExpressions = if (conf.derivationsContainStar) {
-          baseValueSchema.filterNot {
-            conf.derivationExpressionSet contains _.name
-          }
-        } else {
-          Seq.empty
-        }
-        val renameDerivations = if (keepRenameOnly) {
-          conf.derivationsScala.renameOnlyDerivations
-        } else {
-          conf.derivationsWithoutStar
-        }
-        val expressions = baseExpressions ++ renameDerivations.map { d =>
-          StructField(d.name, baseValueSchema.typeOf(d.expression).get)
-        }
-        build(
-          expressions,
-          buildRenameOnlyDerivationFunction(conf.derivationsWithoutStar)
-        )
-      } else {
-        val baseExpressions = if (conf.derivationsContainStar) {
-          baseValueSchema
-            .filterNot {
-              conf.derivationExpressionSet contains _.name
-            }
-            .map(sf => sf.name -> sf.name)
-        } else {
-          Seq.empty
-        }
-        val expressions = baseExpressions ++ conf.derivationsWithoutStar.map { d => d.name -> d.expression }
-        val catalystUtil = {
-          new PooledCatalystUtil(expressions,
-                                 StructType("all", (keySchema ++ baseValueSchema).toArray ++ timeFields))
-        }
-        build(
-          catalystUtil.outputChrononSchema.map(tup => StructField(tup._1, tup._2)),
-          buildDerivationFunction(catalystUtil)
-        )
-      }
+      buildDerivedFields(conf.derivationsScala, keySchema, baseValueSchema, keepRenameOnly)
     }
-  }
-
-  @transient lazy val deriveFunc: (Map[String, Any], Map[String, Any]) => Map[String, Any] =
-    valueSchemaAndDeriveFunc.derivationFunc
-
-  @transient lazy val renameOnlyDeriveFunc: (Map[String, Any], Map[String, Any]) => Map[String, Any] =
-    valueSchemaAndRenameOnlyDeriveFunc.derivationFunc
-
-  @transient lazy val valueSchema: StructType = {
-    val derivedSchema = valueSchemaAndDeriveFunc.valueSchema
+    val derivedSchema: StructType = StructType(s"join_derived_${conf.join.metaData.cleanName}", fields.toArray)
     if (conf.logFullValues) {
       def toMap(schema: StructType): Map[String, DataType] = schema.map(field => (field.name, field.fieldType)).toMap
       val (baseMap, derivedMap) = (toMap(baseValueSchema), toMap(derivedSchema))
@@ -112,6 +51,16 @@ case class JoinCodec(conf: JoinOps,
       derivedSchema
     }
   }
+
+  @transient lazy val deriveFunc: DerivationFunc = buildDerivationFunction(conf.derivationsScala, keySchema, baseValueSchema)
+
+  @transient lazy val renameOnlyDeriveFunc: (Map[String, Any], Map[String, Any]) => Map[String, Any] =
+    buildRenameOnlyDerivationFunction(conf.derivationsScala)
+
+  @transient lazy val renamedOnlyValueSchema: StructType =  getValueSchema(keepRenameOnly = true)
+
+  @transient lazy val valueSchema: StructType = getValueSchema()
+
   @transient lazy val valueCodec: AvroCodec = AvroCodec.of(AvroConversions.fromChrononSchema(valueSchema).toString)
 
   /*
@@ -134,18 +83,6 @@ case class JoinCodec(conf: JoinOps,
 }
 
 object JoinCodec {
-
-  // remove value fields of groupBys that have failed with exceptions
-  // and reintroduce the exceptions back
-  private[online] def reintroduceExceptions(derived: Map[String, Any],
-                                            preDerivation: Map[String, Any]): Map[String, Any] = {
-    val exceptions: Map[String, Any] = preDerivation.iterator.filter(_._1.endsWith("_exception")).toMap
-    if (exceptions.isEmpty) {
-      return derived
-    }
-    val exceptionParts: Array[String] = exceptions.keys.map(_.dropRight("_exception".length)).toArray
-    derived.filterKeys(key => !exceptionParts.exists(key.startsWith)).toMap ++ exceptions
-  }
 
   def buildLoggingSchema(joinName: String, keyCodec: AvroCodec, valueCodec: AvroCodec): String = {
     val schemaMap = Map(

--- a/online/src/main/scala/ai/chronon/online/JoinCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/JoinCodec.scala
@@ -37,7 +37,7 @@ case class JoinCodec(conf: JoinOps,
                      baseValueCodec: AvroCodec)
     extends Serializable {
 
-  @transient private lazy val valueSchema: StructType = {
+  @transient lazy val valueSchema: StructType = {
     val fields = if (conf.join == null || conf.join.derivations == null || baseValueSchema.fields.isEmpty) {
       baseValueSchema
     } else {

--- a/online/src/main/scala/ai/chronon/online/JoinCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/JoinCodec.scala
@@ -22,7 +22,13 @@ import com.google.gson.Gson
 import scala.collection.Seq
 import scala.util.ScalaJavaConversions.JMapOps
 
-import ai.chronon.online.OnlineDerivationUtil.{DerivationFunc, buildDerivationFunction, buildDerivedFields, buildRenameOnlyDerivationFunction, timeFields}
+import ai.chronon.online.OnlineDerivationUtil.{
+  DerivationFunc,
+  buildDerivationFunction,
+  buildDerivedFields,
+  buildRenameOnlyDerivationFunction,
+  timeFields
+}
 
 case class JoinCodec(conf: JoinOps,
                      keySchema: StructType,
@@ -53,7 +59,8 @@ case class JoinCodec(conf: JoinOps,
     }
   }
 
-  @transient lazy val deriveFunc: DerivationFunc = buildDerivationFunction(conf.derivationsScala, keySchema, baseValueSchema)
+  @transient lazy val deriveFunc: DerivationFunc =
+    buildDerivationFunction(conf.derivationsScala, keySchema, baseValueSchema)
 
   @transient lazy val renameOnlyDeriveFunc: (Map[String, Any], Map[String, Any]) => Map[String, Any] =
     buildRenameOnlyDerivationFunction(conf.derivationsScala)

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -27,14 +27,14 @@ object OnlineDerivationUtil {
     derived.filterKeys(key => !exceptionParts.exists(key.startsWith)).toMap ++ exceptions
   }
 
-  def buildRenameOnlyDerivationFunction(derivationsScala: List[Derivation]): DerivationFunc = {
+  private def buildRenameOnlyDerivationFunction(derivationsScala: List[Derivation]): DerivationFunc = {
     {
       case (_: Map[String, Any], values: Map[String, Any]) =>
         reintroduceExceptions(derivationsScala.applyRenameOnlyDerivation(values), values)
     }
   }
 
-  def buildDerivationFunctionWithSql(
+  private def buildDerivationFunctionWithSql(
       catalystUtil: PooledCatalystUtil
   ): DerivationFunc = {
     {

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -51,7 +51,7 @@ object OnlineDerivationUtil {
     if (derivationsScala.isEmpty) {
       return { case (_, values: Map[String, Any]) => values }
     } else if (derivationsScala.areDerivationsRenameOnly) {
-      buildRenameOnlyDerivationFunction(derivationsScala.derivationsWithoutStar)
+      buildRenameOnlyDerivationFunction(derivationsScala)
     } else {
       val baseExpressions = if (derivationsScala.derivationsContainStar) {
         baseValueSchema
@@ -74,8 +74,9 @@ object OnlineDerivationUtil {
     val requestTs = request.atMillis.getOrElse(System.currentTimeMillis())
     val requestDs = TsUtils.toStr(requestTs).substring(0, 10)
     // used for derivation based on ts/ds
-    val tsDsMap: Map[String, AnyRef] =
+    val tsDsMap: Map[String, AnyRef] = {
       Map("ts" -> (requestTs).asInstanceOf[AnyRef], "ds" -> (requestDs).asInstanceOf[AnyRef])
+    }
     val derivedMap: Map[String, AnyRef] = Try(
       deriveFunc(request.keys, baseMap ++ tsDsMap)
         .mapValues(_.asInstanceOf[AnyRef])

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -71,8 +71,8 @@ object OnlineDerivationUtil {
       Map("ts" -> (requestTs).asInstanceOf[AnyRef], "ds" -> (requestDs).asInstanceOf[AnyRef])
     }
     val derivedMap: Map[String, AnyRef] = deriveFunc(request.keys, baseMap ++ tsDsMap)
-        .mapValues(_.asInstanceOf[AnyRef])
-        .toMap
+      .mapValues(_.asInstanceOf[AnyRef])
+      .toMap
     val derivedMapCleaned = derivedMap -- tsDsMap.keys
     derivedMapCleaned
   }

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -70,15 +70,9 @@ object OnlineDerivationUtil {
     val tsDsMap: Map[String, AnyRef] = {
       Map("ts" -> (requestTs).asInstanceOf[AnyRef], "ds" -> (requestDs).asInstanceOf[AnyRef])
     }
-    val derivedMap: Map[String, AnyRef] = Try(
-      deriveFunc(request.keys, baseMap ++ tsDsMap)
+    val derivedMap: Map[String, AnyRef] = deriveFunc(request.keys, baseMap ++ tsDsMap)
         .mapValues(_.asInstanceOf[AnyRef])
-        .toMap) match {
-      case Success(derivedMap) => derivedMap
-      case Failure(exception) => {
-        throw exception
-      }
-    }
+        .toMap
     val derivedMapCleaned = derivedMap -- tsDsMap.keys
     derivedMapCleaned
   }

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -1,10 +1,11 @@
 package ai.chronon.online
 
 import scala.util.{Failure, Success, Try}
+import scala.collection.Seq
 
 import ai.chronon.aggregator.windowing.TsUtils
 import ai.chronon.api.Extensions.DerivationOps
-import ai.chronon.api.{Constants, Derivation, LongType, StringType, StructField, StructType}
+import ai.chronon.api.{Derivation, LongType, StringType, StructField, StructType}
 import ai.chronon.online.Fetcher.Request
 
 object OnlineDerivationUtil {
@@ -99,8 +100,7 @@ object OnlineDerivationUtil {
   def buildDerivedFields(
     derivationsScala: List[Derivation],
     keySchema: StructType,
-    baseValueSchema: StructType,
-    keepRenameOnly: Boolean = false
+    baseValueSchema: StructType
   ): Seq[StructField] = {
     if (derivationsScala.areDerivationsRenameOnly) {
       val baseExpressions = if (derivationsScala.derivationsContainStar) {

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -27,7 +27,7 @@ object OnlineDerivationUtil {
     derived.filterKeys(key => !exceptionParts.exists(key.startsWith)).toMap ++ exceptions
   }
 
-  private def buildRenameOnlyDerivationFunction(derivationsScala: List[Derivation]): DerivationFunc = {
+  def buildRenameOnlyDerivationFunction(derivationsScala: List[Derivation]): DerivationFunc = {
     {
       case (_: Map[String, Any], values: Map[String, Any]) =>
         reintroduceExceptions(derivationsScala.applyRenameOnlyDerivation(values), values)

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -7,7 +7,6 @@ import ai.chronon.api.Extensions.DerivationOps
 import ai.chronon.api.{Constants, Derivation, LongType, StringType, StructField, StructType}
 import ai.chronon.online.Fetcher.Request
 
-
 object OnlineDerivationUtil {
   type DerivationFunc = (Map[String, Any], Map[String, Any]) => Map[String, Any]
 
@@ -36,7 +35,7 @@ object OnlineDerivationUtil {
   }
 
   def buildDerivationFunctionWithSql(
-    catalystUtil: PooledCatalystUtil
+      catalystUtil: PooledCatalystUtil
   ): DerivationFunc = {
     {
       case (keys: Map[String, Any], values: Map[String, Any]) =>
@@ -45,9 +44,9 @@ object OnlineDerivationUtil {
   }
 
   def buildDerivationFunction(
-    derivationsScala: List[Derivation],
-    keySchema: StructType,
-    baseValueSchema: StructType
+      derivationsScala: List[Derivation],
+      keySchema: StructType,
+      baseValueSchema: StructType
   ): DerivationFunc = {
     if (derivationsScala.areDerivationsRenameOnly) {
       buildRenameOnlyDerivationFunction(derivationsScala.derivationsWithoutStar)
@@ -59,17 +58,16 @@ object OnlineDerivationUtil {
       } else { Seq.empty }
       val expressions = baseExpressions ++ derivationsScala.derivationsWithoutStar.map { d => d.name -> d.expression }
       val catalystUtil = {
-        new PooledCatalystUtil(expressions,
-          StructType("all", (keySchema ++ baseValueSchema).toArray ++ timeFields))
+        new PooledCatalystUtil(expressions, StructType("all", (keySchema ++ baseValueSchema).toArray ++ timeFields))
       }
       buildDerivationFunctionWithSql(catalystUtil)
     }
   }
 
   def applyDeriveFunc(
-    deriveFunc: DerivationFunc,
-    request: Request,
-    baseMap: Map[String, AnyRef]
+      deriveFunc: DerivationFunc,
+      request: Request,
+      baseMap: Map[String, AnyRef]
   ): Map[String, AnyRef] = {
     val requestTs = request.atMillis.getOrElse(System.currentTimeMillis())
     val requestDs = TsUtils.toStr(requestTs).substring(0, 10)

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -1,0 +1,41 @@
+package ai.chronon.online
+
+import ai.chronon.api.Extensions.DerivationOps
+import ai.chronon.api.{Derivation, LongType, StringType, StructField, StructType}
+
+
+object OnlineDerivationUtil {
+  type DerivationFunc = (Map[String, Any], Map[String, Any]) => Map[String, Any]
+
+  val timeFields: Array[StructField] = Array(
+    StructField("ts", LongType),
+    StructField("ds", StringType)
+  )
+
+  // remove value fields of groupBys that have failed with exceptions
+  private[online] def reintroduceExceptions(derived: Map[String, Any], preDerivation: Map[String, Any]): Map[String, Any] = {
+    val exceptions: Map[String, Any] = preDerivation.iterator.filter(_._1.endsWith("_exception")).toMap
+    if (exceptions.isEmpty) {
+      return derived
+    }
+    val exceptionParts: Array[String] = exceptions.keys.map(_.dropRight("_exception".length)).toArray
+    derived.filterKeys(key => !exceptionParts.exists(key.startsWith)).toMap ++ exceptions
+  }
+
+  def buildRenameOnlyDerivationFunction(derivationsScala: List[Derivation]): DerivationFunc = {
+    {
+      case (_: Map[String, Any], values: Map[String, Any]) =>
+        reintroduceExceptions(derivationsScala.applyRenameOnlyDerivation(values), values)
+    }
+  }
+
+  def buildDerivationFunction(
+    catalystUtil: PooledCatalystUtil
+  ): DerivationFunc = {
+    {
+      case (keys: Map[String, Any], values: Map[String, Any]) =>
+        reintroduceExceptions(catalystUtil.performSql(keys ++ values).orNull, values)
+    }
+  }
+
+}

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -48,7 +48,9 @@ object OnlineDerivationUtil {
       keySchema: StructType,
       baseValueSchema: StructType
   ): DerivationFunc = {
-    if (derivationsScala.areDerivationsRenameOnly) {
+    if (derivationsScala.isEmpty) {
+      return { case (_, values: Map[String, Any]) => values }
+    } else if (derivationsScala.areDerivationsRenameOnly) {
       buildRenameOnlyDerivationFunction(derivationsScala.derivationsWithoutStar)
     } else {
       val baseExpressions = if (derivationsScala.derivationsContainStar) {

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -19,7 +19,7 @@ object OnlineDerivationUtil {
   // remove value fields of groupBys that have failed with exceptions
   // and reintroduce the exceptions back
   private[online] def reintroduceExceptions(derived: Map[String, Any],
-    preDerivation: Map[String, Any]): Map[String, Any] = {
+                                            preDerivation: Map[String, Any]): Map[String, Any] = {
     val exceptions: Map[String, Any] = preDerivation.iterator.filter(_._1.endsWith("_exception")).toMap
     if (exceptions.isEmpty) {
       return derived
@@ -98,9 +98,9 @@ object OnlineDerivationUtil {
   }
 
   def buildDerivedFields(
-    derivationsScala: List[Derivation],
-    keySchema: StructType,
-    baseValueSchema: StructType
+      derivationsScala: List[Derivation],
+      keySchema: StructType,
+      baseValueSchema: StructType
   ): Seq[StructField] = {
     if (derivationsScala.areDerivationsRenameOnly) {
       val baseExpressions = if (derivationsScala.derivationsContainStar) {
@@ -109,15 +109,15 @@ object OnlineDerivationUtil {
         Seq.empty
       }
       val expressions: Seq[StructField] = baseExpressions ++ derivationsScala.derivationsWithoutStar.map { d =>
-      {
-        if (baseValueSchema.typeOf(d.expression).isEmpty) {
-          throw new IllegalArgumentException(
-            s"Failed to run expression ${d.expression} for ${d.name}. Please ensure the derivation is " +
-              s"correct.")
-        } else {
-          StructField(d.name, baseValueSchema.typeOf(d.expression).get)
+        {
+          if (baseValueSchema.typeOf(d.expression).isEmpty) {
+            throw new IllegalArgumentException(
+              s"Failed to run expression ${d.expression} for ${d.name}. Please ensure the derivation is " +
+                s"correct.")
+          } else {
+            StructField(d.name, baseValueSchema.typeOf(d.expression).get)
+          }
         }
-      }
       }
       expressions
     } else {

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -83,9 +83,9 @@ object OnlineDerivationUtil {
   }
 
   def buildCatalystUtil(
-    derivationsScala: List[Derivation],
-    keySchema: StructType,
-    baseValueSchema: StructType
+      derivationsScala: List[Derivation],
+      keySchema: StructType,
+      baseValueSchema: StructType
   ): PooledCatalystUtil = {
     val baseExpressions = if (derivationsScala.derivationsContainStar) {
       baseValueSchema

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -53,15 +53,7 @@ object OnlineDerivationUtil {
     } else if (derivationsScala.areDerivationsRenameOnly) {
       buildRenameOnlyDerivationFunction(derivationsScala)
     } else {
-      val baseExpressions = if (derivationsScala.derivationsContainStar) {
-        baseValueSchema
-          .filterNot { derivationsScala.derivationExpressionSet contains _.name }
-          .map(sf => sf.name -> sf.name)
-      } else { Seq.empty }
-      val expressions = baseExpressions ++ derivationsScala.derivationsWithoutStar.map { d => d.name -> d.expression }
-      val catalystUtil = {
-        new PooledCatalystUtil(expressions, StructType("all", (keySchema ++ baseValueSchema).toArray ++ timeFields))
-      }
+      val catalystUtil = buildCatalystUtil(derivationsScala, keySchema, baseValueSchema)
       buildDerivationFunctionWithSql(catalystUtil)
     }
   }

--- a/online/src/test/scala/ai/chronon/online/test/JoinCodecTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/JoinCodecTest.scala
@@ -16,12 +16,7 @@
 
 package ai.chronon.online.test
 
-import ai.chronon.online.JoinCodec
-<<<<<<< HEAD
 import ai.chronon.online.OnlineDerivationUtil.reintroduceExceptions
-=======
-import ai.chronon.online.OnlineDerivationUtil.adjustExceptions
->>>>>>> 1aa12815 (minor fix for format and tests)
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -39,11 +34,8 @@ class JoinCodecTest {
       "derived2" -> "val2"
     )
 
-<<<<<<< HEAD
     val result = reintroduceExceptions(derived, preDerived)
-=======
-    val result = adjustExceptions(derived, preDerived)
->>>>>>> 1aa12815 (minor fix for format and tests)
+
     val expected = Map(
       "group_by_3_feature1" -> "val1",
       "derived1" -> "val1",

--- a/online/src/test/scala/ai/chronon/online/test/JoinCodecTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/JoinCodecTest.scala
@@ -17,6 +17,7 @@
 package ai.chronon.online.test
 
 import ai.chronon.online.JoinCodec
+import ai.chronon.online.OnlineDerivationUtil.reintroduceExceptions
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -34,7 +35,7 @@ class JoinCodecTest {
       "derived2" -> "val2"
     )
 
-    val result = JoinCodec.reintroduceExceptions(derived, preDerived)
+    val result = reintroduceExceptions(derived, preDerived)
     val expected = Map(
       "group_by_3_feature1" -> "val1",
       "derived1" -> "val1",

--- a/online/src/test/scala/ai/chronon/online/test/JoinCodecTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/JoinCodecTest.scala
@@ -17,7 +17,11 @@
 package ai.chronon.online.test
 
 import ai.chronon.online.JoinCodec
+<<<<<<< HEAD
 import ai.chronon.online.OnlineDerivationUtil.reintroduceExceptions
+=======
+import ai.chronon.online.OnlineDerivationUtil.adjustExceptions
+>>>>>>> 1aa12815 (minor fix for format and tests)
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -35,7 +39,11 @@ class JoinCodecTest {
       "derived2" -> "val2"
     )
 
+<<<<<<< HEAD
     val result = reintroduceExceptions(derived, preDerived)
+=======
+    val result = adjustExceptions(derived, preDerived)
+>>>>>>> 1aa12815 (minor fix for format and tests)
     val expected = Map(
       "group_by_3_feature1" -> "val1",
       "derived1" -> "val1",

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -653,6 +653,7 @@ object Driver {
             }
             val result = Await.result(resultFuture, 5.seconds)
             val awaitTimeMs = (System.nanoTime - startNs) / 1e6d
+            logger.info(s"[test yuli 1] ${result}")
 
             // treeMap to produce a sorted result
             val tMap = new java.util.TreeMap[String, AnyRef]()
@@ -663,6 +664,7 @@ object Driver {
                     logger.info("No data present for the provided key.")
                   } else {
                     valMap.foreach { case (k, v) => tMap.put(k, v) }
+                    logger.info(s"[test yuli 2] ${tMap}")
                     logger.info(
                       s"--- [FETCHED RESULT] ---\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(tMap)}")
                   }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -653,7 +653,6 @@ object Driver {
             }
             val result = Await.result(resultFuture, 5.seconds)
             val awaitTimeMs = (System.nanoTime - startNs) / 1e6d
-            logger.info(s"[test yuli 1] ${result}")
 
             // treeMap to produce a sorted result
             val tMap = new java.util.TreeMap[String, AnyRef]()
@@ -664,7 +663,6 @@ object Driver {
                     logger.info("No data present for the provided key.")
                   } else {
                     valMap.foreach { case (k, v) => tMap.put(k, v) }
-                    logger.info(s"[test yuli 2] ${tMap}")
                     logger.info(
                       s"--- [FETCHED RESULT] ---\n${objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(tMap)}")
                   }

--- a/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
@@ -26,12 +26,15 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
-
 import java.util.Base64
+
+import scala.+:
 import scala.collection.mutable
 import scala.collection.Seq
 import scala.util.ScalaJavaConversions.{IterableOps, MapOps}
 import scala.util.{Failure, Success, Try}
+
+import ai.chronon.online.OnlineDerivationUtil.timeFields
 
 /**
   * Purpose of LogFlattenerJob is to unpack serialized Avro data from online requests and flatten each field
@@ -120,7 +123,7 @@ class LogFlattenerJob(session: SparkSession,
     // contextual features are logged twice in keys and values, where values are prefixed with ext_contextual
     // here we exclude the duplicated fields as the two are always identical
     val dataFields = allDataFields.filterNot(_.name.startsWith(Constants.ContextualPrefix))
-    val metadataFields = StructField(Constants.SchemaHash, StringType) +: JoinCodec.timeFields
+    val metadataFields = StructField(Constants.SchemaHash, StringType) +: timeFields
     val outputSchema = StructType("", metadataFields ++ dataFields)
     val (keyBase64Idx, valueBase64Idx, tsIdx, dsIdx, schemaHashIdx) = (0, 1, 2, 3, 4)
     val outputRdd: RDD[Row] = rawDf

--- a/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
@@ -24,9 +24,11 @@ import ai.chronon.online._
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.{PartitionRange, TableUtils}
 import org.apache.spark.sql.SparkSession
-
 import java.util
+
 import scala.util.ScalaJavaConversions.{JListOps, ListOps, MapOps}
+
+import ai.chronon.online.OnlineDerivationUtil.timeFields
 
 class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) extends Serializable {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -114,7 +116,7 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
       val joinKeys = if (joinConf.isSetRowIds) {
         joinConf.rowIds.toScala
       } else {
-        JoinCodec.timeFields.map(_.name).toList ++ joinConf.leftKeyCols
+        timeFields.map(_.name).toList ++ joinConf.leftKeyCols
       }
       logger.info(s"Using ${joinKeys.mkString("[", ",", "]")} as join keys between log and backfill.")
       val (compareDf, metricsKvRdd, metrics) =

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -334,6 +334,11 @@ class FetcherTest extends TestCase {
                              windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS)))),
       metaData = Builders.MetaData(name = "unit_test/vendor_credit", namespace = namespace)
     )
+    val creditDerivationGroupBy = creditGroupBy.deepCopy().setDerivations(
+      Seq(
+        Builders.Derivation("credit_sum_2d", "credit_sum_2d_test_rename"),
+        Builders.Derivation("*", "*")
+      ).toJava)
 
     // temporal-entities
     val vendorReviewCols =
@@ -384,7 +389,8 @@ class FetcherTest extends TestCase {
         Builders.JoinPart(groupBy = userBalanceGroupBy, keyMapping = Map("user_id" -> "user")),
         Builders.JoinPart(groupBy = reviewGroupBy),
         Builders.JoinPart(groupBy = creditGroupBy, prefix = "b"),
-        Builders.JoinPart(groupBy = creditGroupBy, prefix = "a")
+        Builders.JoinPart(groupBy = creditGroupBy, prefix = "a"),
+        Builders.JoinPart(groupBy = creditDerivationGroupBy, prefix = "c")
       ),
       metaData = Builders.MetaData(name = "test/payments_join",
                                    namespace = namespace,
@@ -693,6 +699,11 @@ class FetcherTest extends TestCase {
     logger.info("====== Empty request response map ======")
     assertEquals(joinConf.joinParts.size() + joinConf.derivations.toScala.derivationsWithoutStar.size, responseMap.size)
     assertEquals(responseMap.keys.count(_.endsWith("_exception")), joinConf.joinParts.size())
+  }
+
+  def testGroupByDerivation(): Unit = {
+    val namespace = "groupby_derivation"
+    val joinConf = generateRandomData(namespace)
   }
 }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -336,7 +336,7 @@ class FetcherTest extends TestCase {
     )
     val creditDerivationGroupBy = creditGroupBy.deepCopy().setDerivations(
       Seq(
-        Builders.Derivation("credit_sum_2d", "credit_sum_2d_test_rename"),
+        Builders.Derivation("credit_sum_2d_test_rename", "credit_sum_2d"),
         Builders.Derivation("*", "*")
       ).toJava)
 

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -334,11 +334,19 @@ class FetcherTest extends TestCase {
                              windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS)))),
       metaData = Builders.MetaData(name = "unit_test/vendor_credit", namespace = namespace)
     )
-    val creditDerivationGroupBy = creditGroupBy.deepCopy().setDerivations(
-      Seq(
-        Builders.Derivation("credit_sum_2d_test_rename", "credit_sum_2d"),
+    val creditDerivationGroupBy = Builders.GroupBy(
+      sources = Seq(Builders.Source.entities(query = Builders.Query(), snapshotTable = creditTable)),
+      keyColumns = Seq("vendor_id"),
+      aggregations = Seq(
+        Builders.Aggregation(operation = Operation.SUM,
+          inputColumn = "credit",
+          windows = Seq(new Window(3, TimeUnit.DAYS)))),
+      metaData = Builders.MetaData(name = "unit_test/vendor_credit_derivation", namespace = namespace),
+      derivations = Seq(
+        Builders.Derivation("credit_sum_3d_test_rename", "credit_sum_3d"),
         Builders.Derivation("*", "*")
-      ).toJava)
+      )
+    )
 
     // temporal-entities
     val vendorReviewCols =
@@ -699,11 +707,6 @@ class FetcherTest extends TestCase {
     logger.info("====== Empty request response map ======")
     assertEquals(joinConf.joinParts.size() + joinConf.derivations.toScala.derivationsWithoutStar.size, responseMap.size)
     assertEquals(responseMap.keys.count(_.endsWith("_exception")), joinConf.joinParts.size())
-  }
-
-  def testGroupByDerivation(): Unit = {
-    val namespace = "groupby_derivation"
-    val joinConf = generateRandomData(namespace)
   }
 }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Currently feature derivation is only supported for online join. We want to support derivation for online groupBy fetch as well. 

After the code change, users will be able to 
1. Fetch group by data with defined derivation rules.
2. Fetch join data with defined derivation rules in join part.


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
For Airbnb useres, the local tests result are recorded in 
https://docs.google.com/document/d/1uuMkJ8WpQy3XPgfu89OsgdloLdwtLRhNSN6FE2XsHCY/edit?usp=sharing



## Checklist
- [x] Documentation update

## Reviewers
@better365 @nikhilsimha 
