### PR TITLE
FetcherCLI: support fetching with local join conf file without uploading to metadata store

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -634,6 +634,12 @@ object Extensions {
     def sanitize: String = Option(string).map(_.replaceAll("[^a-zA-Z0-9_]", "_")).orNull
 
     def cleanSpec: String = string.split("/").head
+
+    // derive a feature name key from path to file
+    def confPathToKey: String = {
+      // capture <conf_type>/<team>/<conf_name> as key e.g joins/team/team.example_join.v1
+      string.split("/").takeRight(3).mkString("/")
+    }
   }
 
   implicit class ExternalSourceOps(externalSource: ExternalSource) extends ExternalSource(externalSource) {

--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -20,6 +20,7 @@ import ai.chronon.online.Fetcher.Request;
 import ai.chronon.online.Fetcher.Response;
 import scala.collection.Iterator;
 import scala.collection.Seq;
+import scala.Option;
 import scala.collection.mutable.ArrayBuffer;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Future;
@@ -110,7 +111,7 @@ public class JavaFetcher {
     // Convert java requests to scala requests
     Seq<Request> scalaRequests = convertJavaRequestList(requests, false, startTs);
     // Get responses from the fetcher
-    Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchJoin(scalaRequests));
+    Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchJoin(scalaRequests, Option.empty()));
     // Convert responses to CompletableFuture
     return convertResponsesWithTs(scalaResponses, false, startTs);
   }

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -102,7 +102,7 @@ class Fetcher(val kvStore: KVStore,
   // run during initialization
   reportCallerNameFetcherVersion()
 
-  def buildJoinCodec(joinConf: api.Join): JoinCodec = {
+  def buildJoinCodec(joinConf: Join): JoinCodec = {
     val keyFields = new mutable.LinkedHashSet[StructField]
     val valueFields = new mutable.ListBuffer[StructField]
     // collect keyFields and valueFields from joinParts/GroupBys

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -190,9 +190,10 @@ class Fetcher(val kvStore: KVStore,
     }
   }
 
-  override def fetchJoin(requests: scala.collection.Seq[Request]): Future[scala.collection.Seq[Response]] = {
+  override def fetchJoin(requests: scala.collection.Seq[Request],
+                         joinConf: Option[api.Join] = None): Future[scala.collection.Seq[Response]] = {
     val ts = System.currentTimeMillis()
-    val internalResponsesF = super.fetchJoin(requests)
+    val internalResponsesF = super.fetchJoin(requests, joinConf)
     val externalResponsesF = fetchExternal(requests)
     val combinedResponsesF = internalResponsesF.zip(externalResponsesF).map {
       case (internalResponses, externalResponses) =>

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -594,8 +594,9 @@ object Driver {
     @transient lazy val logger = LoggerFactory.getLogger(getClass)
 
     class Args extends Subcommand("fetch") with OnlineSubcommand {
+      val confPath: ScallopOption[String] = opt[String](required = false, descr = "Path to conf to fetch features")
       val keyJson: ScallopOption[String] = opt[String](required = false, descr = "json of the keys to fetch")
-      val name: ScallopOption[String] = opt[String](required = true, descr = "name of the join/group-by to fetch")
+      val name: ScallopOption[String] = opt[String](required = false, descr = "name of the join/group-by to fetch")
       val `type`: ScallopOption[String] =
         choice(Seq("join", "group-by", "join-stats"), descr = "the type of conf to fetch", default = Some("join"))
       val keyJsonFile: ScallopOption[String] = opt[String](
@@ -644,6 +645,7 @@ object Driver {
       if (args.keyJson.isEmpty && args.keyJsonFile.isEmpty) {
         throw new Exception("At least one of keyJson and keyJsonFile should be specified!")
       }
+      require(!args.confPath.isEmpty || !args.name.isEmpty, "--conf-path or --name should be specified!")
       val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
       def readMap: String => Map[String, AnyRef] = { json =>
         objectMapper.readValue(json, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
@@ -675,10 +677,17 @@ object Driver {
           if (args.`type`() == "join-stats") {
             fetchStats(args, objectMapper, keyMap, fetcher)
           } else {
+            val featureName = if (args.name.isDefined) {
+              args.name()
+            } else {
+              args.confPath().split("/").takeRight(3).mkString("/")
+            }
+            lazy val joinConfOption: Option[api.Join] =
+              args.confPath.toOption.map(confPath => parseConf[api.Join](confPath))
             val startNs = System.nanoTime
-            val requests = Seq(Fetcher.Request(args.name(), keyMap, args.atMillis.toOption))
+            val requests = Seq(Fetcher.Request(featureName, keyMap, args.atMillis.toOption))
             val resultFuture = if (args.`type`() == "join") {
-              fetcher.fetchJoin(requests)
+              fetcher.fetchJoin(requests, joinConfOption)
             } else {
               fetcher.fetchGroupBys(requests)
             }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -17,7 +17,7 @@
 package ai.chronon.spark
 
 import ai.chronon.api
-import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, SourceOps}
+import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, SourceOps, StringOps}
 import ai.chronon.api.ThriftJsonCodec
 import ai.chronon.online.{Api, Fetcher, MetadataStore}
 import ai.chronon.spark.stats.{CompareBaseJob, CompareJob, ConsistencyJob, SummaryJob}
@@ -680,7 +680,7 @@ object Driver {
             val featureName = if (args.name.isDefined) {
               args.name()
             } else {
-              args.confPath().split("/").takeRight(3).mkString("/")
+              args.confPath().confPathToKey
             }
             lazy val joinConfOption: Option[api.Join] =
               args.confPath.toOption.map(confPath => parseConf[api.Join](confPath))


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR will enable users to use a local join conf file to fetch features without uploading the conf to metadata store.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
It will simplify the testing process. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [x] tested on gateway macine
```
python3 ./scripts/run.py --mode=fetch -k '<place_holder>' --conf-path <place_holder> -t join --chronon-jar ~/test/chronon-embedded.jar

2024-04-24 21:09:16 INFO  Fetcher:391 - Using passed in join configuration: <place_holder>
```

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers @nikhilsimha @hanyuli1995 @donghanz 
