### PR TITLE
Add skew and kurtosis operations

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -770,8 +770,6 @@ case class MomentsIR(
 )
 
 // Uses Welford/Knuth method as the traditional sum of squares based formula has serious numerical stability problems
-// http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
-// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
 trait MomentAggregator extends SimpleAggregator[Double, MomentsIR, Double] {
   override def prepare(input: Double): MomentsIR = {
     val ir = MomentsIR(
@@ -785,6 +783,10 @@ trait MomentAggregator extends SimpleAggregator[Double, MomentsIR, Double] {
     update(ir, input)
   }
 
+  // Implementation is similar to the variance calculation above, but is extended to calculate the 3rd and 4th moments.
+  // References for the approach are here:
+  // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
+  // https://www.johndcook.com/blog/skewness_kurtosis/
   override def update(ir: MomentsIR, x: Double): MomentsIR = {
     val n1 = ir.n
     val n = ir.n + 1
@@ -810,6 +812,10 @@ trait MomentAggregator extends SimpleAggregator[Double, MomentsIR, Double] {
 
   override def irType: DataType = ListType(DoubleType)
 
+  // Implementation is similar to the variance calculation above, but is extended to calculate the 3rd and 4th moments.
+  // References for the approach are here:
+  // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
+  // https://www.johndcook.com/blog/skewness_kurtosis/
   override def merge(a: MomentsIR, b: MomentsIR): MomentsIR = {
     val n = a.n + b.n
     val delta = b.m1 - a.m1

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -760,3 +760,110 @@ class TopK[T: Ordering: ClassTag](inputType: DataType, k: Int)
     extends OrderByLimit[T](inputType, k, Ordering[T].reverse)
 
 class BottomK[T: Ordering: ClassTag](inputType: DataType, k: Int) extends OrderByLimit[T](inputType, k, Ordering[T])
+
+case class MomentsIR(
+    n: Double,
+    m1: Double,
+    m2: Double,
+    m3: Double,
+    m4: Double
+)
+
+// Uses Welford/Knuth method as the traditional sum of squares based formula has serious numerical stability problems
+// http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
+trait MomentAggregator extends SimpleAggregator[Double, MomentsIR, Double] {
+  override def prepare(input: Double): MomentsIR = {
+    val ir = MomentsIR(
+      n = 0,
+      m1 = 0,
+      m2 = 0,
+      m3 = 0,
+      m4 = 0
+    )
+
+    update(ir, input)
+  }
+
+  override def update(ir: MomentsIR, x: Double): MomentsIR = {
+    val n1 = ir.n
+    val n = ir.n + 1
+    val delta = x - ir.m1
+    val deltaN = delta / n
+    val deltaN2 = deltaN * deltaN
+    val term1 = delta * deltaN * n1
+    val m1 = ir.m1 + deltaN
+    val m4 = ir.m4 + term1 * deltaN2 * (n * n - 3 * n + 3) + 6 * deltaN2 * ir.m2 - 4 * deltaN * ir.m3
+    val m3 = ir.m3 + term1 * deltaN * (n - 2) - 3 * deltaN * ir.m2
+    val m2 = ir.m2 + term1
+
+    MomentsIR(
+      n = n,
+      m1 = m1,
+      m2 = m2,
+      m3 = m3,
+      m4 = m4
+    )
+  }
+
+  override def outputType: DataType = DoubleType
+
+  override def irType: DataType = ListType(DoubleType)
+
+  override def merge(a: MomentsIR, b: MomentsIR): MomentsIR = {
+    val n = a.n + b.n
+    val delta = b.m1 - a.m1
+    val delta2 = delta * delta
+    val delta3 = delta * delta2
+    val delta4 = delta2 * delta2
+
+    val m1 = (a.n * a.m1 + b.n * b.m1) / n
+    val m2 = a.m2 + b.m2 + delta2 * a.n * b.n / n
+    val m3 = a.m3 + b.m3 + delta3 * a.n * b.n * (a.n - b.n) / (n * n) +
+      3.0 * delta * (a.n * b.m2 - b.n * a.m2) / n
+    val m4 = a.m4 + b.m4 + delta4 * a.n * b.n * (a.n * a.n - a.n * b.n + b.n * b.n) / (n * n * n) +
+      6.0 * delta2 * (a.n * a.n * b.m2 + b.n * b.n * a.m2) / (n * n) + 4.0 * delta * (a.n * b.m3 - b.n * a.m3) / n
+
+    MomentsIR(
+      n = n,
+      m1 = m1,
+      m2 = m2,
+      m3 = m3,
+      m4 = m4
+    )
+  }
+
+  override def finalize(ir: MomentsIR): Double
+
+  override def clone(ir: MomentsIR): MomentsIR = {
+    MomentsIR(
+      n = ir.n,
+      m1 = ir.m1,
+      m2 = ir.m2,
+      m3 = ir.m3,
+      m4 = ir.m4
+    )
+  }
+
+  override def normalize(ir: MomentsIR): util.ArrayList[Double] = {
+    val values = List(ir.n, ir.m1, ir.m2, ir.m3, ir.m4)
+    new util.ArrayList[Double](values.asJava)
+  }
+
+  override def denormalize(normalized: Any): MomentsIR = {
+    val values = normalized.asInstanceOf[util.ArrayList[Double]].asScala
+    MomentsIR(values(0), values(1), values(2), values(3), values(4))
+  }
+
+  override def isDeletable = false
+}
+
+class Skew extends MomentAggregator {
+  override def finalize(ir: MomentsIR): Double =
+    if (ir.n < 3 || ir.m2 == 0) Double.NaN else Math.sqrt(ir.n) * ir.m3 / Math.pow(ir.m2, 1.5)
+}
+
+class Kurtosis extends MomentAggregator {
+  override def finalize(ir: MomentsIR): Double =
+    if (ir.n < 4 || ir.m2 == 0) Double.NaN else ir.n * ir.m4 / (ir.m2 * ir.m2) - 3
+}

--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
@@ -340,6 +340,26 @@ object ColumnAggregator {
           case _          => mismatchException
         }
 
+      case Operation.SKEW =>
+        inputType match {
+          case IntType    => simple(new Skew, toDouble[Int])
+          case LongType   => simple(new Skew, toDouble[Long])
+          case ShortType  => simple(new Skew, toDouble[Short])
+          case DoubleType => simple(new Skew)
+          case FloatType  => simple(new Skew, toDouble[Float])
+          case _          => mismatchException
+        }
+
+      case Operation.KURTOSIS =>
+        inputType match {
+          case IntType    => simple(new Kurtosis, toDouble[Int])
+          case LongType   => simple(new Kurtosis, toDouble[Long])
+          case ShortType  => simple(new Kurtosis, toDouble[Short])
+          case DoubleType => simple(new Kurtosis)
+          case FloatType  => simple(new Kurtosis, toDouble[Float])
+          case _          => mismatchException
+        }
+
       case Operation.MIN =>
         inputType match {
           case IntType    => simple(new Min[Int](inputType))

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MomentTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MomentTest.scala
@@ -1,0 +1,72 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.base._
+import junit.framework.TestCase
+import org.apache.commons.math3.stat.descriptive.moment.{Kurtosis => ApacheKurtosis, Skewness => ApacheSkew}
+import org.junit.Assert._
+
+class MomentTest extends TestCase {
+  def makeAgg(aggregator: MomentAggregator, values: Seq[Double]): (MomentAggregator, MomentsIR) = {
+    var ir = aggregator.prepare(values.head)
+
+    values.tail.foreach(v => {
+      ir = aggregator.update(ir, v)
+    })
+
+    (aggregator, ir)
+  }
+
+  def expectedSkew(values: Seq[Double]): Double = new ApacheSkew().evaluate(values.toArray)
+  def expectedKurtosis(values: Seq[Double]): Double = new ApacheKurtosis().evaluate(values.toArray)
+
+  def assertUpdate(aggregator: MomentAggregator, values: Seq[Double], expected: Seq[Double] => Double): Unit = {
+    val (agg, ir) = makeAgg(aggregator, values)
+    assertEquals(expected(values), agg.finalize(ir), 0.1)
+  }
+
+  def assertMerge(aggregator: MomentAggregator,
+                  v1: Seq[Double],
+                  v2: Seq[Double],
+                  expected: Seq[Double] => Double): Unit = {
+    val (agg, ir1) = makeAgg(aggregator, v1)
+    val (_, ir2) = makeAgg(aggregator, v2)
+
+    val ir = agg.merge(ir1, ir2)
+    assertEquals(expected(v1 ++ v2), agg.finalize(ir), 0.1)
+  }
+
+  def testUpdate(): Unit = {
+    val values = Seq(1.1, 2.2, 3.3, 4.4, 5.5)
+    assertUpdate(new Skew(), values, expectedSkew)
+    assertUpdate(new Kurtosis(), values, expectedKurtosis)
+  }
+
+  def testInsufficientSizes(): Unit = {
+    val values = Seq(1.1, 2.2, 3.3, 4.4)
+    assertUpdate(new Skew(), values.take(2), _ => Double.NaN)
+    assertUpdate(new Kurtosis(), values.take(3), _ => Double.NaN)
+  }
+
+  def testNoVariance(): Unit = {
+    val values = Seq(1.0, 1.0, 1.0, 1.0)
+    assertUpdate(new Skew(), values, _ => Double.NaN)
+    assertUpdate(new Kurtosis(), values, _ => Double.NaN)
+  }
+
+  def testMerge(): Unit = {
+    val values1 = Seq(1.1, 2.2, 3.3)
+    val values2 = Seq(4.4, 5.5)
+    assertMerge(new Kurtosis(), values1, values2, expectedKurtosis)
+    assertMerge(new Skew(), values1, values2, expectedSkew)
+  }
+
+  def testNormalize(): Unit = {
+    val values = Seq(1.0, 2.0, 3.0, 4.0, 5.0)
+    val (agg, ir) = makeAgg(new Kurtosis, values)
+
+    val normalized = agg.normalize(ir)
+    val denormalized = agg.denormalize(normalized)
+
+    assertEquals(ir, denormalized)
+  }
+}

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -68,6 +68,8 @@ class Operation:
     SUM = ttypes.Operation.SUM
     AVERAGE = ttypes.Operation.AVERAGE
     VARIANCE = ttypes.Operation.VARIANCE
+    SKEW = ttypes.Operation.SKEW
+    KURTOSIS = ttypes.Operation.KURTOSIS
     HISTOGRAM = ttypes.Operation.HISTOGRAM
     # k truncates the map to top_k most frequent items, 0 turns off truncation
     HISTOGRAM_K = collector(ttypes.Operation.HISTOGRAM)

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -150,8 +150,8 @@ enum Operation {
     SUM = 7
     AVERAGE = 8
     VARIANCE = 9
-    SKEW = 10     // TODO
-    KURTOSIS = 11  // TODO
+    SKEW = 10
+    KURTOSIS = 11
     APPROX_PERCENTILE = 12
 
     LAST_K = 13

--- a/docs/source/authoring_features/GroupBy.md
+++ b/docs/source/authoring_features/GroupBy.md
@@ -133,19 +133,20 @@ Limitations:
 
 ## Table of properties for aggregations
 
-| aggregation         | input type      | nesting allowed? | output type       | reversible | parameters         | bounded memory |
-|---------------------|-----------------|------------------|-------------------|------------|--------------------|----------------|
-| count               | all types       | list, map        | long              | yes        |                    | yes            |
-| min, max            | primitive types | list, map        | input             | no         |                    | yes            |
-| top_k, bottom_k     | primitive types | list, map        | list<input,>      | no         | k                  | yes            |
-| first, last         | all types       | NO               | input             | no         |                    | yes            |
-| first_k, last_k     | all types       | NO               | list<input,>      | no         | k                  | yes            |
-| average, variance   | numeric types   | list, map        | double            | yes        |                    | yes            |
-| histogram           | string          | list, map        | map<string, long> | yes        | k=inf              | no             |
-| approx_histogram_k  | primitive types | list, map        | map<string, long> | yes        | k=inf              | yes            |
-| approx_unique_count | primitive types | list, map        | long              | no         | k=8                | yes            |
-| approx_percentile   | primitive types | list, map        | list<input,>      | no         | k=128, percentiles | yes            |
-| unique_count        | primitive types | list, map        | long              | no         |                    | no             |
+| aggregation              | input type      | nesting allowed? | output type       | reversible | parameters         | bounded memory |
+|--------------------------|-----------------|------------------|-------------------|------------|--------------------|----------------|
+| count                    | all types       | list, map        | long              | yes        |                    | yes            |
+| min, max                 | primitive types | list, map        | input             | no         |                    | yes            |
+| top_k, bottom_k          | primitive types | list, map        | list<input,>      | no         | k                  | yes            |
+| first, last              | all types       | NO               | input             | no         |                    | yes            |
+| first_k, last_k          | all types       | NO               | list<input,>      | no         | k                  | yes            |
+| average                  | numeric types   | list, map        | double            | yes        |                    | yes            |
+| variance, skew, kurtosis | numeric types   | list, map        | double            | no         |                    | yes            |
+| histogram                | string          | list, map        | map<string, long> | yes        | k=inf              | no             |
+| approx_histogram_k       | primitive types | list, map        | map<string, long> | yes        | k=inf              | yes            |
+| approx_unique_count      | primitive types | list, map        | long              | no         | k=8                | yes            |
+| approx_percentile        | primitive types | list, map        | list<input,>      | no         | k=128, percentiles | yes            |
+| unique_count             | primitive types | list, map        | long              | no         |                    | no             |
 
 
 ## Accuracy

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -85,6 +85,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.types.Metadata",
       "ai.chronon.api.Row",
       "ai.chronon.spark.KeyWithHash",
+      "ai.chronon.aggregator.base.MomentsIR",
       "ai.chronon.aggregator.windowing.BatchIr",
       "ai.chronon.aggregator.base.ApproxHistogramIr",
       "ai.chronon.online.RowWrapper",

--- a/spark/src/main/scala/ai/chronon/spark/Comparison.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Comparison.scala
@@ -18,7 +18,7 @@ package ai.chronon.spark
 
 import org.slf4j.LoggerFactory
 import ai.chronon.online.Extensions.StructTypeOps
-import com.google.gson.Gson
+import com.google.gson.{Gson, GsonBuilder}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{DecimalType, DoubleType, FloatType, MapType}
 
@@ -32,7 +32,9 @@ object Comparison {
     if (m == null) return null
     val tm = new util.TreeMap[String, Any]()
     m.iterator.foreach { case (key, value) => tm.put(key, value) }
-    val gson = new Gson()
+    val gson = new GsonBuilder()
+      .serializeSpecialFloatingPointValues()
+      .create()
     gson.toJson(tm)
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -232,6 +232,11 @@ class FetcherTest extends TestCase {
           operation = Operation.AVERAGE,
           inputColumn = "rating",
           windows = Seq(new Window(1, TimeUnit.DAYS))
+        ),
+        Builders.Aggregation(
+          operation = Operation.SKEW,
+          inputColumn = "rating",
+          windows = Seq(new Window(1, TimeUnit.DAYS))
         )
       ),
       accuracy = Accuracy.TEMPORAL,
@@ -294,6 +299,10 @@ class FetcherTest extends TestCase {
       keyColumns = Seq("vendor"),
       aggregations = Seq(
         Builders.Aggregation(operation = Operation.AVERAGE,
+                             inputColumn = "rating",
+                             windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS)),
+                             buckets = Seq("bucket")),
+        Builders.Aggregation(operation = Operation.SKEW,
                              inputColumn = "rating",
                              windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS)),
                              buckets = Seq("bucket")),

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -617,4 +617,43 @@ class GroupByTest {
     }
     assertEquals(0, diff.count())
   }
+
+  @Test
+  def testDescriptiveStats(): Unit = {
+    val (source, endPartition) = createTestSource(suffix = "_descriptive_stats")
+    val tableUtils = TableUtils(spark)
+    val namespace = "test_descriptive_stats"
+    val aggs = Seq(
+      Builders.Aggregation(
+        operation = Operation.VARIANCE,
+        inputColumn = "price",
+        windows = Seq(
+          new Window(15, TimeUnit.DAYS),
+          new Window(60, TimeUnit.DAYS)
+        )
+      ),
+      Builders.Aggregation(
+        operation = Operation.SKEW,
+        inputColumn = "price",
+        windows = Seq(
+          new Window(15, TimeUnit.DAYS),
+          new Window(60, TimeUnit.DAYS)
+        )
+      ),
+      Builders.Aggregation(
+        operation = Operation.KURTOSIS,
+        inputColumn = "price",
+        windows = Seq(
+          new Window(15, TimeUnit.DAYS),
+          new Window(60, TimeUnit.DAYS)
+        )
+      ),
+    )
+    backfill(name = "unit_test_group_by_descriptive_stats",
+      source = source,
+      endPartition = endPartition,
+      namespace = namespace,
+      tableUtils = tableUtils,
+      additionalAgg = aggs)
+  }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -339,12 +339,12 @@ class GroupByTest {
 
     print(aggregationsMetadata)
     assertTrue(aggregationsMetadata.length == 2)
+
     val columns = aggregationsMetadata.map(a => a.name -> a.columnType).toMap
     assertEquals(Map(
-                   "time_spent_ms" -> LongType,
-                   "price" -> DoubleType
-                 ),
-                 columns)
+      "time_spent_ms" -> LongType,
+      "price" -> DoubleType
+    ), columns)
   }
 
   // test that OrderByLimit and OrderByLimitTimed serialization works well with Spark's data type
@@ -414,8 +414,8 @@ class GroupByTest {
     tableUtils.createDatabase(namespace)
     DataFrameGen.events(spark, sourceSchema, count = 1000, partitions = 200).save(sourceTable)
     val source = Builders.Source.events(
-      query = Builders.Query(selects = Builders.Selects("ts", "item", "time_spent_ms", "price"),
-                             startPartition = startPartition),
+      query =
+        Builders.Query(selects = Builders.Selects("ts", "item", "time_spent_ms", "price"), startPartition = startPartition),
       table = sourceTable
     )
     (source, endPartition)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adds operations for [skew](https://en.wikipedia.org/wiki/Skew) and [kurtosis](https://en.wikipedia.org/wiki/Kurtosis). 

The implementation uses the same Welford/Knuth approach as the variance operation.
https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics

I have the operations set as non-deletable as the reversals weren't straightforward (variance is also set this way). 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
We have existing features in our previous feature store which rely on these statistics. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [x] Documentation update

## Reviewers

