### PR TITLE
Make sure there is a mutation table for mutation sources 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -514,7 +514,9 @@ object GroupBy {
     }
 
     // Generate mutation Df if required, align the columns with inputDf so no additional schema is needed by aggregator.
-    val mutationSources = groupByConf.sources.toScala.filter { _.isSetEntities }
+    val mutationSources = groupByConf.sources.toScala.filter { source =>
+      source.isSetEntities && source.getEntities.isSetMutationTable
+    }
     val mutationsColumnOrder = inputDf.columns ++ Constants.MutationFields.map(_.name)
 
     def mutationDfFn(): DataFrame = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
In this PR, we will check if there is a mutation table in the entity source to determine if it is a mutation source. The entity source itself is not enough. 

Before this PR: 
In the Entity JoinSource case, it will try to generate the mutation data frame. However, there are no mutation related fields like `is_before` or `mutation_time_column`. Therefore, the job will exit early with some schema could not resolved error. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [x] tested with Airbnb internal case 

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers @nikhilsimha @hanyuli1995 @donghanz @ezvz 
