### PR TITLE
MutationScan seems to be doing the wrong thing 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,19 @@ jobs:
                   destination: spark_warehouse.tar.gz
                   when: on_fail
 
+    "Scala 11 -- Compile":
+      executor: docker_baseimg_executor
+      steps:
+        - checkout
+        - run:
+            name: Compile Scala 11
+            shell: /bin/bash -leuxo pipefail
+            command: |
+              conda activate chronon_py
+              # Increase if we see OOM.
+              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+              sbt "++ 2.11.12 compile"
+
     "Chronon Python Lint":
         executor: docker_baseimg_executor
         steps:
@@ -125,6 +138,9 @@ workflows:
     build_test_deploy:
         jobs:
             - "Pull Docker Image"
+            - "Scala 11 -- Compile":
+                requires:
+                  - "Pull Docker Image"
             - "Scala 12 -- Spark 3 Tests":
                   requires:
                       - "Pull Docker Image"

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -433,7 +433,7 @@ class Analyzer(tableUtils: TableUtils,
             val table = source.table
             logger.info(s"Checking table $table for data availability ... Expected start partition: $expectedStart")
             val existingPartitions = tableUtils.partitions(table)
-            val minPartition = existingPartitions.reduceOption(Ordering[String].min)
+            val minPartition = existingPartitions.reduceOption((a, b) => Ordering[String].min(a, b))
             //check if partition available or table is cumulative
             if (!tableUtils.ifPartitionExistsInTable(table, expectedStart) && !source.isCumulative) {
               println(s"""

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -75,15 +75,14 @@ object BootstrapInfo {
   def from(joinConf: api.Join,
            range: PartitionRange,
            tableUtils: TableUtils,
-           leftSchema: Option[StructType],
-           mutationScan: Boolean = true): BootstrapInfo = {
+           leftSchema: Option[StructType]): BootstrapInfo = {
 
     // Enrich each join part with the expected output schema
     logger.info(s"\nCreating BootstrapInfo for GroupBys for Join ${joinConf.metaData.name}")
     var joinParts: Seq[JoinPartMetadata] = Option(joinConf.joinParts.toScala)
       .getOrElse(Seq.empty)
       .map(part => {
-        val gb = GroupBy.from(part.groupBy, range, tableUtils, computeDependency = true, mutationScan = mutationScan)
+        val gb = GroupBy.from(part.groupBy, range, tableUtils, computeDependency = true)
         val keySchema = SparkConversions
           .toChrononSchema(gb.keySchema)
           .map(field => StructField(part.rightToLeft(field._1), field._2))

--- a/spark/src/main/scala/ai/chronon/spark/Extensions.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Extensions.scala
@@ -31,6 +31,7 @@ import org.apache.spark.util.sketch.BloomFilter
 import java.util
 import scala.collection.Seq
 import scala.reflect.ClassTag
+import scala.util.ScalaJavaConversions.IteratorOps
 
 object Extensions {
 
@@ -178,9 +179,12 @@ object Extensions {
     private def mightContain(f: BloomFilter): UserDefinedFunction =
       udf((x: Object) => if (x != null) f.mightContain(x) else true)
 
-    def filterBloom(bloomMap: Map[String, BloomFilter]): DataFrame =
-      bloomMap.foldLeft(df) {
-        case (dfIter, (col, bloom)) => dfIter.where(mightContain(bloom)(dfIter(col)))
+    def filterBloom(bloomMap: util.Map[String, BloomFilter]): DataFrame =
+      bloomMap.entrySet().iterator().toScala.foldLeft(df) {
+        case (dfIter, entry) =>
+          val col = entry.getKey
+          val bloom = entry.getValue
+          dfIter.where(mightContain(bloom)(dfIter(col)))
       }
 
     // math for computing bloom size
@@ -323,6 +327,14 @@ object Extensions {
 
         override def copy(): Row = internalRow.copy().toRow(schema)
       }
+    }
+  }
+
+  implicit class TupleToJMapOps[K, V](tuples: Iterator[(K, V)]) {
+    def toJMap: util.Map[K, V] = {
+      val map = new util.HashMap[K, V]()
+      tuples.foreach { case (k, v) => map.put(k, v) }
+      map
     }
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/FastHashing.scala
+++ b/spark/src/main/scala/ai/chronon/spark/FastHashing.scala
@@ -16,7 +16,7 @@
 
 package ai.chronon.spark
 
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import ai.chronon.spark.Extensions._
 import com.google.common.hash.{Hasher, Hashing}
 import org.apache.spark.sql.Row

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -459,7 +459,7 @@ object GroupBy {
            queryRange: PartitionRange,
            tableUtils: TableUtils,
            computeDependency: Boolean,
-           bloomMapOpt: Option[Map[String, BloomFilter]] = None,
+           bloomMapOpt: Option[util.Map[String, BloomFilter]] = None,
            skewFilter: Option[String] = None,
            finalize: Boolean = true,
            showDf: Boolean = false): GroupBy = {

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -417,7 +417,7 @@ object GroupBy {
           groupByConf.dataModel == DataModel.Events && groupByConf.inferredAccuracy == Accuracy.TEMPORAL
         val endDate = if (isPreShifted) beforeDs else queryRange.end
 
-        val join = new Join(joinConf, endDate, tableUtils, mutationScan = false, showDf = showDf)
+        val join = new Join(joinConf, endDate, tableUtils, showDf = showDf)
         if (computeDependency) {
           val df = join.computeJoin()
           if (showDf) {

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -119,8 +119,7 @@ object GroupByUpload {
       .from(groupByConf,
             PartitionRange(endDs, endDs),
             TableUtils(session),
-            computeDependency = false,
-            mutationScan = false)
+            computeDependency = false)
     groupByServingInfo.setBatchEndDate(nextDay)
     groupByServingInfo.setGroupBy(groupByConf)
     groupByServingInfo.setKeyAvroSchema(groupBy.keySchema.toAvroSchema("Key").toString(true))
@@ -192,7 +191,6 @@ object GroupByUpload {
                                     PartitionRange(endDs, endDs),
                                     tableUtils,
                                     computeDependency = true,
-                                    mutationScan = false,
                                     showDf = showDf)
     lazy val groupByUpload = new GroupByUpload(endDs, groupBy)
     // for temporal accuracy - we don't need to scan mutations for upload
@@ -203,7 +201,6 @@ object GroupByUpload {
                    PartitionRange(endDs, endDs).shift(1),
                    tableUtils,
                    computeDependency = true,
-                   mutationScan = false,
                    showDf = showDf)
     lazy val shiftedGroupByUpload = new GroupByUpload(batchEndDate, shiftedGroupBy)
     // for mutations I need the snapshot from the previous day, but a batch end date of ds +1

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -116,10 +116,7 @@ object GroupByUpload {
     val nextDay = tableUtils.partitionSpec.after(endDs)
 
     val groupBy = ai.chronon.spark.GroupBy
-      .from(groupByConf,
-            PartitionRange(endDs, endDs),
-            TableUtils(session),
-            computeDependency = false)
+      .from(groupByConf, PartitionRange(endDs, endDs), TableUtils(session), computeDependency = false)
     groupByServingInfo.setBatchEndDate(nextDay)
     groupByServingInfo.setGroupBy(groupByConf)
     groupByServingInfo.setKeyAvroSchema(groupBy.keySchema.toAvroSchema("Key").toString(true))
@@ -187,11 +184,8 @@ object GroupByUpload {
     // add 1 day to the batch end time to reflect data [ds 00:00:00.000, ds + 1 00:00:00.000)
     val batchEndDate = tableUtils.partitionSpec.after(endDs)
     // for snapshot accuracy - we don't need to scan mutations
-    lazy val groupBy = GroupBy.from(groupByConf,
-                                    PartitionRange(endDs, endDs),
-                                    tableUtils,
-                                    computeDependency = true,
-                                    showDf = showDf)
+    lazy val groupBy =
+      GroupBy.from(groupByConf, PartitionRange(endDs, endDs), tableUtils, computeDependency = true, showDf = showDf)
     lazy val groupByUpload = new GroupByUpload(endDs, groupBy)
     // for temporal accuracy - we don't need to scan mutations for upload
     // when endDs = xxxx-01-02 the timestamp from airflow is more than (xxxx-01-03 00:00:00)

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -76,10 +76,9 @@ class Join(joinConf: api.Join,
            endPartition: String,
            tableUtils: TableUtils,
            skipFirstHole: Boolean = true,
-           mutationScan: Boolean = true,
            showDf: Boolean = false,
            selectedJoinParts: Option[List[String]] = None)
-    extends JoinBase(joinConf, endPartition, tableUtils, skipFirstHole, mutationScan, showDf, selectedJoinParts) {
+    extends JoinBase(joinConf, endPartition, tableUtils, skipFirstHole, showDf, selectedJoinParts) {
 
   private def padFields(df: DataFrame, structType: sql.types.StructType): DataFrame = {
     structType.foldLeft(df) {

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -270,7 +270,7 @@ class Join(joinConf: api.Join,
     // info to filter records that need backfills vs can be waived from backfills
     val bootstrapCoveringSets = findBootstrapSetCoverings(bootstrapDf, bootstrapInfo, leftRange)
 
-    // compute a single bloomfilter at join level if there is no bootstrap operation
+    // compute a single bloom filter at join level if there is no bootstrap operation
     lazy val joinLevelBloomMapOpt = if (bootstrapDf.columns.contains(Constants.MatchedHashes)) {
       // do not compute if any bootstrap is involved
       None
@@ -279,9 +279,9 @@ class Join(joinConf: api.Join,
       if (leftRowCount > tableUtils.bloomFilterThreshold) {
         None
       } else {
-        val leftBlooms = joinConf.leftKeyCols.toSeq.map { key =>
+        val leftBlooms = joinConf.leftKeyCols.iterator.map { key =>
           key -> bootstrapDf.generateBloomFilter(key, leftRowCount, joinConf.left.table, leftRange)
-        }.toMap
+        }.toJMap
         Some(leftBlooms)
       }
     }

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -345,7 +345,7 @@ abstract class JoinBase(joinConf: api.Join,
       logger.info(s"Range to fill already computed. Skipping query execution...")
     } else {
       val leftSchema = leftDf(joinConf, unfilledRanges.head, tableUtils, limit = Some(1)).map(df => df.schema)
-      val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema, mutationScan = mutationScan)
+      val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema)
       logger.info(s"Running ranges: $unfilledRanges")
       unfilledRanges.foreach { unfilledRange =>
         val leftDf = JoinUtils.leftDf(joinConf, unfilledRange, tableUtils)
@@ -378,7 +378,7 @@ abstract class JoinBase(joinConf: api.Join,
       logger.info(s"Range to fill already computed. Skipping query execution...")
     } else {
       val leftSchema = leftDf(joinConf, unfilledRanges.head, tableUtils, limit = Some(1)).map(df => df.schema)
-      val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema, mutationScan = mutationScan)
+      val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema)
       logger.info(s"Running ranges: $unfilledRanges")
       unfilledRanges.foreach { unfilledRange =>
         val leftDf = JoinUtils.leftDf(joinConf, unfilledRange, tableUtils)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -32,6 +32,7 @@ import java.time.Instant
 
 import scala.collection.JavaConverters._
 import scala.collection.Seq
+import java.util
 import scala.util.ScalaJavaConversions.ListOps
 
 abstract class JoinBase(joinConf: api.Join,
@@ -122,7 +123,7 @@ abstract class JoinBase(joinConf: api.Join,
   def computeRightTable(leftDf: Option[DfWithStats],
                         joinPart: JoinPart,
                         leftRange: PartitionRange,
-                        joinLevelBloomMapOpt: Option[Map[String, BloomFilter]],
+                        joinLevelBloomMapOpt: Option[util.Map[String, BloomFilter]],
                         smallMode: Boolean = false): Option[DataFrame] = {
 
     val partTable = joinConf.partOutputTable(joinPart)
@@ -199,7 +200,7 @@ abstract class JoinBase(joinConf: api.Join,
 
   def computeJoinPart(leftDfWithStats: Option[DfWithStats],
                       joinPart: JoinPart,
-                      joinLevelBloomMapOpt: Option[Map[String, BloomFilter]],
+                      joinLevelBloomMapOpt: Option[util.Map[String, BloomFilter]],
                       skipBloom: Boolean = false): Option[DataFrame] = {
 
     if (leftDfWithStats.isEmpty) {
@@ -217,13 +218,7 @@ abstract class JoinBase(joinConf: api.Join,
     val rightBloomMap = if (skipBloom) {
       None
     } else {
-      JoinUtils.genBloomFilterIfNeeded(leftDf,
-                                       joinPart,
-                                       joinConf,
-                                       rowCount,
-                                       unfilledRange,
-                                       tableUtils,
-                                       joinLevelBloomMapOpt)
+      JoinUtils.genBloomFilterIfNeeded(joinPart, joinConf, rowCount, unfilledRange, joinLevelBloomMapOpt)
     }
     val rightSkewFilter = joinConf.partSkewFilter(joinPart)
     def genGroupBy(partitionRange: PartitionRange) =

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -38,7 +38,6 @@ abstract class JoinBase(joinConf: api.Join,
                         endPartition: String,
                         tableUtils: TableUtils,
                         skipFirstHole: Boolean,
-                        mutationScan: Boolean = true,
                         showDf: Boolean = false,
                         selectedJoinParts: Option[Seq[String]] = None) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -234,7 +233,6 @@ abstract class JoinBase(joinConf: api.Join,
                    computeDependency = true,
                    rightBloomMap,
                    rightSkewFilter,
-                   mutationScan = mutationScan,
                    showDf = showDf)
 
     // all lazy vals - so evaluated only when needed by each case.
@@ -471,7 +469,7 @@ abstract class JoinBase(joinConf: api.Join,
 
     val leftSchema = leftDf(joinConf, unfilledRanges.head, tableUtils, limit = Some(1)).map(df => df.schema)
     // build bootstrap info once for the entire job
-    val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema, mutationScan = mutationScan)
+    val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema)
 
     val wholeRange = PartitionRange(unfilledRanges.minBy(_.start).start, unfilledRanges.maxBy(_.end).end)(tableUtils)
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -32,7 +32,6 @@ import scala.collection.compat._
 import scala.jdk.CollectionConverters._
 import scala.util.ScalaJavaConversions.{JIteratorOps, JMapOps, MapOps}
 import ai.chronon.api
-import ai.chronon.online.TTLCache.Entry
 
 object JoinUtils {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -293,32 +292,30 @@ object JoinUtils {
     */
 
   def genBloomFilterIfNeeded(
-      leftDf: DataFrame,
       joinPart: ai.chronon.api.JoinPart,
       joinConf: ai.chronon.api.Join,
       leftRowCount: Long,
       unfilledRange: PartitionRange,
-      tableUtils: TableUtils,
-      joinLevelBloomMapOpt: Option[Map[String, BloomFilter]]): Option[Map[String, BloomFilter]] = {
-    logger.info(
-      s"\nRow count to be filled for ${joinPart.groupBy.metaData.name}. BloomFilter Threshold: ${tableUtils.bloomFilterThreshold}")
+      joinLevelBloomMapOpt: Option[util.Map[String, BloomFilter]]): Option[util.Map[String, BloomFilter]] = {
 
-    // apply bloom filter when left row count is below threshold
-    if (leftRowCount > tableUtils.bloomFilterThreshold) {
-      logger.info("Row count is above threshold. Skip gen bloom filter.")
-      Option.empty
-    } else {
+    val rightBlooms = joinLevelBloomMapOpt.map { joinBlooms =>
+      joinPart.rightToLeft.iterator.map {
+        case (rightCol, leftCol) =>
+          rightCol -> joinBlooms.get(leftCol)
+      }.toJMap
+    }
 
-      val requiredLeftColumns = joinPart.rightToLeft.values.toSeq
-      val leftBlooms = {
-        joinLevelBloomMapOpt.getOrElse(requiredLeftColumns.map { key =>
-          key -> leftDf.generateBloomFilter(key, leftRowCount, joinConf.left.table, unfilledRange)
-        }.toMap)
-      }
+    // print bloom sizes
+    val bloomSizes = rightBlooms.map { blooms =>
+      val sizes = blooms.asScala
+        .map {
+          case (rightCol, bloom) =>
+            s"$rightCol -> ${bloom.bitSize()}"
+        }
+      logger.info(s"Bloom sizes: ${sizes.mkString(", ")}")
+    }
 
-      val rightBloomMap = joinPart.rightToLeft.mapValues(leftBlooms(_)).map(identity)
-      val bloomSizes = rightBloomMap.map { case (col, bloom) => s"$col -> ${bloom.bitSize()}" }.pretty
-      logger.info(s"""
+    logger.info(s"""
            Generating bloom filter for joinPart:
            |  part name : ${joinPart.groupBy.metaData.name},
            |  left type : ${joinConf.left.dataModel},
@@ -329,8 +326,7 @@ object JoinUtils {
            |  bloom sizes: $bloomSizes
            |  groupBy: ${joinPart.groupBy.toString}
            |""".stripMargin)
-      Some(rightBloomMap)
-    }
+    rightBlooms
   }
 
   def injectKeyFilter(leftDf: DataFrame, joinPart: api.JoinPart): Unit = {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -17,7 +17,6 @@
 package ai.chronon.spark
 
 import java.util
-
 import org.slf4j.LoggerFactory
 import ai.chronon.api.Constants
 import ai.chronon.api.DataModel.Events
@@ -28,11 +27,12 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{coalesce, col, udf}
 import org.apache.spark.util.sketch.BloomFilter
+
 import scala.collection.compat._
 import scala.jdk.CollectionConverters._
-import scala.util.ScalaJavaConversions.MapOps
-
+import scala.util.ScalaJavaConversions.{JIteratorOps, JMapOps, MapOps}
 import ai.chronon.api
+import ai.chronon.online.TTLCache.Entry
 
 object JoinUtils {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -316,7 +316,7 @@ object JoinUtils {
         }.toMap)
       }
 
-      val rightBloomMap = joinPart.rightToLeft.mapValues(leftBlooms(_)).toMap
+      val rightBloomMap = joinPart.rightToLeft.mapValues(leftBlooms(_)).map(identity)
       val bloomSizes = rightBloomMap.map { case (col, bloom) => s"$col -> ${bloom.bitSize()}" }.pretty
       logger.info(s"""
            Generating bloom filter for joinPart:

--- a/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
@@ -26,9 +26,10 @@ import scala.reflect.io.Path
 import scala.util.Properties
 
 object SparkSessionBuilder {
-  @transient lazy val logger = LoggerFactory.getLogger(getClass)
+  @transient private lazy val logger = LoggerFactory.getLogger(getClass)
 
-  val DefaultWarehouseDir = new File("/tmp/chronon/spark-warehouse")
+  private val warehouseId = java.util.UUID.randomUUID().toString.takeRight(6)
+  private val DefaultWarehouseDir = new File("/tmp/chronon/spark-warehouse_" + warehouseId)
 
   def expandUser(path: String): String = path.replaceFirst("~", System.getProperty("user.home"))
   // we would want to share locally generated warehouse during CI testing

--- a/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
@@ -91,6 +91,7 @@ object SparkSessionBuilder {
     val spark = builder.getOrCreate()
     // disable log spam
     spark.sparkContext.setLogLevel("ERROR")
+
     Logger.getLogger("parquet.hadoop").setLevel(java.util.logging.Level.SEVERE)
     spark
   }

--- a/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
@@ -91,7 +91,7 @@ object SparkSessionBuilder {
     }
     val spark = builder.getOrCreate()
     // disable log spam
-    spark.sparkContext.setLogLevel("ERROR")
+    // spark.sparkContext.setLogLevel("ERROR")
 
     Logger.getLogger("parquet.hadoop").setLevel(java.util.logging.Level.SEVERE)
     spark
@@ -119,7 +119,7 @@ object SparkSessionBuilder {
     }
     val spark = builder.getOrCreate()
     // disable log spam
-    spark.sparkContext.setLogLevel("ERROR")
+    // spark.sparkContext.setLogLevel("ERROR")
     Logger.getLogger("parquet.hadoop").setLevel(java.util.logging.Level.SEVERE)
     spark
   }

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -24,6 +24,7 @@ import ai.chronon.api.Extensions._
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import ai.chronon.spark.Extensions.{DfStats, DfWithStats}
 import jnr.ffi.annotations.Synchronized
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
@@ -125,9 +126,11 @@ case class TableUtils(sparkSession: SparkSession) {
       sql(command)
       true
     } catch {
+      case _: AlreadyExistsException =>
+        false // 'already exists' is a swallowable exception
       case e: Exception =>
         logger.error(s"Failed to create database $database", e)
-        false
+        throw e
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -44,7 +44,7 @@ case class TableUtils(sparkSession: SparkSession) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
 
   private val ARCHIVE_TIMESTAMP_FORMAT = "yyyyMMddHHmmss"
-  private lazy val archiveTimestampFormatter = DateTimeFormatter
+  @transient private lazy val archiveTimestampFormatter = DateTimeFormatter
     .ofPattern(ARCHIVE_TIMESTAMP_FORMAT)
     .withZone(ZoneId.systemDefault())
   val partitionColumn: String =

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -118,6 +118,19 @@ case class TableUtils(sparkSession: SparkSession) {
     schema.fieldNames.contains(partitionColumn)
   }
 
+  def createDatabase(database: String): Boolean = {
+    try {
+      val command = s"CREATE DATABASE IF NOT EXISTS $database"
+      logger.info(s"Creating database with command: $command")
+      sql(command)
+      true
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to create database $database", e)
+        false
+    }
+  }
+
   // return all specified partition columns in a table in format of Map[partitionName, PartitionValue]
   def allPartitions(tableName: String, partitionColumnsFilter: Seq[String] = Seq.empty): Seq[Map[String, String]] = {
     if (!tableExists(tableName)) return Seq.empty[Map[String, String]]

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -36,7 +36,7 @@ class AnalyzerTest {
   private val oneYearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
 
   private val namespace = "analyzer_test_ns"
-  spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+  tableUtils.createDatabase(namespace)
 
   private val viewsSource = getTestEventSource()
 

--- a/spark/src/test/scala/ai/chronon/spark/test/AvroTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AvroTest.scala
@@ -36,7 +36,7 @@ class AvroTest {
   def testDecimal(): Unit = {
 
     val namespace = "test_decimal"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
 
     /* create group by that uses a decimal field */
     val txnTable = s"$namespace.transactions"

--- a/spark/src/test/scala/ai/chronon/spark/test/ChainingFetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/ChainingFetcherTest.scala
@@ -54,7 +54,7 @@ class ChainingFetcherTest extends TestCase {
     * Chained Join: latest rating of the listings the user viewed in the last 7 days
     */
   def generateMutationData(namespace: String, accuracy: Accuracy): api.Join = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     // left user views table
     // {listing, user, ts, ds}
     val viewsSchema = StructType(
@@ -150,7 +150,7 @@ class ChainingFetcherTest extends TestCase {
   }
 
   def generateChainingJoinData(namespace: String, accuracy: Accuracy): api.Join = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     // User search listing event. Schema: user, listing, ts, ds
     val searchSchema = StructType(
       "user_search_listing_event",

--- a/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
@@ -31,8 +31,8 @@ class FeatureWithLabelJoinTest {
 
   private val namespace = "final_join"
   private val tableName = "test_feature_label_join"
-  tableUtils.createDatabase(namespace)
   private val tableUtils = TableUtils(spark)
+  tableUtils.createDatabase(namespace)
 
   private val labelDS = "2022-10-30"
   private val viewsGroupBy = TestUtils.createViewsGroupBy(namespace, spark)
@@ -56,16 +56,16 @@ class FeatureWithLabelJoinTest {
     val labelDf = runner.computeLabelJoin()
     logger.info(" == First Run Label version 2022-10-30 == ")
     prefixColumnName(labelDf, exceptions = labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn))
-                                                        .show()
+      .show()
     val featureDf = tableUtils.sparkSession.table(joinConf.metaData.outputTable)
     logger.info(" == Features == ")
     featureDf.show()
     val computed = tableUtils.sql(s"select * from ${joinConf.metaData.outputFinalView}")
-    val expectedFinal = featureDf.join(prefixColumnName(labelDf,
-                                                        exceptions = labelJoinConf.rowIdentifier(null,
-                                                                                                  tableUtils.partitionColumn)),
-                                       labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn),
-                                       "left_outer")
+    val expectedFinal = featureDf.join(
+      prefixColumnName(labelDf, exceptions = labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn)),
+      labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn),
+      "left_outer"
+    )
     assertResult(computed, expectedFinal)
 
     // add another label version
@@ -141,15 +141,16 @@ class FeatureWithLabelJoinTest {
     val labelDf = runner.computeLabelJoin()
     logger.info(" == Label DF == ")
     prefixColumnName(labelDf, exceptions = labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn))
-                                                        .show()
+      .show()
     val featureDf = tableUtils.sparkSession.table(joinConf.metaData.outputTable)
     logger.info(" == Features DF == ")
     featureDf.show()
     val computed = tableUtils.sql(s"select * from ${joinConf.metaData.outputFinalView}")
-    val expectedFinal = featureDf.join(prefixColumnName(labelDf,
-                                                        exceptions = labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn)),
-                                       labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn),
-                                       "left_outer")
+    val expectedFinal = featureDf.join(
+      prefixColumnName(labelDf, exceptions = labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn)),
+      labelJoinConf.rowIdentifier(null, tableUtils.partitionColumn),
+      "left_outer"
+    )
     assertResult(computed, expectedFinal)
 
     // add new labels

--- a/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
@@ -31,7 +31,7 @@ class FeatureWithLabelJoinTest {
 
   private val namespace = "final_join"
   private val tableName = "test_feature_label_join"
-  spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+  tableUtils.createDatabase(namespace)
   private val tableUtils = TableUtils(spark)
 
   private val labelDS = "2022-10-30"

--- a/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
@@ -58,7 +58,7 @@ class FetchStatsTest extends TestCase {
 
   def testFetchStats(): Unit = {
     // Part 1: Build the assets. Join definition, compute and serve stats.
-    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val nameSuffix = "_fetch_stats_test"
 
     // LeftDf ->  item, value, ts, ds

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -106,7 +106,7 @@ class FetcherTest extends TestCase {
     * Generate deterministic data for testing and checkpointing IRs and streaming data.
     */
   def generateMutationData(namespace: String): api.Join = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     def toTs(arg: String): Long = TsUtils.datetimeToTs(arg)
     val eventData = Seq(
       Row(595125622443733822L, toTs("2021-04-10 09:00:00"), "2021-04-10"),
@@ -238,7 +238,7 @@ class FetcherTest extends TestCase {
   }
 
   def generateRandomData(namespace: String, keyCount: Int = 10, cardinality: Int = 100): api.Join = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val rowCount = cardinality * keyCount
     val userCol = Column("user", StringType, keyCount)
     val vendorCol = Column("vendor", StringType, keyCount)
@@ -416,7 +416,7 @@ class FetcherTest extends TestCase {
   }
 
   def generateEventOnlyData(namespace: String, groupByCustomJson: Option[String] = None): api.Join = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
 
     def toTs(arg: String): Long = TsUtils.datetimeToTs(arg)
 

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -406,7 +406,7 @@ class GroupByTest {
     val namespace = "chronon_test"
     val sourceTable = s"$namespace.test_group_by_steps$suffix"
 
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     DataFrameGen.events(spark, sourceSchema, count = 1000, partitions = 200).save(sourceTable)
     val source = Builders.Source.events(
       query =
@@ -423,7 +423,7 @@ class GroupByTest {
                tableUtils: TableUtils,
                stepDays: Option[Int] = None,
                additionalAgg: Seq[Aggregation] = Seq.empty): String = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val groupBy = getSampleGroupBy(name, source, namespace, additionalAgg)
 
     GroupBy.computeBackfill(

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
@@ -44,7 +44,7 @@ class GroupByUploadTest {
   def temporalEventsLastKTest(): Unit = {
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
-    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     tableUtils.sql(s"USE $namespace")
     val eventsTable = "events_last_k_dup" // occurs in groupByTest
     val eventSchema = List(
@@ -73,7 +73,7 @@ class GroupByUploadTest {
   def structSupportTest(): Unit = {
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
-    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     tableUtils.sql(s"USE $namespace")
     val eventsBase = "events_source"
     val eventsTable = "events_table_struct"
@@ -115,7 +115,7 @@ class GroupByUploadTest {
   def multipleAvgCountersTest(): Unit = {
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
-    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     tableUtils.sql(s"USE $namespace")
     val eventsTable = "my_events"
     val eventSchema = List(
@@ -148,7 +148,7 @@ class GroupByUploadTest {
   // groupBy = keys:[listing, category], aggs:[avg(rating)]
   @Test
   def listingRatingCategoryJoinSourceTest(): Unit = {
-    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     tableUtils.sql(s"USE $namespace")
 
     val ratingsTable = s"${namespace}.ratings"

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -72,7 +72,7 @@ class JoinTest {
     spark.sql(s"DROP TABLE IF EXISTS $dollarTable")
     spark.sql(s"DROP TABLE IF EXISTS $rupeeTable")
     DataFrameGen.entities(spark, dollarTransactions, 3000, partitions = 200).save(dollarTable, Map("tblProp1" -> "1"))
-    DataFrameGen.entities(spark, rupeeTransactions, 450, partitions = 30).save(rupeeTable)
+    DataFrameGen.entities(spark, rupeeTransactions, 500, partitions = 80).save(rupeeTable)
 
     val dollarSource = Builders.Source.entities(
       query = Builders.Query(

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
@@ -36,7 +36,7 @@ class JoinUtilsTest {
 
   lazy val spark: SparkSession = SparkSessionBuilder.build("JoinUtilsTest", local = true)
   private val tableUtils = TableUtils(spark)
-
+  private val namespace = "joinUtil"
   @Test
   def testUDFSetAdd(): Unit = {
     val data = Seq(
@@ -238,7 +238,7 @@ class JoinUtilsTest {
     val finalViewName = "testCreateView"
     val leftTableName = "joinUtil.testFeatureTable"
     val rightTableName = "joinUtil.testLabelTable"
-    spark.sql("CREATE DATABASE IF NOT EXISTS joinUtil")
+    tableUtils.createDatabase(namespace)
     TestUtils.createSampleFeatureTableDf(spark).write.saveAsTable(leftTableName)
     TestUtils.createSampleLabelTableDf(spark).write.saveAsTable(rightTableName)
     val keys = Array("listing_id", tableUtils.partitionColumn)
@@ -277,7 +277,7 @@ class JoinUtilsTest {
     val finalViewName = "joinUtil.testFinalView"
     val leftTableName = "joinUtil.testFeatureTable2"
     val rightTableName = "joinUtil.testLabelTable2"
-    spark.sql("CREATE DATABASE IF NOT EXISTS joinUtil")
+    tableUtils.createDatabase(namespace)
     TestUtils.createSampleFeatureTableDf(spark).write.saveAsTable(leftTableName)
     tableUtils.insertPartitions(TestUtils.createSampleLabelTableDf(spark),
                                 rightTableName,
@@ -328,7 +328,7 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFill(): Unit = {
-    spark.sql("CREATE DATABASE IF NOT EXISTS joinUtil")
+    tableUtils.createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
     val itemQueriesTable = "joinUtil.item_queries_table"
@@ -345,7 +345,7 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFillWithOverride(): Unit = {
-    spark.sql("CREATE DATABASE IF NOT EXISTS joinUtil")
+    tableUtils.createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
     val itemQueriesTable = "joinUtil.queries_table"

--- a/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
@@ -30,6 +30,7 @@ import org.junit.Assert.assertEquals
 
 import scala.io.Source
 import java.io.File
+import java.net.URL
 
 class MetadataExporterTest extends TestCase {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -83,7 +84,8 @@ class MetadataExporterTest extends TestCase {
     printFilesInDirectory(s"${confResource.getPath}/joins/team")
     printFilesInDirectory(s"${tmpDir.getAbsolutePath}/joins")
     // Read the files.
-    val jsonString = Source.fromFile(s"${tmpDir.getAbsolutePath}/joins/example_join.v1").getLines().mkString("\n")
+    val file = Source.fromFile(s"${tmpDir.getAbsolutePath}/joins/example_join.v1")
+    val jsonString = file.getLines().mkString("\n")
     val objectMapper = new ObjectMapper()
     objectMapper.registerModule(DefaultScalaModule)
     val jsonNode = objectMapper.readTree(jsonString)

--- a/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
@@ -65,7 +65,7 @@ class MetadataExporterTest extends TestCase {
     // Create the tables.
     val namespace = "example_namespace"
     val tablename = "table"
-    tableUtils.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val sampleData = List(
       Column("a", api.StringType, 10),
       Column("b", api.StringType, 10),

--- a/spark/src/test/scala/ai/chronon/spark/test/MigrationCompareTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MigrationCompareTest.scala
@@ -35,7 +35,7 @@ class MigrationCompareTest {
   private val namespace = "migration_compare_chronon_test"
   private val monthAgo = tableUtils.partitionSpec.minus(today, new Window(30, TimeUnit.DAYS))
   private val yearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
-  spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+  tableUtils.createDatabase(namespace)
 
   def setupTestData(): (api.Join, api.StagingQuery) = {
     // ------------------------------------------JOIN------------------------------------------

--- a/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
@@ -232,7 +232,7 @@ class SchemaEvolutionTest extends TestCase {
       tableUtils: TableUtils,
       inMemoryKvStore: InMemoryKvStore
   ): Unit = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     joinTestSuite.groupBys.foreach { gbTestSuite =>
       val tableName = s"${namespace}.${gbTestSuite.name}"
       gbTestSuite.groupByData.save(tableName)

--- a/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
@@ -34,7 +34,7 @@ class StagingQueryTest {
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   private val ninetyDaysAgo = tableUtils.partitionSpec.minus(today, new Window(90, TimeUnit.DAYS))
   private val namespace = "staging_query_chronon_test"
-  spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+  tableUtils.createDatabase(namespace)
 
   @Test
   def testStagingQuery(): Unit = {

--- a/spark/src/test/scala/ai/chronon/spark/test/StatsComputeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StatsComputeTest.scala
@@ -53,7 +53,7 @@ class StatsComputeTest {
 
   @Test
   def snapshotSummaryTest(): Unit = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val data = Seq(
       ("1", Some(1L), Some(1.0), Some("a")),
       ("1", Some(1L), None, Some("b")),

--- a/spark/src/test/scala/ai/chronon/spark/test/StreamingTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StreamingTest.scala
@@ -50,7 +50,7 @@ class StreamingTest extends TestCase {
   private val yearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
 
   def testStructInStreaming(): Unit = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val topicName = "fake_topic"
     val inMemoryKvStore = buildInMemoryKvStore()
     val nameSuffix = "_struct_streaming_test"

--- a/spark/src/test/scala/ai/chronon/spark/test/TestUtils.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TestUtils.scala
@@ -386,7 +386,7 @@ object TestUtils {
   }
 
   def getParentJoin(spark: SparkSession, namespace: String, name: String, gbName: String): api.Join = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val topic = "kafka://test_topic/schema=my_schema/host=X/port=Y"
     val listingCol = Column("listing", StringType, 50)
     // price for listing

--- a/spark/src/test/scala/ai/chronon/spark/test/TestUtils.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TestUtils.scala
@@ -21,6 +21,7 @@ import ai.chronon.api
 import ai.chronon.api._
 import ai.chronon.online.SparkConversions
 import ai.chronon.spark.Extensions._
+import ai.chronon.spark.TableUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
@@ -386,7 +387,7 @@ object TestUtils {
   }
 
   def getParentJoin(spark: SparkSession, namespace: String, name: String, gbName: String): api.Join = {
-    tableUtils.createDatabase(namespace)
+    TableUtils(spark).createDatabase(namespace)
     val topic = "kafka://test_topic/schema=my_schema/host=X/port=Y"
     val listingCol = Column("listing", StringType, 50)
     // price for listing
@@ -411,7 +412,8 @@ object TestUtils {
     val viewsCols = Seq(listingCol, userCol)
     val viewsTable = s"$namespace.views_table"
     val viewsDf = DataFrameGen
-      .events(spark, viewsCols, 30, 7).filter(col("user").isNotNull && col("listing").isNotNull)
+      .events(spark, viewsCols, 30, 7)
+      .filter(col("user").isNotNull && col("listing").isNotNull)
     viewsDf.show()
     viewsDf.save(viewsTable)
 

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
@@ -45,7 +45,7 @@ class DerivationTest {
   @Test
   def testBootstrapToDerivations(): Unit = {
     val namespace = "test_derivations"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
 
     val derivation1 = Builders.Derivation(name = "user_amount_30d_avg",
@@ -292,7 +292,7 @@ class DerivationTest {
   @Test
   def testBootstrapToDerivationsNoStar(): Unit = {
     val namespace = "test_derivations_no_star"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
 
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
     val queryTable = BootstrapUtils.buildQuery(namespace, spark)
@@ -374,7 +374,7 @@ class DerivationTest {
   }
 
   private def runLoggingTest(namespace: String, wildcardSelection: Boolean): Unit = {
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
 
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
     val queryTable = BootstrapUtils.buildQuery(namespace, spark)
@@ -500,7 +500,7 @@ class DerivationTest {
   @Test
   def testContextual(): Unit = {
     val namespace = "test_contextual"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val queryTable = BootstrapUtils.buildQuery(namespace, spark)
     val bootstrapDf = spark
       .table(queryTable)
@@ -629,7 +629,7 @@ class DerivationTest {
   @Test
   def testGroupByDerivations(): Unit = {
     val namespace = "test_group_by_derivations"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
     groupBy.setBackfillStartDate(today)
     groupBy.setDerivations(Seq(

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/LogBootstrapTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/LogBootstrapTest.scala
@@ -38,8 +38,8 @@ class LogBootstrapTest {
 
   val spark: SparkSession = SparkSessionBuilder.build("BootstrapTest", local = true)
   val namespace = "test_log_bootstrap"
-  tableUtils.createDatabase(namespace)
   private implicit val tableUtils: TableUtils = TableUtils(spark)
+  tableUtils.createDatabase(namespace)
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
 
   @Test
@@ -50,7 +50,7 @@ class LogBootstrapTest {
     val groupBy2 = groupBy
       .deepCopy()
       .setAggregations(
-          Seq(Builders.Aggregation(operation = Operation.SUM, inputColumn = "amount_dollars")).toJava
+        Seq(Builders.Aggregation(operation = Operation.SUM, inputColumn = "amount_dollars")).toJava
       )
       .setMetaData(Builders.MetaData(name = "unit_test.user_transactions_v2", namespace = namespace, team = "chronon"))
 

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/LogBootstrapTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/LogBootstrapTest.scala
@@ -38,7 +38,7 @@ class LogBootstrapTest {
 
   val spark: SparkSession = SparkSessionBuilder.build("BootstrapTest", local = true)
   val namespace = "test_log_bootstrap"
-  spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+  tableUtils.createDatabase(namespace)
   private implicit val tableUtils: TableUtils = TableUtils(spark)
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
 

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/TableBootstrapTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/TableBootstrapTest.scala
@@ -77,7 +77,7 @@ class TableBootstrapTest {
   def testBootstrap(): Unit = {
 
     val namespace = "test_table_bootstrap"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
 
     // group by
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
@@ -161,7 +161,7 @@ class TableBootstrapTest {
   def testBootstrapSameJoinPartMultipleSources(): Unit = {
 
     val namespace = "test_bootstrap_multi_source"
-    spark.sql(s"CREATE DATABASE IF NOT EXISTS $namespace")
+    tableUtils.createDatabase(namespace)
 
     val queryTable = BootstrapUtils.buildQuery(namespace, spark)
     val endDs = spark.table(queryTable).select(max(tableUtils.partitionColumn)).head().getString(0)


### PR DESCRIPTION
## Summary

when joinSource left is events & right is entities, mutationScan is being set to false, but we still enter temporalEntities case as we should. This PR disables mutation scan all together.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@ezvz @better365 
