### PR TITLE
Add bounded unique count aggregation

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -635,7 +635,7 @@ class BoundedUniqueCount[T](inputType: DataType, k: Int = 8) extends SimpleAggre
   override def irType: DataType = ListType(StringType)
 
   override def merge(ir1: util.Set[String], ir2: util.Set[String]): util.Set[String] = {
-    ir2.asScala.foreach(v =>
+    ir2.iterator().asScala.foreach(v =>
       if (ir1.size() < k) {
         ir1.add(v)
       })

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -649,7 +649,8 @@ class BoundedUniqueCount[T](inputType: DataType, k: Int = 8) extends SimpleAggre
 
   override def normalize(ir: util.Set[String]): Any = new util.ArrayList[String](ir)
 
-  override def denormalize(ir: Any): util.Set[String] = new util.HashSet[String](ir.asInstanceOf[util.ArrayList[String]])
+  override def denormalize(ir: Any): util.Set[String] =
+    new util.HashSet[String](ir.asInstanceOf[util.ArrayList[String]])
 }
 
 // Based on CPC sketch (a faster, smaller and more accurate version of HLL)

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -635,10 +635,13 @@ class BoundedUniqueCount[T](inputType: DataType, k: Int = 8) extends SimpleAggre
   override def irType: DataType = ListType(StringType)
 
   override def merge(ir1: util.Set[String], ir2: util.Set[String]): util.Set[String] = {
-    ir2.iterator().asScala.foreach(v =>
-      if (ir1.size() < k) {
-        ir1.add(v)
-      })
+    ir2
+      .iterator()
+      .asScala
+      .foreach(v =>
+        if (ir1.size() < k) {
+          ir1.add(v)
+        })
 
     ir1
   }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -632,7 +632,7 @@ class BoundedUniqueCount[T](inputType: DataType, k: Int = 8) extends SimpleAggre
 
   override def outputType: DataType = LongType
 
-  override def irType: DataType = ListType(inputType)
+  override def irType: DataType = ListType(StringType)
 
   override def merge(ir1: util.Set[String], ir2: util.Set[String]): util.Set[String] = {
     ir2.asScala.foreach(v =>

--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
@@ -307,7 +307,19 @@ object ColumnAggregator {
           case BinaryType => simple(new ApproxDistinctCount[Array[Byte]](aggregationPart.getInt("k", Some(8))))
           case _          => mismatchException
         }
+      case Operation.BOUNDED_UNIQUE_COUNT =>
+        val k = aggregationPart.getInt("k", Some(8))
 
+        inputType match {
+          case IntType    => simple(new BoundedUniqueCount[Int](inputType, k))
+          case LongType   => simple(new BoundedUniqueCount[Long](inputType, k))
+          case ShortType  => simple(new BoundedUniqueCount[Short](inputType, k))
+          case DoubleType => simple(new BoundedUniqueCount[Double](inputType, k))
+          case FloatType  => simple(new BoundedUniqueCount[Float](inputType, k))
+          case StringType => simple(new BoundedUniqueCount[String](inputType, k))
+          case BinaryType => simple(new BoundedUniqueCount[Array[Byte]](inputType, k))
+          case _          => mismatchException
+        }
       case Operation.APPROX_PERCENTILE =>
         val k = aggregationPart.getInt("k", Some(128))
         val mapper = new ObjectMapper()

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/BoundedUniqueCountTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/BoundedUniqueCountTest.scala
@@ -1,0 +1,44 @@
+package ai.chronon.aggregator.test
+
+import ai.chronon.aggregator.base.BoundedUniqueCount
+import ai.chronon.api.StringType
+import junit.framework.TestCase
+import org.junit.Assert._
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+class BoundedUniqueCountTest extends TestCase {
+  def testHappyCase(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[String](StringType, 5)
+    var ir = boundedDistinctCount.prepare("1")
+    ir = boundedDistinctCount.update(ir, "1")
+    ir = boundedDistinctCount.update(ir, "2")
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(2, result)
+  }
+
+  def testExceedSize(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[String](StringType, 5)
+    var ir = boundedDistinctCount.prepare("1")
+    ir = boundedDistinctCount.update(ir, "2")
+    ir = boundedDistinctCount.update(ir, "3")
+    ir = boundedDistinctCount.update(ir, "4")
+    ir = boundedDistinctCount.update(ir, "5")
+    ir = boundedDistinctCount.update(ir, "6")
+    ir = boundedDistinctCount.update(ir, "7")
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(5, result)
+  }
+
+  def testMerge(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[String](StringType, 5)
+    val ir1 = new util.HashSet[String](Seq("1", "2", "3").asJava)
+    val ir2 = new util.HashSet[String](Seq("4", "5", "6").asJava)
+
+    val merged = boundedDistinctCount.merge(ir1, ir2)
+    assertEquals(merged.size(), 5)
+  }
+}

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/BoundedUniqueCountTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/BoundedUniqueCountTest.scala
@@ -1,7 +1,7 @@
 package ai.chronon.aggregator.test
 
 import ai.chronon.aggregator.base.BoundedUniqueCount
-import ai.chronon.api.StringType
+import ai.chronon.api.{StringType, IntType, LongType, DoubleType, FloatType, BinaryType}
 import junit.framework.TestCase
 import org.junit.Assert._
 
@@ -35,10 +35,173 @@ class BoundedUniqueCountTest extends TestCase {
 
   def testMerge(): Unit = {
     val boundedDistinctCount = new BoundedUniqueCount[String](StringType, 5)
-    val ir1 = new util.HashSet[String](Seq("1", "2", "3").asJava)
-    val ir2 = new util.HashSet[String](Seq("4", "5", "6").asJava)
+    val ir1 = new util.HashSet[Any](Seq("1", "2", "3").asJava)
+    val ir2 = new util.HashSet[Any](Seq("4", "5", "6").asJava)
 
     val merged = boundedDistinctCount.merge(ir1, ir2)
-    assertEquals(merged.size(), 5)
+    val result = boundedDistinctCount.finalize(merged)
+    assertEquals(5, result) // Should return k=5 when exceeding the limit
+  }
+
+  def testIntTypeHappyCase(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Int](IntType, 5)
+    var ir = boundedDistinctCount.prepare(1)
+    ir = boundedDistinctCount.update(ir, 1)
+    ir = boundedDistinctCount.update(ir, 2)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(2, result)
+  }
+
+  def testIntTypeExceedSize(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Int](IntType, 5)
+    var ir = boundedDistinctCount.prepare(1)
+    ir = boundedDistinctCount.update(ir, 2)
+    ir = boundedDistinctCount.update(ir, 3)
+    ir = boundedDistinctCount.update(ir, 4)
+    ir = boundedDistinctCount.update(ir, 5)
+    ir = boundedDistinctCount.update(ir, 6)
+    ir = boundedDistinctCount.update(ir, 7)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(5, result)
+  }
+
+  def testIntTypeMerge(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Int](IntType, 5)
+    val ir1 = new util.HashSet[Any](Seq(1, 2, 3).asJava)
+    val ir2 = new util.HashSet[Any](Seq(4, 5, 6).asJava)
+
+    val merged = boundedDistinctCount.merge(ir1, ir2)
+    val result = boundedDistinctCount.finalize(merged)
+    assertEquals(5, result) // Should return k=5 when exceeding the limit
+  }
+
+  def testLongTypeHappyCase(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Long](LongType, 5)
+    var ir = boundedDistinctCount.prepare(1L)
+    ir = boundedDistinctCount.update(ir, 1L)
+    ir = boundedDistinctCount.update(ir, 2L)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(2, result)
+  }
+
+  def testLongTypeExceedSize(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Long](LongType, 5)
+    var ir = boundedDistinctCount.prepare(1L)
+    ir = boundedDistinctCount.update(ir, 2L)
+    ir = boundedDistinctCount.update(ir, 3L)
+    ir = boundedDistinctCount.update(ir, 4L)
+    ir = boundedDistinctCount.update(ir, 5L)
+    ir = boundedDistinctCount.update(ir, 6L)
+    ir = boundedDistinctCount.update(ir, 7L)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(5, result)
+  }
+
+  def testDoubleTypeHappyCase(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Double](DoubleType, 5)
+    var ir = boundedDistinctCount.prepare(1.0)
+    ir = boundedDistinctCount.update(ir, 1.0)
+    ir = boundedDistinctCount.update(ir, 2.5)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(2, result)
+  }
+
+  def testDoubleTypeExceedSize(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Double](DoubleType, 5)
+    var ir = boundedDistinctCount.prepare(1.0)
+    ir = boundedDistinctCount.update(ir, 2.5)
+    ir = boundedDistinctCount.update(ir, 3.7)
+    ir = boundedDistinctCount.update(ir, 4.2)
+    ir = boundedDistinctCount.update(ir, 5.8)
+    ir = boundedDistinctCount.update(ir, 6.3)
+    ir = boundedDistinctCount.update(ir, 7.9)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(5, result)
+  }
+
+  def testFloatTypeHappyCase(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Float](FloatType, 5)
+    var ir = boundedDistinctCount.prepare(1.0f)
+    ir = boundedDistinctCount.update(ir, 1.0f)
+    ir = boundedDistinctCount.update(ir, 2.5f)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(2, result)
+  }
+
+  def testFloatTypeExceedSize(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Float](FloatType, 5)
+    var ir = boundedDistinctCount.prepare(1.0f)
+    ir = boundedDistinctCount.update(ir, 2.5f)
+    ir = boundedDistinctCount.update(ir, 3.7f)
+    ir = boundedDistinctCount.update(ir, 4.2f)
+    ir = boundedDistinctCount.update(ir, 5.8f)
+    ir = boundedDistinctCount.update(ir, 6.3f)
+    ir = boundedDistinctCount.update(ir, 7.9f)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(5, result)
+  }
+
+  def testBinaryTypeHappyCase(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Array[Byte]](BinaryType, 5)
+    val bytes1 = Array[Byte](1, 2, 3)
+    val bytes2 = Array[Byte](4, 5, 6)
+    
+    var ir = boundedDistinctCount.prepare(bytes1)
+    ir = boundedDistinctCount.update(ir, bytes1)
+    ir = boundedDistinctCount.update(ir, bytes2)
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(2, result)
+  }
+
+  def testBinaryTypeExceedSize(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Array[Byte]](BinaryType, 5)
+    var ir = boundedDistinctCount.prepare(Array[Byte](1))
+    ir = boundedDistinctCount.update(ir, Array[Byte](2))
+    ir = boundedDistinctCount.update(ir, Array[Byte](3))
+    ir = boundedDistinctCount.update(ir, Array[Byte](4))
+    ir = boundedDistinctCount.update(ir, Array[Byte](5))
+    ir = boundedDistinctCount.update(ir, Array[Byte](6))
+    ir = boundedDistinctCount.update(ir, Array[Byte](7))
+
+    val result = boundedDistinctCount.finalize(ir)
+    assertEquals(5, result)
+  }
+
+  def testBinaryTypeMerge(): Unit = {
+    val boundedDistinctCount = new BoundedUniqueCount[Array[Byte]](BinaryType, 5)
+    val ir1 = new util.HashSet[Any](Seq(Array[Byte](1), Array[Byte](2), Array[Byte](3)).asJava)
+    val ir2 = new util.HashSet[Any](Seq(Array[Byte](4), Array[Byte](5), Array[Byte](6)).asJava)
+
+    val merged = boundedDistinctCount.merge(ir1, ir2)
+    val result = boundedDistinctCount.finalize(merged)
+    assertEquals(5, result) // Should return k=5 when exceeding the limit
+  }
+
+  def testNumericTypeIrType(): Unit = {
+    val intBoundedDistinctCount = new BoundedUniqueCount[Int](IntType, 5)
+    val longBoundedDistinctCount = new BoundedUniqueCount[Long](LongType, 5)
+    val doubleBoundedDistinctCount = new BoundedUniqueCount[Double](DoubleType, 5)
+    val floatBoundedDistinctCount = new BoundedUniqueCount[Float](FloatType, 5)
+    val binaryBoundedDistinctCount = new BoundedUniqueCount[Array[Byte]](BinaryType, 5)
+    val stringBoundedDistinctCount = new BoundedUniqueCount[String](StringType, 5)
+
+    // For numeric and binary types, irType should be ListType(inputType)
+    assertEquals(ai.chronon.api.ListType(IntType), intBoundedDistinctCount.irType)
+    assertEquals(ai.chronon.api.ListType(LongType), longBoundedDistinctCount.irType)
+    assertEquals(ai.chronon.api.ListType(DoubleType), doubleBoundedDistinctCount.irType)
+    assertEquals(ai.chronon.api.ListType(FloatType), floatBoundedDistinctCount.irType)
+    assertEquals(ai.chronon.api.ListType(BinaryType), binaryBoundedDistinctCount.irType)
+    
+    // For non-numeric types, irType should be ListType(StringType)
+    assertEquals(ai.chronon.api.ListType(StringType), stringBoundedDistinctCount.irType)
   }
 }

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -65,6 +65,7 @@ class Operation:
     # https://github.com/apache/incubator-datasketches-java/blob/master/src/main/java/org/apache/datasketches/cpc/CpcSketch.java#L180
     APPROX_UNIQUE_COUNT_LGK = collector(ttypes.Operation.APPROX_UNIQUE_COUNT)
     UNIQUE_COUNT = ttypes.Operation.UNIQUE_COUNT
+    BOUNDED_UNIQUE_COUNT = ttypes.Operation.BOUNDED_UNIQUE_COUNT
     COUNT = ttypes.Operation.COUNT
     SUM = ttypes.Operation.SUM
     AVERAGE = ttypes.Operation.AVERAGE

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -65,7 +65,7 @@ class Operation:
     # https://github.com/apache/incubator-datasketches-java/blob/master/src/main/java/org/apache/datasketches/cpc/CpcSketch.java#L180
     APPROX_UNIQUE_COUNT_LGK = collector(ttypes.Operation.APPROX_UNIQUE_COUNT)
     UNIQUE_COUNT = ttypes.Operation.UNIQUE_COUNT
-    BOUNDED_UNIQUE_COUNT = ttypes.Operation.BOUNDED_UNIQUE_COUNT
+    BOUNDED_UNIQUE_COUNT_K = collector(ttypes.Operation.BOUNDED_UNIQUE_COUNT)
     COUNT = ttypes.Operation.COUNT
     SUM = ttypes.Operation.SUM
     AVERAGE = ttypes.Operation.AVERAGE

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -161,7 +161,8 @@ enum Operation {
     BOTTOM_K = 16
 
     HISTOGRAM = 17, // use this only if you know the set of inputs is bounded
-    APPROX_HISTOGRAM_K = 18
+    APPROX_HISTOGRAM_K = 18,
+    BOUNDED_UNIQUE_COUNT = 19
 }
 
 // integers map to milliseconds in the timeunit

--- a/docs/source/authoring_features/GroupBy.md
+++ b/docs/source/authoring_features/GroupBy.md
@@ -147,6 +147,7 @@ Limitations:
 | approx_unique_count      | primitive types | list, map        | long              | no         | k=8                | yes            |
 | approx_percentile        | primitive types | list, map        | list<input,>      | no         | k=128, percentiles | yes            |
 | unique_count             | primitive types | list, map        | long              | no         |                    | no             |
+| bounded_unique_count     | primitive types | list, map        | long              | no         | k=inf              | yes            |
 
 
 ## Accuracy

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -273,8 +273,11 @@ class FetcherTest extends TestCase {
         Builders.Aggregation(operation = Operation.LAST_K,
                              argMap = Map("k" -> "300"),
                              inputColumn = "user",
-                             windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS)))
-      ),
+                             windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS))),
+        Builders.Aggregation(operation = Operation.BOUNDED_UNIQUE_COUNT,
+                             argMap = Map("k" -> "5"),
+                             inputColumn = "user",
+                             windows = Seq(new Window(2, TimeUnit.DAYS), new Window(30, TimeUnit.DAYS)))),
       metaData = Builders.MetaData(name = "unit_test/vendor_ratings", namespace = namespace),
       accuracy = Accuracy.SNAPSHOT
     )
@@ -501,6 +504,11 @@ class FetcherTest extends TestCase {
         ),
         Builders.Aggregation(
           operation = Operation.APPROX_HISTOGRAM_K,
+          inputColumn = "rating",
+          windows = Seq(new Window(1, TimeUnit.DAYS))
+        ),
+        Builders.Aggregation(
+          operation = Operation.BOUNDED_UNIQUE_COUNT,
           inputColumn = "rating",
           windows = Seq(new Window(1, TimeUnit.DAYS))
         )

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -727,6 +727,7 @@ class GroupByTest {
 
   @Test
   def testBoundedUniqueCounts(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource(suffix = "_bounded_counts")
     val tableUtils = TableUtils(spark)
     val namespace = "test_bounded_counts"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adds a BOUNDED_UNIQUE_COUNT aggregation. This will allow exact unique/distinct counts, but will cap at a given value to keep memory usage constant.

## Why / Goal
We have use cases where we'd prefer an exact solution instead of the approx equivalents, but want to have protections in place so that memory doesn't become an issue. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [x] Documentation update

## Reviewers

