### PR TITLE
refactor: lazy import and add left table setups

### DIFF
--- a/api/py/ai/chronon/repo/join_backfill.py
+++ b/api/py/ai/chronon/repo/join_backfill.py
@@ -2,7 +2,6 @@ import json
 import os
 from typing import Optional
 
-from ai.chronon.constants import ADAPTERS
 from ai.chronon.scheduler.interfaces.flow import Flow
 from ai.chronon.scheduler.interfaces.node import Node
 from ai.chronon.utils import (
@@ -97,6 +96,8 @@ class JoinBackfill:
         return self.export_template(settings) + " && " + self.command_template(extra_args={"mode": "backfill-final"})
 
     def run(self, orchestrator: str, overrides: Optional[dict] = None):
+        from ai.chronon.constants import ADAPTERS
+
         ADAPTERS.update(overrides)
         orchestrator = ADAPTERS[orchestrator](dag_id=self.dag_id, start_date=self.start_date)
         orchestrator.setup()

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -339,8 +339,6 @@ abstract class JoinBase(joinConf: api.Join,
   }
 
   def computeLeft(overrideStartPartition: Option[String] = None): Unit = {
-    // Register UDFs for the left part computation
-    joinConf.setups.foreach(tableUtils.sql)
     // Runs the left side query for a join and saves the output to a table, for reuse by joinPart
     // Computation in parallelized joinPart execution mode.
     if (shouldRecomputeLeft(joinConf, bootstrapTable, tableUtils)) {
@@ -354,6 +352,8 @@ abstract class JoinBase(joinConf: api.Join,
     if (unfilledRanges.isEmpty) {
       logger.info(s"Range to fill already computed. Skipping query execution...")
     } else {
+      // Register UDFs for the left part computation
+      joinConf.setups.foreach(tableUtils.sql)
       val leftSchema = leftDf(joinConf, unfilledRanges.head, tableUtils, limit = Some(1)).map(df => df.schema)
       val bootstrapInfo = BootstrapInfo.from(joinConf, rangeToFill, tableUtils, leftSchema)
       logger.info(s"Running ranges: $unfilledRanges")

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -339,6 +339,8 @@ abstract class JoinBase(joinConf: api.Join,
   }
 
   def computeLeft(overrideStartPartition: Option[String] = None): Unit = {
+    // Register UDFs for the left part computation
+    joinConf.setups.foreach(tableUtils.sql)
     // Runs the left side query for a join and saves the output to a table, for reuse by joinPart
     // Computation in parallelized joinPart execution mode.
     if (shouldRecomputeLeft(joinConf, bootstrapTable, tableUtils)) {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- lazy import ADAPTERS constant 
- add left table setups in computeLeft()


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested


## Reviewers

