### PR TITLE
[Fetcher] Don't throw for old query time; Use datadog to count it instead

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -82,7 +82,12 @@ class FetcherBase(kvStore: KVStore,
       val streamingResponses = streamingResponsesOpt.get
       val mutations: Boolean = servingInfo.groupByOps.dataModel == DataModel.Entities
       val aggregator: SawtoothOnlineAggregator = servingInfo.aggregator
-      if (batchBytes == null && (streamingResponses == null || streamingResponses.isEmpty)) {
+      if (aggregator.batchEndTs > queryTimeMs) {
+        context.incrementException(
+          new IllegalArgumentException(
+            s"Request time of $queryTimeMs is less than batch time ${aggregator.batchEndTs}"))
+        null
+      } else if (batchBytes == null && (streamingResponses == null || streamingResponses.isEmpty)) {
         if (debug) logger.info("Both batch and streaming data are null")
         null
       } else {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We got false alarm caused by old query time. In this PR, we will change it to use datadog to count the exceptions. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Avoid false alarms. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hanyuli1995 @donghanz 
