### PR TITLE
Update analyzer for metadata extraction

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -258,27 +258,22 @@ class Analyzer(tableUtils: TableUtils,
     // run SQL environment setups such as UDFs and JARs
     joinConf.setups.foreach(tableUtils.sql)
 
-    val (analysis, leftSchema) = if (enableHitter) {
+    val (analysis, leftDf) = if (enableHitter) {
       val leftDf = JoinUtils.leftDf(joinConf, range, tableUtils, allowEmpty = true).get
       val analysis = analyze(leftDf, joinConf.leftKeyCols, joinConf.left.table)
-      val leftSchema: Map[String, DataType] =
-        leftDf.schema.fields
-          .map(field => (field.name, SparkConversions.toChrononType(field.name, field.dataType)))
-          .toMap
-      (analysis, leftSchema)
+      (analysis, leftDf)
     } else {
       val analysis = ""
       val scanQuery = range.genScanQuery(joinConf.left.query,
                                          joinConf.left.table,
                                          fillIfAbsent = Map(tableUtils.partitionColumn -> null))
-      val leftSchema: Map[String, DataType] = tableUtils
-        .sql(scanQuery)
-        .schema
-        .fields
-        .map(field => (field.name, SparkConversions.toChrononType(field.name, field.dataType)))
-        .toMap
-      (analysis, leftSchema)
+      val leftDf: DataFrame = tableUtils.sql(scanQuery)
+      (analysis, leftDf)
     }
+
+    val leftSchema = leftDf.schema.fields
+      .map(field => (field.name, SparkConversions.toChrononType(field.name, field.dataType)))
+      .toMap
     val aggregationsMetadata = ListBuffer[AggregationMetadata]()
     val keysWithError: ListBuffer[(String, String)] = ListBuffer.empty[(String, String)]
     val gbTables = ListBuffer[String]()

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -81,9 +81,6 @@ object MetadataExporter {
   }
 
   def processEntities(inputPath: String, outputPath: String, suffix: String): Unit = {
-    logger.info(s"Processing files from ${inputPath + suffix}")
-    val paths = getFilePaths(inputPath + suffix)
-    logger.info(s"Processing ${paths.length} files from ${paths}")
     val processSuccess = getFilePaths(inputPath + suffix).map { path =>
       try {
         val data = enrichMetadata(path)

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -58,7 +58,7 @@ object MetadataExporter {
           configData + { "features" -> analyzer.analyzeGroupBy(groupBy)._1.map(_.asMap) }
         } else {
           val join = ThriftJsonCodec.fromJsonFile[api.Join](path, check = false)
-          val joinAnalysis = analyzer.analyzeJoin(join)
+          val joinAnalysis = analyzer.analyzeJoin(join, metadataExtraction = true)
           val featureMetadata: Seq[Map[String, String]] = joinAnalysis._2.toSeq.map(_.asMap)
           configData + { "features" -> featureMetadata }
         }

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -100,8 +100,7 @@ object MetadataExporter {
   }
 
   def run(inputPath: String, outputPath: String): Unit = {
-    //processEntities(inputPath, outputPath, GROUPBY_PATH_SUFFIX)
-    //processEntities(inputPath, outputPath, JOIN_PATH_SUFFIX)
-    processEntities(inputPath, outputPath, "")
+    processEntities(inputPath, outputPath, GROUPBY_PATH_SUFFIX)
+    processEntities(inputPath, outputPath, JOIN_PATH_SUFFIX)
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -81,6 +81,9 @@ object MetadataExporter {
   }
 
   def processEntities(inputPath: String, outputPath: String, suffix: String): Unit = {
+    logger.info(s"Processing files from ${inputPath + suffix}")
+    val paths = getFilePaths(inputPath + suffix)
+    logger.info(s"Processing ${paths.length} files from ${paths}")
     val processSuccess = getFilePaths(inputPath + suffix).map { path =>
       try {
         val data = enrichMetadata(path)
@@ -97,7 +100,8 @@ object MetadataExporter {
   }
 
   def run(inputPath: String, outputPath: String): Unit = {
-    processEntities(inputPath, outputPath, GROUPBY_PATH_SUFFIX)
-    processEntities(inputPath, outputPath, JOIN_PATH_SUFFIX)
+    //processEntities(inputPath, outputPath, GROUPBY_PATH_SUFFIX)
+    //processEntities(inputPath, outputPath, JOIN_PATH_SUFFIX)
+    processEntities(inputPath, outputPath, "")
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -58,7 +58,7 @@ object MetadataExporter {
           configData + { "features" -> analyzer.analyzeGroupBy(groupBy)._1.map(_.asMap) }
         } else {
           val join = ThriftJsonCodec.fromJsonFile[api.Join](path, check = false)
-          val joinAnalysis = analyzer.analyzeJoin(join, metadataExtraction = true)
+          val joinAnalysis = analyzer.analyzeJoin(join, validateTablePermission = false)
           val featureMetadata: Seq[Map[String, String]] = joinAnalysis._2.toSeq.map(_.asMap)
           configData + { "features" -> featureMetadata }
         }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
The metadata exporter is calling Analyzer to do data analysis before generating the metadata, which include:
1. Validate input source table permission for the users who run the metadata export.
2. Run a query on the input source table to get the output schema.

The process works well for users, but for metadata exporter since it is running by chronon team who may not have access on some of the source tables, the task will fail to generate the metadata for these group_by/joins. 

To solve this issue, we decided to introduce a flag **validateTablePermission** in Analyzer for metadata exporter. The flag is set to be true by default. But it is set to be false for metadata exporter and it will avoid table permission validation and source table read to get rid of the permission issue. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@ezvz @nikhilsimha 
