### PR TITLE
fix: Update derivation response map to pass through base exceptions 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -250,10 +250,13 @@ class Fetcher(val kvStore: KVStore,
                       Map("derivation_fetch_exception" -> exception.traceString.asInstanceOf[AnyRef])
                     renameOnlyDerivedMap ++ derivedExceptionMap
                 }
+                // Preserve exceptions from baseMap
+                val baseMapExceptions = baseMap.filter(_._1.endsWith("_exception"))
+                val finalizedDerivedMap = derivedMap ++ baseMapExceptions
                 val requestEndTs = System.currentTimeMillis()
                 ctx.distribution("derivation.latency.millis", requestEndTs - derivationStartTs)
                 ctx.distribution("overall.latency.millis", requestEndTs - ts)
-                ResponseWithContext(internalResponse.request, derivedMap, baseMap)
+                ResponseWithContext(internalResponse.request, finalizedDerivedMap, baseMap)
               case Failure(exception) =>
                 // more validation logic will be covered in compile.py to avoid this case
                 ctx.incrementException(exception)

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -738,8 +738,11 @@ class FetcherTest extends TestCase {
     val responseMap = responses.head.values.get
 
     logger.info("====== Empty request response map ======")
-    assertEquals(joinConf.joinParts.size() + joinConf.derivations.toScala.derivationsWithoutStar.size, responseMap.size)
-    assertEquals(responseMap.keys.count(_.endsWith("_exception")), joinConf.joinParts.size())
+    logger.info(responseMap.toString)
+    // In this case because of empty keys, both attempts to compute derivation will fail
+    val derivationExceptionTypes = Seq("derivation_fetch_exception", "derivation_rename_exception")
+    assertEquals(joinConf.joinParts.size() + derivationExceptionTypes.size, responseMap.size)
+    assertTrue(responseMap.keys.forall(_.endsWith("_exception")))
   }
 }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -725,7 +725,7 @@ class FetcherTest extends TestCase {
     val namespace = "empty_request"
     val joinConf = generateRandomData(namespace, 5, 5)
     implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
-    val kvStoreFunc = () => OnlineUtils.buildInMemoryKVStore("FetcherTest")
+    val kvStoreFunc = () => OnlineUtils.buildInMemoryKVStore("FetcherTest#empty_request")
     val inMemoryKvStore = kvStoreFunc()
     val mockApi = new MockApi(kvStoreFunc, namespace)
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

One of the UTs of `FetcherTest` is failing on main branch. The RC is that we updated fetcher response map logic when there is failure in derivations. 

This PR updated the logic to pass through the base exceptions. Base map fetching failure will **guarantee** failure of derivation because some fields are missing, so passing through the base exception is important to keep trace of the original issue.  Also the UT is updated to match the new behavior. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Fix a UT on main branch, and properly handle exception logging in response map.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pengyu-hou @yuli-han @donghanz 
