### PR TITLE
Add metadata upload to Mussel by team

### DIFF
--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -213,7 +213,6 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     }
   }
 
-
   // process chronon configs only. others will be ignored
   // todo: add metrics
   private def loadJson[T <: TBase[_, _]: Manifest: ClassTag](file: String): Option[String] = {
@@ -226,7 +225,6 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         None
     }
   }
-
 
   def parseName(path: String): Option[String] = {
     val gson = new Gson()
@@ -275,9 +273,9 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
                          |key: $key
                          |conf: $value""".stripMargin)
           PutRequest(keyBytes = key.getBytes(),
-            valueBytes = value.getBytes(),
-            dataset = dataset,
-            tsMillis = Some(System.currentTimeMillis()))
+                     valueBytes = value.getBytes(),
+                     dataset = dataset,
+                     tsMillis = Some(System.currentTimeMillis()))
         }
       }
     val putsBatches = puts.grouped(CONF_BATCH_SIZE).toSeq
@@ -300,27 +298,26 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         name.isDefined
       }
 
-    val kvPairs: Map[String, List[String]] = validFileList.foldLeft(Map.empty[String, List[String]]) {
-        (map, file) => {
-          val path = file.getPath
-          val key = pathToTeam(path)
-          val value = pathToKey(path)
-          val updatedList = map.getOrElse(key, List()) :+ value
-          map + (key -> updatedList)
+    val kvPairs: Map[String, List[String]] = validFileList.foldLeft(Map.empty[String, List[String]]) { (map, file) =>
+      {
+        val path = file.getPath
+        val key = pathToTeam(path)
+        val value = pathToKey(path)
+        val updatedList = map.getOrElse(key, List()) :+ value
+        map + (key -> updatedList)
       }
     }
 
     val puts: Seq[PutRequest] = kvPairs.map {
       case (key, list) => {
         val listStr = list.toString()
-        logger.info(
-          s"""Putting metadata for
+        logger.info(s"""Putting metadata for
              |key: $key
              |conf: $listStr""".stripMargin)
         PutRequest(keyBytes = key.getBytes(),
-          valueBytes = listStr.getBytes(),
-          dataset = dataset,
-          tsMillis = Some(System.currentTimeMillis()))
+                   valueBytes = listStr.getBytes(),
+                   dataset = dataset,
+                   tsMillis = Some(System.currentTimeMillis()))
       }
     }.toSeq
 

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -222,7 +222,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     val putsByName: Seq[PutRequest] = putConfByName(fileList)
 
     // Upload entities list to KV store by team to KV store
-    val putsByTeam: Seq[PutRequest] = putConfByName(fileList)
+    val putsByTeam: Seq[PutRequest] = putConfByTeam(fileList)
 
     val puts = putsByName ++ putsByTeam
 

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -161,11 +161,10 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     confPath.split("/").takeRight(3)(1)
   }
 
-
   def putConfByKey(
-    configPath: String,
-    keyFunc: String => String,
-    valueFunc: String => Option[String]
+      configPath: String,
+      keyFunc: String => String,
+      valueFunc: String => Option[String]
   ): Future[Seq[Boolean]] = {
     val configFile = new File(configPath)
     assert(configFile.exists(), s"$configFile does not exist")
@@ -188,47 +187,15 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
                          |key: $key
                          |conf: $value""".stripMargin)
           PutRequest(keyBytes = key.getBytes(),
-            valueBytes = value.getBytes(),
-            dataset = dataset,
-            tsMillis = Some(System.currentTimeMillis()))
+                     valueBytes = value.getBytes(),
+                     dataset = dataset,
+                     tsMillis = Some(System.currentTimeMillis()))
         }
       }
     val putsBatches = puts.grouped(CONF_BATCH_SIZE).toSeq
     logger.info(s"Putting ${puts.size} configs to KV Store, dataset=$dataset")
     val futures = putsBatches.map(batch => kvStore.multiPut(batch))
     Future.sequence(futures).map(_.flatten)
-  }
-
-  // upload the materialized JSONs to KV store:
-  // key = <conf_type>/<team>/<conf_name> in bytes e.g joins/team/team.example_join.v1 value = materialized json string in bytes
-  def putConfByName(configPath: String): Future[Seq[Boolean]] = {
-    def keyFunc(confPath: String): String = {
-      pathToKey(confPath)
-    }
-
-    def valueFunc(confPath: String): Option[String] = {
-      val confJsonOpt = confPath match {
-        case value if value.contains("staging_queries/") => loadJson[StagingQuery](value)
-        case value if value.contains("joins/")           => loadJson[Join](value)
-        case value if value.contains("group_bys/")       => loadJson[GroupBy](value)
-        case _                                           => logger.info(s"unknown config type in file $confPath"); None
-      }
-      confJsonOpt
-    }
-
-    putConfByKey(configPath, keyFunc, valueFunc)
-  }
-
-  def putConfByTeam(configPath: String): Future[Seq[Boolean]] = {
-    def keyFunc(confPath: String): String = {
-      pathToTeam(confPath)
-    }
-
-    def valueFunc(confPath: String): Option[String] = {
-      Some(pathToKey(confPath))
-    }
-
-    putConfByKey(configPath, keyFunc, valueFunc)
   }
 
   // list file recursively
@@ -246,6 +213,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     }
   }
 
+
   // process chronon configs only. others will be ignored
   // todo: add metrics
   private def loadJson[T <: TBase[_, _]: Manifest: ClassTag](file: String): Option[String] = {
@@ -258,6 +226,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         None
     }
   }
+
 
   def parseName(path: String): Option[String] = {
     val gson = new Gson()
@@ -275,5 +244,89 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         ex.printStackTrace()
         None
     }
+  }
+
+  // upload the materialized JSONs to KV store:
+  // key = <conf_type>/<team>/<conf_name> in bytes e.g joins/team/team.example_join.v1 value = materialized json string in bytes
+  def putConfByName(configPath: String): Future[Seq[Boolean]] = {
+    val configFile = new File(configPath)
+    assert(configFile.exists(), s"$configFile does not exist")
+    logger.info(s"Uploading Chronon configs from $configPath")
+    val fileList = listFiles(configFile)
+
+    val puts: Seq[PutRequest] = fileList
+      .filter { file =>
+        val name = parseName(file.getPath)
+        if (name.isEmpty) logger.info(s"Skipping invalid file ${file.getPath}")
+        name.isDefined
+      }
+      .flatMap { file =>
+        val path = file.getPath
+        val key = pathToKey(path)
+        val confJsonOpt = path match {
+          case value if value.contains("staging_queries/") => loadJson[StagingQuery](value)
+          case value if value.contains("joins/")           => loadJson[Join](value)
+          case value if value.contains("group_bys/")       => loadJson[GroupBy](value)
+          case _                                           => logger.info(s"unknown config type in file $path"); None
+        }
+
+        confJsonOpt.map { value =>
+          logger.info(s"""Putting metadata for
+                         |key: $key
+                         |conf: $value""".stripMargin)
+          PutRequest(keyBytes = key.getBytes(),
+            valueBytes = value.getBytes(),
+            dataset = dataset,
+            tsMillis = Some(System.currentTimeMillis()))
+        }
+      }
+    val putsBatches = puts.grouped(CONF_BATCH_SIZE).toSeq
+    logger.info(s"Putting ${puts.size} configs to KV Store, dataset=$dataset")
+    val futures = putsBatches.map(batch => kvStore.multiPut(batch))
+    Future.sequence(futures).map(_.flatten)
+  }
+
+  def putConfByTeam(configPath: String): Future[Seq[Boolean]] = {
+
+    val configFile = new File(configPath)
+    assert(configFile.exists(), s"$configFile does not exist")
+    logger.info(s"Uploading Chronon configs from $configPath")
+    val fileList = listFiles(configFile)
+    val nameByTeam: Map[String, List[String]] = Map()
+    val validFileList = fileList
+      .filter { file =>
+        val name = parseName(file.getPath)
+        if (name.isEmpty) logger.info(s"Skipping invalid file ${file.getPath}")
+        name.isDefined
+      }
+
+    val kvPairs: Map[String, List[String]] = validFileList.foldLeft(Map.empty[String, List[String]]) {
+        (map, file) => {
+          val path = file.getPath
+          val key = pathToTeam(path)
+          val value = pathToKey(path)
+          val updatedList = map.getOrElse(key, List()) :+ value
+          map + (key -> updatedList)
+      }
+    }
+
+    val puts: Seq[PutRequest] = kvPairs.map {
+      case (key, list) => {
+        val listStr = list.toString()
+        logger.info(
+          s"""Putting metadata for
+             |key: $key
+             |conf: $listStr""".stripMargin)
+        PutRequest(keyBytes = key.getBytes(),
+          valueBytes = listStr.getBytes(),
+          dataset = dataset,
+          tsMillis = Some(System.currentTimeMillis()))
+      }
+    }.toSeq
+
+    val putsBatches = puts.grouped(CONF_BATCH_SIZE).toSeq
+    logger.info(s"Putting ${puts.size} configs to KV Store, dataset=$dataset")
+    val futures = putsBatches.map(batch => kvStore.multiPut(batch))
+    Future.sequence(futures).map(_.flatten)
   }
 }

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -162,7 +162,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
   }
 
   // list file recursively
-  def listFiles(base: File, recursive: Boolean = true): Seq[File] = {
+  private def listFiles(base: File, recursive: Boolean = true): Seq[File] = {
     if (base.isFile) {
       Seq(base)
     } else {
@@ -178,7 +178,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
   // process chronon configs only. others will be ignored
   // todo: add metrics
-  def loadJson[T <: TBase[_, _]: Manifest: ClassTag](file: String): Option[String] = {
+  private def loadJson[T <: TBase[_, _]: Manifest: ClassTag](file: String): Option[String] = {
     try {
       val configConf = ThriftJsonCodec.fromJsonFile[T](file, check = true)
       Some(ThriftJsonCodec.toJsonStr(configConf))
@@ -207,6 +207,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     }
   }
 
+  // upload the metadata to KV store:
   def putConf(configPath: String): Future[Seq[Boolean]] = {
     val configFile = new File(configPath)
     assert(configFile.exists(), s"$configFile does not exist")
@@ -217,7 +218,10 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
       name.isDefined
     }
 
+    // Upload materialized JSONs to KV store by name to KV store
     val putsByName: Seq[PutRequest] = putConfByName(fileList)
+
+    // Upload entities list to KV store by team to KV store
     val putsByTeam: Seq[PutRequest] = putConfByName(fileList)
 
     val puts = putsByName ++ putsByTeam

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -157,7 +157,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
   // derive team from path to file
   def pathToTeam(confPath: String): String = {
-    //  // capture <conf_type>/<team> as key e.g joins/team
+    //  capture <conf_type>/<team> as key e.g group_bys/host_churn
     confPath.split("/").takeRight(3).take(2).mkString("/")
   }
 
@@ -284,6 +284,9 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     Future.sequence(futures).map(_.flatten)
   }
 
+  // upload the configs list by team to KV store:
+  // key = <conf_type>/<team> in bytes, e.g group_bys/host_churn
+  // value = list of config names in bytes, e.g List(group_bys/host_churn/agg_p2_impressions.v1, group_bys/host_churn/agg_deactivations.v1)
   def putConfByTeam(configPath: String): Future[Seq[Boolean]] = {
 
     val configFile = new File(configPath)

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -276,12 +276,13 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
     val puts: Seq[PutRequest] = kvPairs.map {
       case (key, list) => {
-        val listStr = list.toString()
+        val gson = new Gson()
+        val jsonString = gson.toJson(list)
         logger.info(s"""Putting metadata for
              |key: $key
-             |conf: $listStr""".stripMargin)
+             |conf: $jsonString""".stripMargin)
         PutRequest(keyBytes = key.getBytes(),
-                   valueBytes = listStr.getBytes(),
+                   valueBytes = jsonString.getBytes(),
                    dataset = dataset,
                    tsMillis = Some(System.currentTimeMillis()))
       }

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -39,7 +39,7 @@ case class DataMetrics(series: Seq[(Long, SortedMap[String, Any])])
 class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, timeoutMillis: Long) {
   @transient implicit lazy val logger = LoggerFactory.getLogger(getClass)
   private var partitionSpec = PartitionSpec(format = "yyyy-MM-dd", spanMillis = WindowUtils.Day.millis)
-  private val CONF_BATCH_SIZE = 50
+  private val CONF_BATCH_SIZE = 100
 
   // Note this should match with the format used in the warehouse
   def setPartitionMeta(format: String, spanMillis: Long): Unit = {

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -157,8 +157,8 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
   // derive team from path to file
   def pathToTeam(confPath: String): String = {
-    // capture team as key
-    confPath.split("/").takeRight(3)(1)
+    //  // capture <conf_type>/<team> as key e.g joins/team
+    confPath.split("/").takeRight(3).take(2).mkString("/")
   }
 
   def putConfByKey(

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -53,7 +53,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
   implicit val executionContext: ExecutionContext = kvStore.executionContext
 
-  def getConf[T <: TBase[_, _] : Manifest](confPathOrName: String): Try[T] = {
+  def getConf[T <: TBase[_, _]: Manifest](confPathOrName: String): Try[T] = {
     val clazz = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
     val confKey = confPathOrName.confPathToKey
     kvStore
@@ -97,8 +97,8 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     logger.info(s"uploading join conf to dataset: $dataset by key: joins/${join.metaData.nameToFilePath}")
     kvStore.put(
       PutRequest(s"joins/${join.metaData.nameToFilePath}".getBytes(Constants.UTF8),
-        ThriftJsonCodec.toJsonStr(join).getBytes(Constants.UTF8),
-        dataset))
+                 ThriftJsonCodec.toJsonStr(join).getBytes(Constants.UTF8),
+                 dataset))
   }
 
   def getSchemaFromKVStore(dataset: String, key: String): AvroCodec = {
@@ -135,8 +135,8 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         if (metaData.isFailure) {
           Failure(
             new RuntimeException(s"Couldn't fetch group by serving info for $batchDataset, " +
-              s"please make sure a batch upload was successful",
-              metaData.failed.get))
+                                   s"please make sure a batch upload was successful",
+                                 metaData.failed.get))
         } else {
           val groupByServingInfo = ThriftJsonCodec
             .fromJsonStr[GroupByServingInfo](metaData.get, check = true, classOf[GroupByServingInfo])
@@ -161,7 +161,6 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     confPath.split("/").takeRight(3).take(2).mkString("/")
   }
 
-
   // list file recursively
   def listFiles(base: File, recursive: Boolean = true): Seq[File] = {
     if (base.isFile) {
@@ -179,7 +178,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
   // process chronon configs only. others will be ignored
   // todo: add metrics
-  def loadJson[T <: TBase[_, _] : Manifest : ClassTag](file: String): Option[String] = {
+  def loadJson[T <: TBase[_, _]: Manifest: ClassTag](file: String): Option[String] = {
     try {
       val configConf = ThriftJsonCodec.fromJsonFile[T](file, check = true)
       Some(ThriftJsonCodec.toJsonStr(configConf))
@@ -227,20 +226,19 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         val key = pathToKey(path)
         val confJsonOpt = path match {
           case value if value.contains("staging_queries/") => loadJson[StagingQuery](value)
-          case value if value.contains("joins/") => loadJson[Join](value)
-          case value if value.contains("group_bys/") => loadJson[GroupBy](value)
-          case _ => logger.info(s"unknown config type in file $path"); None
+          case value if value.contains("joins/")           => loadJson[Join](value)
+          case value if value.contains("group_bys/")       => loadJson[GroupBy](value)
+          case _                                           => logger.info(s"unknown config type in file $path"); None
         }
 
         confJsonOpt.map { value =>
-          logger.info(
-            s"""Putting metadata for
+          logger.info(s"""Putting metadata for
                |key: $key
                |conf: $value""".stripMargin)
           PutRequest(keyBytes = key.getBytes(),
-            valueBytes = value.getBytes(),
-            dataset = dataset,
-            tsMillis = Some(System.currentTimeMillis()))
+                     valueBytes = value.getBytes(),
+                     dataset = dataset,
+                     tsMillis = Some(System.currentTimeMillis()))
         }
       }
     val putsBatches = puts.grouped(CONF_BATCH_SIZE).toSeq
@@ -266,26 +264,26 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
         name.isDefined
       }
 
-    val kvPairs: Map[String, List[String]] = validFileList.foldLeft(Map.empty[String, List[String]]) { (map, file) => {
-      val path = file.getPath
-      val key = pathToTeam(path)
-      val value = pathToKey(path)
-      val updatedList = map.getOrElse(key, List()) :+ value
-      map + (key -> updatedList)
-    }
+    val kvPairs: Map[String, List[String]] = validFileList.foldLeft(Map.empty[String, List[String]]) { (map, file) =>
+      {
+        val path = file.getPath
+        val key = pathToTeam(path)
+        val value = pathToKey(path)
+        val updatedList = map.getOrElse(key, List()) :+ value
+        map + (key -> updatedList)
+      }
     }
 
     val puts: Seq[PutRequest] = kvPairs.map {
       case (key, list) => {
         val listStr = list.toString()
-        logger.info(
-          s"""Putting metadata for
+        logger.info(s"""Putting metadata for
              |key: $key
              |conf: $listStr""".stripMargin)
         PutRequest(keyBytes = key.getBytes(),
-          valueBytes = listStr.getBytes(),
-          dataset = dataset,
-          tsMillis = Some(System.currentTimeMillis()))
+                   valueBytes = listStr.getBytes(),
+                   dataset = dataset,
+                   tsMillis = Some(System.currentTimeMillis()))
       }
     }.toSeq
 

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -276,8 +276,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
 
     val puts: Seq[PutRequest] = kvPairs.map {
       case (key, list) => {
-        val gson = new Gson()
-        val jsonString = gson.toJson(list)
+        val jsonString = "[" + list.map(name => "\"" + name + "\"").mkString(",") + "]"
         logger.info(s"""Putting metadata for
              |key: $key
              |conf: $jsonString""".stripMargin)

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -723,10 +723,14 @@ object Driver {
     }
 
     def run(args: Args): Unit = {
-      val putRequest = args.metaDataStore.putConf(args.confPath())
+      val putRequest = args.metaDataStore.putConfByName(args.confPath())
       val res = Await.result(putRequest, 1.hour)
       logger.info(
-        s"Uploaded Chronon Configs to the KV store, success count = ${res.count(v => v)}, failure count = ${res.count(!_)}")
+        s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v => v)}, failure count = ${res.count(!_)}")
+      val putByTeamRequest = args.metaDataStore.putConfByTeam(args.confPath())
+      val resByTeam = Await.result(putByTeamRequest, 1.hour)
+      logger.info(
+        s"Uploaded Chronon ${args.confPath} entity by team to the KV store, success count = ${resByTeam.count(v => v)}, failure count = ${resByTeam.count(!_)}")
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -723,10 +723,11 @@ object Driver {
     }
 
     def run(args: Args): Unit = {
-      val putRequest = args.metaDataStore.putConfByName(args.confPath())
+      /*val putRequest = args.metaDataStore.putConfByName(args.confPath())
       val res = Await.result(putRequest, 1.hour)
       logger.info(
         s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v => v)}, failure count = ${res.count(!_)}")
+      */
       val putByTeamRequest = args.metaDataStore.putConfByTeam(args.confPath())
       val resByTeam = Await.result(putByTeamRequest, 1.hour)
       logger.info(

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -725,12 +725,12 @@ object Driver {
     def run(args: Args): Unit = {
       val putRequest = args.metaDataStore.putConfByName(args.confPath())
       val res = Await.result(putRequest, 1.hour)
-      logger.info(
-        s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v => v)}, failure count = ${res.count(!_)}")
+      logger.info(s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v =>
+        v)}, failure count = ${res.count(!_)}")
       val putByTeamRequest = args.metaDataStore.putConfByTeam(args.confPath())
       val resByTeam = Await.result(putByTeamRequest, 1.hour)
-      logger.info(
-        s"Uploaded Chronon ${args.confPath} entity by team to the KV store, success count = ${resByTeam.count(v => v)}, failure count = ${resByTeam.count(!_)}")
+      logger.info(s"Uploaded Chronon ${args.confPath} entity by team to the KV store, success count = ${resByTeam.count(
+        v => v)}, failure count = ${resByTeam.count(!_)}")
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -732,10 +732,10 @@ object Driver {
     }
 
     def run(args: Args): Unit = {
-      val putRequest = args.metaDataStore.putConfByName(args.confPath())
+      /*val putRequest = args.metaDataStore.putConfByName(args.confPath())
       val res = Await.result(putRequest, 1.hour)
       logger.info(s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v =>
-        v)}, failure count = ${res.count(!_)}")
+        v)}, failure count = ${res.count(!_)}")*/
       val putByTeamRequest = args.metaDataStore.putConfByTeam(args.confPath())
       val resByTeam = Await.result(putByTeamRequest, 1.hour)
       logger.info(s"Uploaded Chronon ${args.confPath} entity by team to the KV store, success count = ${resByTeam.count(

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -723,11 +723,10 @@ object Driver {
     }
 
     def run(args: Args): Unit = {
-      /*val putRequest = args.metaDataStore.putConfByName(args.confPath())
+      val putRequest = args.metaDataStore.putConfByName(args.confPath())
       val res = Await.result(putRequest, 1.hour)
       logger.info(
         s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v => v)}, failure count = ${res.count(!_)}")
-      */
       val putByTeamRequest = args.metaDataStore.putConfByTeam(args.confPath())
       val resByTeam = Await.result(putByTeamRequest, 1.hour)
       logger.info(

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -732,14 +732,10 @@ object Driver {
     }
 
     def run(args: Args): Unit = {
-      /*val putRequest = args.metaDataStore.putConfByName(args.confPath())
-      val res = Await.result(putRequest, 1.hour)
+      val putRequests = args.metaDataStore.putConf(args.confPath())
+      val res = Await.result(putRequests, 1.hour)
       logger.info(s"Uploaded Chronon ${args.confPath} Configs to the KV store, success count = ${res.count(v =>
-        v)}, failure count = ${res.count(!_)}")*/
-      val putByTeamRequest = args.metaDataStore.putConfByTeam(args.confPath())
-      val resByTeam = Await.result(putByTeamRequest, 1.hour)
-      logger.info(s"Uploaded Chronon ${args.confPath} entity by team to the KV store, success count = ${resByTeam.count(
-        v => v)}, failure count = ${resByTeam.count(!_)}")
+        v)}, failure count = ${res.count(!_)}")
     }
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -74,7 +74,7 @@ class FetcherTest extends TestCase {
     val singleFileMetadataStore = new MetadataStore(inMemoryKvStore, singleFileDataSet, timeoutMillis = 10000)
     inMemoryKvStore.create(singleFileDataSet)
     // set the working directory to /chronon instead of $MODULE_DIR in configuration if Intellij fails testing
-    val singleFilePut = singleFileMetadataStore.putConf(confResource.getPath)
+    val singleFilePut = singleFileMetadataStore.putConfByName(confResource.getPath)
     Await.result(singleFilePut, Duration.Inf)
     val response = inMemoryKvStore.get(GetRequest(joinPath.getBytes(), singleFileDataSet))
     val res = Await.result(response, Duration.Inf)
@@ -86,7 +86,7 @@ class FetcherTest extends TestCase {
     val directoryDataSetDataSet = ChrononMetadataKey + "_directory_test"
     val directoryMetadataStore = new MetadataStore(inMemoryKvStore, directoryDataSetDataSet, timeoutMillis = 10000)
     inMemoryKvStore.create(directoryDataSetDataSet)
-    val directoryPut = directoryMetadataStore.putConf(confResource.getPath.replace(s"/$joinPath", ""))
+    val directoryPut = directoryMetadataStore.putConfByName(confResource.getPath.replace(s"/$joinPath", ""))
     Await.result(directoryPut, Duration.Inf)
     val dirResponse =
       inMemoryKvStore.get(GetRequest(joinPath.getBytes(), directoryDataSetDataSet))


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We want to upload the key-value pair: team -> list of groupBy entities under the key team to mussel.

```
2024-04-28 23:12:51 INFO  MetadataStore:280 - Putting metadata for
key: group_bys/cs_ds
conf: ["group_bys/cs_ds/host.trip_stage.v1","group_bys/cs_ds/user.message_intent.v1"]

```


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
Test run log: https://docs.google.com/document/d/1XmwDgBKdDYjabdyUYxW6YRaoBaW8OGe1ZVhWgurECVY/edit?usp=sharing
## Checklist
- [ ] Documentation update

## Reviewers
@nikhilsimha 
