### PR TITLE
fix: join source backfill

### DIFF
--- a/api/py/ai/chronon/scheduler/interfaces/flow.py
+++ b/api/py/ai/chronon/scheduler/interfaces/flow.py
@@ -8,10 +8,10 @@ It can be visualized as a tree structure.
 class Flow:
     def __init__(self, name):
         self.name = name
-        self.nodes = []
+        self.nodes = set()
 
     def add_node(self, node):
-        self.nodes.append(node)
+        self.nodes.add(node)
 
     def find_node(self, name):
         for node in self.nodes:

--- a/api/py/ai/chronon/scheduler/interfaces/node.py
+++ b/api/py/ai/chronon/scheduler/interfaces/node.py
@@ -4,7 +4,15 @@ class Node:
         self.command = command
         self.args = args
         self.kwargs = kwargs
-        self.dependencies = []
+        self.dependencies = set()
 
     def add_dependency(self, node):
-        self.dependencies.append(node)
+        self.dependencies.add(node)
+
+    def __eq__(self, other):
+        if isinstance(other, Node):
+            return self.name == other.name
+        return False
+
+    def __hash__(self):
+        return hash(self.name)

--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -464,3 +464,9 @@ def convert_json_to_obj(d):
         return [convert_json_to_obj(item) for item in d]
     else:
         return d
+
+
+def get_config_path(join_name: str) -> str:
+    assert "." in join_name, f"Invalid join name: {join_name}"
+    team_name, config_name = join_name.split(".", 1)
+    return f"production/joins/{team_name}/{config_name}"

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -444,7 +444,7 @@ object Extensions {
     def semanticHash: String = {
       val newGroupBy = groupBy.deepCopy()
       newGroupBy.unsetMetaData()
-      logger.info(s"GroupBy object: ${ThriftJsonCodec.toJsonStr(newGroupBy)}")
+      logger.info(s"Computing semantic hash for GroupBy object: ${ThriftJsonCodec.toJsonStr(newGroupBy)}")
       ThriftJsonCodec.md5Digest(newGroupBy)
     }
 

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -424,6 +424,7 @@ object Extensions {
   }
 
   implicit class GroupByOps(groupBy: GroupBy) extends GroupBy(groupBy) {
+    @transient lazy val logger = LoggerFactory.getLogger(getClass)
     def maxWindow: Option[Window] = {
       val allWindowsOpt = Option(groupBy.aggregations)
         .flatMap(_.toScala.toSeq.allWindowsOpt)
@@ -443,6 +444,7 @@ object Extensions {
     def semanticHash: String = {
       val newGroupBy = groupBy.deepCopy()
       newGroupBy.unsetMetaData()
+      logger.info(s"GroupBy object: ${ThriftJsonCodec.toJsonStr(newGroupBy)}")
       ThriftJsonCodec.md5Digest(newGroupBy)
     }
 
@@ -852,7 +854,6 @@ object Extensions {
      */
     def semanticHash: Map[String, String] = {
       val leftHash = ThriftJsonCodec.md5Digest(join.left)
-      logger.info(s"Join Left Hash: $leftHash")
       logger.info(s"Join Left Object: ${ThriftJsonCodec.toJsonStr(join.left)}")
       val partHashes = join.joinParts.toScala.map { jp => partOutputTable(jp) -> jp.groupBy.semanticHash }.toMap
       val derivedHashMap = Option(join.derivations)

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -75,14 +75,16 @@ object BootstrapInfo {
   def from(joinConf: api.Join,
            range: PartitionRange,
            tableUtils: TableUtils,
-           leftSchema: Option[StructType]): BootstrapInfo = {
+           leftSchema: Option[StructType],
+           computeDependency: Boolean = false): BootstrapInfo = {
 
     // Enrich each join part with the expected output schema
     logger.info(s"\nCreating BootstrapInfo for GroupBys for Join ${joinConf.metaData.name}")
     var joinParts: Seq[JoinPartMetadata] = Option(joinConf.joinParts.toScala)
       .getOrElse(Seq.empty)
       .map(part => {
-        val gb = GroupBy.from(part.groupBy, range, tableUtils, computeDependency = true)
+        // set computeDependency to False as we compute dependency upstream
+        val gb = GroupBy.from(part.groupBy, range, tableUtils, computeDependency)
         val keySchema = SparkConversions
           .toChrononSchema(gb.keySchema)
           .map(field => StructField(part.rightToLeft(field._1), field._2))

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -480,7 +480,9 @@ abstract class JoinBase(joinConf: api.Join,
     val runSmallMode = {
       if (tableUtils.smallModelEnabled) {
         val thresholdCount =
-          leftDf(joinConf, wholeRange, tableUtils, limit = Some(tableUtils.smallModeNumRowsCutoff + 1)).get.count()
+          leftDf(joinConf, wholeRange, tableUtils, limit = Some(tableUtils.smallModeNumRowsCutoff + 1))
+            .map(_.count)
+            .getOrElse(0)
         val result = thresholdCount <= tableUtils.smallModeNumRowsCutoff
         if (result) {
           logger.info(s"Counted $thresholdCount rows, running join in small mode.")

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -479,9 +479,9 @@ abstract class JoinBase(joinConf: api.Join,
 
     val runSmallMode = {
       if (tableUtils.smallModelEnabled) {
-        val thresholdCount =
+        val thresholdCount: Int =
           leftDf(joinConf, wholeRange, tableUtils, limit = Some(tableUtils.smallModeNumRowsCutoff + 1))
-            .map(_.count)
+            .map(_.count.toInt)
             .getOrElse(0)
         val result = thresholdCount <= tableUtils.smallModeNumRowsCutoff
         if (result) {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -16,8 +16,7 @@
 
 package ai.chronon.spark
 
-import java.util
-import org.slf4j.LoggerFactory
+import ai.chronon.api
 import ai.chronon.api.Constants
 import ai.chronon.api.DataModel.Events
 import ai.chronon.api.Extensions.{JoinOps, _}
@@ -27,11 +26,12 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{coalesce, col, udf}
 import org.apache.spark.util.sketch.BloomFilter
+import org.slf4j.LoggerFactory
 
+import java.util
 import scala.collection.compat._
 import scala.jdk.CollectionConverters._
-import scala.util.ScalaJavaConversions.{JIteratorOps, JMapOps, MapOps}
-import ai.chronon.api
+import scala.util.ScalaJavaConversions.MapOps
 
 object JoinUtils {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -368,9 +368,12 @@ object JoinUtils {
             s"$groupByKeyExpression in (${valueSet.mkString(sep = ",")})"
         }
         .foreach { whereClause =>
-          val currentWheres = Option(source.rootQuery.getWheres).getOrElse(new util.ArrayList[String]())
-          currentWheres.add(whereClause)
-          source.rootQuery.setWheres(currentWheres)
+          // Skip adding the filter if it is a join source
+          if (!source.isSetJoinSource) {
+            val currentWheres = Option(source.rootQuery.getWheres).getOrElse(new util.ArrayList[String]())
+            currentWheres.add(whereClause)
+            source.rootQuery.setWheres(currentWheres)
+          }
         }
     }
   }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- build a join flow in the case of join source
- skip analyzer in join part tasks
- more logging
- bug fix: `None.get`
- skip small mode in the case of join source
- set computeDependency to False if not a mega join
## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Join source backfill couldn't run in parallel as the normal join. They were bundled in the left table computation. With this fix, we put the join source backfill as a upstream. After it is done, the downstream join, which is the actual one that user defines, will be triggered.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested: internal testing

## Reviewers

