### PR TITLE
Add print logging behind a flag

### DIFF
--- a/spark/src/main/resources/log4j.properties
+++ b/spark/src/main/resources/log4j.properties
@@ -1,0 +1,25 @@
+#Log4j pattern documentation - https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} [%p] [%c{1}:%L] %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=ERROR
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=WARN
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=WARN
+log4j.logger.org.apache.spark.scheduler=ERROR
+log4j.logger.org.apache.spark.storage.memory=ERROR
+log4j.logger.org.apache.spark.SecurityManager=ERROR
+log4j.logger.org.apache.spark.SparkEnv=WARN
+log4j.logger.org.apache.spark.storage=ERROR
+log4j.logger.org.apache.spark.sql=WARN
+log4j.logger.org.apache.spark.executor=ERROR
+log4j.logger.org.apache.parquet.filter2=WARN
+log4j.logger.org.apache.spark.SparkContext=WARN
+log4j.logger.org.apache.parquet.hadoop=WARN
+log4j.logger.org.apache.hadoop.mapreduce=ERROR
+log4j.logger.ai.chronon.spark=INFO

--- a/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
@@ -91,7 +91,7 @@ object SparkSessionBuilder {
     }
     val spark = builder.getOrCreate()
     // disable log spam
-    // spark.sparkContext.setLogLevel("ERROR")
+    spark.sparkContext.setLogLevel("ERROR")
 
     Logger.getLogger("parquet.hadoop").setLevel(java.util.logging.Level.SEVERE)
     spark
@@ -119,7 +119,7 @@ object SparkSessionBuilder {
     }
     val spark = builder.getOrCreate()
     // disable log spam
-    // spark.sparkContext.setLogLevel("ERROR")
+    spark.sparkContext.setLogLevel("ERROR")
     Logger.getLogger("parquet.hadoop").setLevel(java.util.logging.Level.SEVERE)
     spark
   }


### PR DESCRIPTION
## Summary
In a lot of environments configuring logs is not straight forward. This flag allows driver logs to appear on stdout regardless of log4j properties that might be lurking deep in the EMR environment and suppressing our logs.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Reviewers
@ezvz @donghanz 
