### PR TITLE
fix: analyzer handle multiple sources and bootstrap 

### DIFF
--- a/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
+++ b/api/src/main/scala/ai/chronon/api/PartitionSpec.scala
@@ -54,5 +54,5 @@ case class PartitionSpec(format: String, spanMillis: Long) {
 
   def now: String = at(System.currentTimeMillis())
 
-  def shiftBackFromNow(days: Int) = shift(now, 0 - days)
+  def shiftBackFromNow(days: Int): String = shift(now, 0 - days)
 }

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -352,7 +352,7 @@ class Analyzer(tableUtils: TableUtils,
       logger.info(noAccessTables.mkString("\n"))
       logger.info(s"---- Data availability check completed. Found issue in ${dataAvailabilityErrors.size} tables ----")
       dataAvailabilityErrors.foreach(error =>
-        logger.info(s"Table ${error._1} : Group_By ${error._2} : Expected start ${error._3}"))
+        logger.info(s"Group_By ${error._2} : Source Tables ${error._1} : Expected start ${error._3}"))
     }
 
     if (validationAssert) {
@@ -404,9 +404,9 @@ class Analyzer(tableUtils: TableUtils,
   // - For aggregation case, gb table earliest partition should go back to (first_unfilled_partition - max_window) date
   // - For none aggregation case or unbounded window, no earliest partition is required
   // return a list of (table, gb_name, expected_start) that don't have data available
-  def runDataAvailabilityCheck(leftDataModel: DataModel,
-                               groupBy: api.GroupBy,
-                               unfilledRanges: Seq[PartitionRange]): List[(String, String, String)] = {
+  private def runDataAvailabilityCheck(leftDataModel: DataModel,
+                                       groupBy: api.GroupBy,
+                                       unfilledRanges: Seq[PartitionRange]): List[(String, String, String)] = {
     if (unfilledRanges.isEmpty) {
       logger.info("No unfilled ranges found.")
       List.empty
@@ -430,21 +430,36 @@ class Analyzer(tableUtils: TableUtils,
             case (Events, Entities, Accuracy.TEMPORAL) =>
               tableUtils.partitionSpec.minus(leftShiftedPartitionRangeStart, window)
           }
-          groupBy.sources.toScala.flatMap { source =>
-            val table = source.table
-            logger.info(s"Checking table $table for data availability ... Expected start partition: $expectedStart")
-            val existingPartitions = tableUtils.partitions(table)
-            val minPartition = existingPartitions.reduceOption((a, b) => Ordering[String].min(a, b))
-            //check if partition available or table is cumulative
-            if (!tableUtils.ifPartitionExistsInTable(table, expectedStart) && !source.isCumulative) {
-              println(s"""
-                         |Join needs data older than what is available for GroupBy: ${groupBy.metaData.name}, table: $table,
+          logger.info(
+            s"Checking data availability for group_by ${groupBy.metaData.name} ... Expected start partition: $expectedStart")
+          if (groupBy.sources.toScala.exists(s => s.isCumulative)) {
+            List.empty
+          } else {
+            val tableToPartitions = groupBy.sources.toScala.map { source =>
+              val table = source.table
+              logger.info(s"Checking table $table for data availability ...")
+              val partitions = tableUtils.partitions(table)
+              val startOpt = if (partitions.isEmpty) None else Some(partitions.min)
+              val endOpt = if (partitions.isEmpty) None else Some(partitions.max)
+              (table, partitions, startOpt, endOpt)
+            }
+            val allPartitions = tableToPartitions.flatMap(_._2)
+            val minPartition = if (allPartitions.isEmpty) None else Some(allPartitions.min)
+
+            if (minPartition.isEmpty || minPartition.get > expectedStart) {
+              logger.info(s"""
+                         |Join needs data older than what is available for GroupBy: ${groupBy.metaData.name}
                          |left-$leftDataModel, right-${groupBy.dataModel}, accuracy-${groupBy.inferredAccuracy}
-                         |expectedStartPartition: $expectedStart, actualStartPartition: $minPartition
-                         |""".stripMargin)
-              Some((table, groupBy.getMetaData.getName, expectedStart))
+                         |expected earliest available data partition: $expectedStart""".stripMargin)
+              tableToPartitions.foreach {
+                case (table, _, startOpt, endOpt) =>
+                  logger.info(
+                    s"Table $table startPartition ${startOpt.getOrElse("empty")} endPartition ${endOpt.getOrElse("empty")}")
+              }
+              val tables = tableToPartitions.map(_._1)
+              List((tables.mkString(", "), groupBy.metaData.name, expectedStart))
             } else {
-              None
+              List.empty
             }
           }
         case None =>

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -356,10 +356,19 @@ class Analyzer(tableUtils: TableUtils,
     }
 
     if (validationAssert) {
-      assert(
-        keysWithError.isEmpty && noAccessTables.isEmpty && dataAvailabilityErrors.isEmpty,
-        "ERROR: Join validation failed. Please check error message for details."
-      )
+      if (joinConf.isSetBootstrapParts) {
+        // For joins with bootstrap_parts, do not assert on data availability errors, as bootstrap can cover them
+        // Only print out the errors as a warning
+        assert(
+          keysWithError.isEmpty && noAccessTables.isEmpty,
+          "ERROR: Join validation failed. Please check error message for details."
+        )
+      } else {
+        assert(
+          keysWithError.isEmpty && noAccessTables.isEmpty && dataAvailabilityErrors.isEmpty,
+          "ERROR: Join validation failed. Please check error message for details."
+        )
+      }
     }
     // (schema map showing the names and datatypes, right side feature aggregations metadata for metadata upload)
     (leftSchema ++ rightSchema, aggregationsMetadata)

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -287,9 +287,6 @@ case class TableUtils(sparkSession: SparkSession) {
   def firstAvailablePartition(tableName: String, subPartitionFilters: Map[String, String] = Map.empty): Option[String] =
     partitions(tableName, subPartitionFilters).reduceOption((x, y) => Ordering[String].min(x, y))
 
-  def ifPartitionExistsInTable(tableName: String, partition: String): Boolean =
-    partitions(tableName).contains(partition)
-
   def insertPartitions(df: DataFrame,
                        tableName: String,
                        tableProperties: Map[String, String] = null,

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -16,16 +16,16 @@
 
 package ai.chronon.spark.test
 
-import org.slf4j.LoggerFactory
 import ai.chronon.aggregator.test.Column
 import ai.chronon.api
-import ai.chronon.api.{Accuracy, Builders, Operation, TimeUnit, Window}
-import ai.chronon.spark.{Analyzer, Join, SparkSessionBuilder, TableUtils}
+import ai.chronon.api._
 import ai.chronon.spark.Extensions._
+import ai.chronon.spark.{Analyzer, Join, SparkSessionBuilder, TableUtils}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.{col, max, min}
+import org.apache.spark.sql.functions.col
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.slf4j.LoggerFactory
 
 class AnalyzerTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -121,9 +121,9 @@ class AnalyzerTest {
       sources = Seq(viewsSource),
       keyColumns = Seq("item_id"),
       aggregations = Seq(
-        Builders.Aggregation( windows = Seq(new Window(365, TimeUnit.DAYS)), // greater than one year
-          operation = Operation.AVERAGE,
-          inputColumn = "time_spent_ms")
+        Builders.Aggregation(windows = Seq(new Window(365, TimeUnit.DAYS)), // greater than one year
+                             operation = Operation.AVERAGE,
+                             inputColumn = "time_spent_ms")
       ),
       metaData = Builders.MetaData(name = "join_analyzer_test.item_data_avail_gb", namespace = namespace),
       accuracy = Accuracy.SNAPSHOT
@@ -184,16 +184,16 @@ class AnalyzerTest {
       )
     }
 
-    val groupBy =  Builders.GroupBy(
+    val groupBy = Builders.GroupBy(
       sources = Seq(
         buildSource(Some(firstSourceStartPartition), Some(firstSourceEndPartition), rightSourceTable1),
         buildSource(Some(secondSourceStartPartition), None, rightSourceTable2)
       ),
       keyColumns = Seq("item"),
       aggregations = Seq(
-        Builders.Aggregation( windows = Seq(new Window(90, TimeUnit.DAYS)), // greater than one year
-          operation = Operation.AVERAGE,
-          inputColumn = "price")
+        Builders.Aggregation(windows = Seq(new Window(90, TimeUnit.DAYS)), // greater than one year
+                             operation = Operation.AVERAGE,
+                             inputColumn = "price")
       ),
       metaData = Builders.MetaData(name = "multiple_sources.item_gb", namespace = namespace),
       accuracy = Accuracy.SNAPSHOT

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
@@ -424,12 +424,4 @@ class TableUtilsTest {
     tableUtils.sql("CREATE TEMPORARY FUNCTION test AS 'ai.chronon.spark.test.SimpleAddUDF'")
   }
 
-  @Test
-  def testIfPartitionExistsInTable(): Unit = {
-    val tableName = "db.test_if_partition_exists"
-    prepareTestDataWithSubPartitions(tableName)
-    assertTrue(tableUtils.ifPartitionExistsInTable(tableName, "2022-11-03"))
-    assertFalse(tableUtils.ifPartitionExistsInTable(tableName, "2023-01-01"))
-  }
-
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Update analyzer logic: 
- handle multiple sources
- handle bootstrap (skip validation)

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

GroupBy with multiple sources is supported and all sources is "unioned" before processing the group by. So the data availability check in analyer only need to verify that the combined date range of the sources need to cover required date ranges. Current logic requires each source covering all date range which is wrong. 

For joins with bootstrap, there is no straightforward to identify the required date range without actually running the bootstrap. So for joins with bootstrap we simply don't raise data availability "errors" (but only print them). 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested 

Ran local JAR on user joins 

## Checklist
- [ ] Documentation update

## Reviewers

@yuli-han @pengyu-hou @donghanz 