### PR TITLE
Fix the typo in the doc and README to `Because`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Let's start with three feature sets, built on top of our raw input sources.
 
 We can aggregate the purchases log data to the user level, to give us a view into this user's previous activity on our platform. Specifically, we can compute `SUM`s `COUNT`s and `AVERAGE`s of their previous purchase amounts over various windows.
 
-Becuase this feature is built upon a source that includes both a table and a topic, its features can be computed in both batch and streaming.
+Because this feature is built upon a source that includes both a table and a topic, its features can be computed in both batch and streaming.
 
 ```python
 source = Source(

--- a/docs/source/getting_started/Tutorial.md
+++ b/docs/source/getting_started/Tutorial.md
@@ -65,7 +65,7 @@ Let's start with three feature sets, built on top of our raw input sources.
 
 We can aggregate the purchases log data to the user level, to give us a view into this user's previous activity on our platform. Specifically, we can compute `SUM`s `COUNT`s and `AVERAGE`s of their previous purchase amounts over various windows.
 
-Becuase this feature is built upon a source that includes both a table and a topic, its features can be computed in both batch and streaming.
+Because this feature is built upon a source that includes both a table and a topic, its features can be computed in both batch and streaming.
 
 ```python
 source = Source(


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
 
Typo in the README and doc. Replace `Becuase` to `Because`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Improve quality of the doc and source code.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->

N/A

## Checklist
- [X] Documentation update

## Reviewers

