### PR TITLE
Unsetting wheres for left query when using bootstrap and adding joinSource logic

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -348,7 +348,7 @@ object Extensions {
       if (source.isSetEntities) { source.getEntities.setSnapshotTable(table) }
       else if (source.isSetEvents) { source.getEvents.setTable(table) }
       else {
-        val metadata = source.getJoinSource.getJoin.metaData
+        val metadata = source.getJoinSource.getJoin.getMetaData
         val Array(namespace, tableName) = table.split(".")
         metadata.setOutputNamespace(namespace)
         metadata.setName(tableName)

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -344,6 +344,17 @@ object Extensions {
       else { source.getJoinSource.getJoin.metaData.outputTable }
     }
 
+    def overwriteTable(table: String): Unit = {
+      if (source.isSetEntities) { source.getEntities.setSnapshotTable(table) }
+      else if (source.isSetEvents) { source.getEvents.setTable(table) }
+      else {
+        val metadata = source.getJoinSource.getJoin.metaData
+        val Array(namespace, tableName) = table.split(".")
+        metadata.setOutputNamespace(namespace)
+        metadata.setName(tableName)
+      }
+    }
+
     def table: String = rawTable.cleanSpec
 
     def subPartitionFilters: Map[String, String] = {

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -411,7 +411,6 @@ abstract class JoinBase(joinConf: api.Join,
     }
 
     val source = joinConf.left
-
     if (useBootstrapForLeft) {
       logger.info("Overwriting left side to use saved Bootstrap table...")
       source.overwriteTable(bootstrapTable)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -411,15 +411,14 @@ abstract class JoinBase(joinConf: api.Join,
     }
 
     val source = joinConf.left
-    if (useBootstrapForLeft && !source.isSetJoinSource) {
+
+    if (useBootstrapForLeft) {
       logger.info("Overwriting left side to use saved Bootstrap table...")
-      if (source.isSetEntities) {
-        source.getEntities.setSnapshotTable(bootstrapTable)
-        source.getEntities.getQuery.setSelects(null)
-      } else if (source.isSetEvents) {
-        source.getEvents.setTable(bootstrapTable)
-        source.getEvents.getQuery.setSelects(null)
-      }
+      source.overwriteTable(bootstrapTable)
+      val query = source.query
+      // Selects map and where clauses already applied to bootstrap transformation
+      query.setSelects(null)
+      query.setWheres(null)
     }
 
     // Run validations before starting the job

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -416,7 +416,7 @@ abstract class JoinBase(joinConf: api.Join,
       logger.info("Overwriting left side to use saved Bootstrap table...")
       source.overwriteTable(bootstrapTable)
       val query = source.query
-      // Selects map and where clauses already applied to bootstrap transformation
+      // sets map and where clauses already applied to bootstrap transformation
       query.setSelects(null)
       query.setWheres(null)
     }


### PR DESCRIPTION
## Summary
Unsetting `wheres` when using bootstrap because wheres already applied to left side.
Implementing table overwrite for bootstrap for joinSource case.

## Why / Goal
Fixes column not found bug.


## Test Plan

- [ ] Devbox test

## Reviewers
@hzding621 @donghanz 
