### PR TITLE
[BugFix] Path creation in explore.py command for when different format is provided

### DIFF
--- a/airflow/constants.py
+++ b/airflow/constants.py
@@ -1,7 +1,11 @@
-import os
-
 CHRONON_PATH = "TODO"  # Set to the root of your Chronon config repo - there should be a `production` subdirectory within the directory
-TEST_TEAM_NAME = "chronon_test"  # Setting this to a team in your `teams.json` will configure jobs to run with a staging JAR
+TEST_TEAM_NAME = (
+    "chronon_test"  # Setting this to a team in your `teams.json` will configure jobs to run with a staging JAR
+)
 GROUP_BY_BATCH_CONCURRENCY = 300  # Increase as required if many group_bys per team causing DAGs to fall behind
 JOIN_CONCURRENCY = 100  # Increase as required if large Joins causing DAGs to fall behind
-time_parts = ["ds", "ts", "hr"]  # The list of time-based partition column names used in your warehouse. These are used to set up partition sensors in DAGs.
+time_parts = [
+    "ds",
+    "ts",
+    "hr",
+]  # The list of time-based partition column names used in your warehouse. These are used to set up partition sensors in DAGs.

--- a/airflow/decorators.py
+++ b/airflow/decorators.py
@@ -3,7 +3,8 @@ import time
 
 
 def retry(retries=3, backoff=20):
-    """ Same as open source run.py """
+    """Same as open source run.py"""
+
     def wrapper(func):
         def wrapped(*args, **kwargs):
             attempt = 0
@@ -15,9 +16,11 @@ def retry(retries=3, backoff=20):
                     logging.exception(e)
                     sleep_time = attempt * backoff
                     logging.info(
-                        "[{}] Retry: {} out of {}/ Sleeping for {}"
-                        .format(func.__name__, attempt, retries, sleep_time))
+                        "[{}] Retry: {} out of {}/ Sleeping for {}".format(func.__name__, attempt, retries, sleep_time)
+                    )
                     time.sleep(sleep_time)
             return func(*args, **kwargs)
+
         return wrapped
+
     return wrapper

--- a/airflow/group_by_dag_constructor.py
+++ b/airflow/group_by_dag_constructor.py
@@ -1,7 +1,9 @@
-import helpers
-from constants import CHRONON_PATH, GROUP_BY_BATCH_CONCURRENCY
-from airflow.models import DAG
 from datetime import datetime, timedelta
+
+import helpers
+from constants import CHRONON_PATH
+
+from airflow.models import DAG
 
 
 def batch_constructor(conf, mode, conf_type, team_conf):
@@ -14,7 +16,6 @@ def batch_constructor(conf, mode, conf_type, team_conf):
             retries=1,
             retry_delay=timedelta(minutes=1),
         ),
-
     )
 
 
@@ -26,7 +27,7 @@ def streaming_constructor(conf, mode, conf_type, team_conf):
             conf["metaData"]["team"],
             retries=1,
             retry_delay=timedelta(seconds=60),
-            queue='silver_medium',
+            queue="silver_medium",
         ),
         start_date=datetime.strptime("2022-02-01", "%Y-%m-%d"),
         max_active_runs=1,
@@ -37,11 +38,7 @@ def streaming_constructor(conf, mode, conf_type, team_conf):
 
 
 all_dags = helpers.walk_and_define_tasks("streaming", "group_bys", CHRONON_PATH, streaming_constructor, dags={})
-all_dags.update(
-    helpers.walk_and_define_tasks("backfill", "group_bys", CHRONON_PATH, batch_constructor, dags=all_dags)
-)
-all_dags.update(
-    helpers.walk_and_define_tasks("upload", "group_bys", CHRONON_PATH, batch_constructor, dags=all_dags)
-)
+all_dags.update(helpers.walk_and_define_tasks("backfill", "group_bys", CHRONON_PATH, batch_constructor, dags=all_dags))
+all_dags.update(helpers.walk_and_define_tasks("upload", "group_bys", CHRONON_PATH, batch_constructor, dags=all_dags))
 g = globals()
 g.update(all_dags)

--- a/airflow/helpers.py
+++ b/airflow/helpers.py
@@ -2,16 +2,17 @@
 Helper to walk files and build dags.
 """
 
-from operators import ChrononOperator, create_skip_operator, SensorWithEndDate
-import constants
-
-from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
-from datetime import timedelta
-import logging
 import json
+import logging
 import os
 import re
 from datetime import datetime, timedelta
+
+import constants
+from operators import ChrononOperator, SensorWithEndDate, create_skip_operator
+
+from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+
 
 def task_default_args(team_conf, team_name, **kwargs):
     """
@@ -20,20 +21,19 @@ def task_default_args(team_conf, team_name, **kwargs):
     base = team_conf["default"].copy()
     base.update(team_conf.get(team_name, {}))
     airflow_base = {
-        'owner': base.get('team_name'),
-        "queue": base.get('airflow_queue'),
-        'start_date': base.get('dag_start_date'),
-        'email': base.get('maintainer_emails'),
-        'hive_cli_conn_id': base.get('hive_cli_conn_id'),
-        'queue': base.get("airflow_queue"),
-        'run_as_user': base.get('user'),
-        'metastore_conn_id': 'metastore_default',
-        'presto_conn_id': 'presto_default',
-        'depends_on_past': False,
-        'email_on_failure': True,
-        'email_on_retry': False,
-        'task_concurrency': 1,
-        'retries': 1
+        "owner": base.get("team_name"),
+        "start_date": base.get("dag_start_date"),
+        "email": base.get("maintainer_emails"),
+        "hive_cli_conn_id": base.get("hive_cli_conn_id"),
+        "queue": base.get("airflow_queue"),
+        "run_as_user": base.get("user"),
+        "metastore_conn_id": "metastore_default",
+        "presto_conn_id": "presto_default",
+        "depends_on_past": False,
+        "email_on_failure": True,
+        "email_on_retry": False,
+        "task_concurrency": 1,
+        "retries": 1,
     }
     airflow_base.update(kwargs)
     return airflow_base
@@ -41,12 +41,13 @@ def task_default_args(team_conf, team_name, **kwargs):
 
 def dag_default_args(**kwargs):
     return {
-        'start_date': datetime.strptime("2023-02-01", "%Y-%m-%d"),
-        'dagrun_timeout': timedelta(days=4),
-        'schedule_interval': '@daily',
-        'concurrency': BATCH_CONCURRENCY,
-        'catchup': False,
+        "start_date": datetime.strptime("2023-02-01", "%Y-%m-%d"),
+        "dagrun_timeout": timedelta(days=4),
+        "schedule_interval": "@daily",
+        "concurrency": BATCH_CONCURRENCY,
+        "catchup": False,
     }.update(kwargs)
+
 
 def get_kv_store_upload_operator(dag, conf, team_conf):
     """TODO: Your internal implementation"""
@@ -57,10 +58,7 @@ def normalize_name(object_name):
     """Eliminate characters that would be problematic on task names"""
 
     def safe_part(p):
-        return not any([
-            p.startswith("{}=".format(time_part))
-            for time_part in constants.time_parts
-        ])
+        return not any([p.startswith("{}=".format(time_part)) for time_part in constants.time_parts])
 
     safe_name = "__".join(filter(safe_part, object_name.split("/")))
     return re.sub("[^A-Za-z0-9_]", "__", safe_name)
@@ -97,11 +95,13 @@ def requires_frontfill(conf):
 def requires_streaming_task(conf, conf_type):
     """Find if there's topic or mutationTopic for a source helps define streaming tasks"""
     if conf_type == "group_bys":
-        return any([
-            source.get("entities", {}).get("mutationTopic") is not None or
-            source.get("events", {}).get("topic") is not None
-            for source in conf["sources"]
-        ])
+        return any(
+            [
+                source.get("entities", {}).get("mutationTopic") is not None
+                or source.get("events", {}).get("topic") is not None
+                for source in conf["sources"]
+            ]
+        )
     return False
 
 
@@ -115,17 +115,16 @@ def should_schedule(conf, mode, conf_type):
         if mode == "streaming":
             # online + (realtime or has topic)
             online = conf["metaData"].get("online", 0) == 1
-            streaming = requires_streaming_task(conf, conf_type)
+            requires_streaming_task(conf, conf_type)
             return conf["metaData"].get("online", 0) == 1 and (
-                conf["metaData"].get("accuracy", 1) == 0 or
-                requires_streaming_task(conf, conf_type)
+                conf["metaData"].get("accuracy", 1) == 0 or requires_streaming_task(conf, conf_type)
             )
     if conf_type == "joins":
         if mode == "metadata-upload":
             return True
         if mode == "backfill":
             return requires_frontfill(conf)
-        if mode == 'stats-summary':
+        if mode == "stats-summary":
             return requires_frontfill(conf)
         if mode == "consistency-metrics-compute":
             customJson = json.loads(conf["metaData"]["customJson"])
@@ -150,14 +149,16 @@ def extract_dependencies(conf, mode, conf_type, common_env, dag):
     - Join Backfill
     """
 
-    if conf_type == 'joins' and mode == "stats-summary":
-        dependencies = [{
-            "name": f"wf_{sanitize(output_table(conf['metaData']))}",
-            "spec": f"{output_table(conf['metaData'])}/ds={{{{ ds }}}}",
-        }]
+    if conf_type == "joins" and mode == "stats-summary":
+        dependencies = [
+            {
+                "name": f"wf_{sanitize(output_table(conf['metaData']))}",
+                "spec": f"{output_table(conf['metaData'])}/ds={{{{ ds }}}}",
+            }
+        ]
     elif mode == "consistency-metrics-compute":
         table_name = logged_table(conf["metaData"])
-        dependencies = [{'name': 'wf_flattened_log_table', 'spec': f'{table_name}/ds={{{{ ds }}}}'}]
+        dependencies = [{"name": "wf_flattened_log_table", "spec": f"{table_name}/ds={{{{ ds }}}}"}]
     elif mode == "streaming":
         # Streaming has no dependencies as it's purpose is a check if job is alive.
         return []
@@ -168,37 +169,36 @@ def extract_dependencies(conf, mode, conf_type, common_env, dag):
         dependencies = [
             {
                 # wait for SCHEMA_PUBLISH_EVENT partition which guarantees to exist every day
-                'name': f'wf_raw_log_table',
-                'spec': f'{common_env["CHRONON_LOG_TABLE"]}/ds={{{{ ds }}}}/name=SCHEMA_PUBLISH_EVENT',
+                "name": f"wf_raw_log_table",
+                "spec": f'{common_env["CHRONON_LOG_TABLE"]}/ds={{{{ ds }}}}/name=SCHEMA_PUBLISH_EVENT',
             },
-            {
-                'name': 'wf_schema_table',
-                'spec': f'{common_env["CHRONON_SCHEMA_TABLE"]}/ds={{{{ ds }}}}'
-            }
+            {"name": "wf_schema_table", "spec": f'{common_env["CHRONON_SCHEMA_TABLE"]}/ds={{{{ ds }}}}'},
         ]
     else:
-        dependencies = [
-            json.loads(dep) for dep in conf["metaData"].get('dependencies', [])
-        ]
+        dependencies = [json.loads(dep) for dep in conf["metaData"].get("dependencies", [])]
     operators = set()
     for dep in dependencies:
         name = normalize_name(dep["name"])
         if name in dag.task_dict:
             operators.add(dag.task_dict[name])
             continue
-        op = SensorWithEndDate(
-            task_id=name,
-            partition_names=[dep["spec"]],
-            params={"end_partition": dep["end"]},
-            execution_timeout=timedelta(hours=48),
-            dag=dag,
-            retries=3,
-        ) if dep.get("end") else NamedHivePartitionSensor(
-            task_id=name,
-            partition_names=[dep["spec"]],
-            execution_timeout=timedelta(hours=48),
-            dag=dag,
-            retries=3,
+        op = (
+            SensorWithEndDate(
+                task_id=name,
+                partition_names=[dep["spec"]],
+                params={"end_partition": dep["end"]},
+                execution_timeout=timedelta(hours=48),
+                dag=dag,
+                retries=3,
+            )
+            if dep.get("end")
+            else NamedHivePartitionSensor(
+                task_id=name,
+                partition_names=[dep["spec"]],
+                execution_timeout=timedelta(hours=48),
+                dag=dag,
+                retries=3,
+            )
         )
         operators.add(op)
 
@@ -225,14 +225,13 @@ def get_downstream(conf, mode, conf_type, team_conf, dag):
 def get_extra_args(mode, conf_type, common_env, conf):
     args = {}
     if conf_type == "joins" and mode == "log-flattener":
-        args.update({
-            "log-table": common_env["CHRONON_LOG_TABLE"],
-            "schema-table": common_env["CHRONON_SCHEMA_TABLE"]
-        })
+        args.update({"log-table": common_env["CHRONON_LOG_TABLE"], "schema-table": common_env["CHRONON_SCHEMA_TABLE"]})
     if conf["metaData"]["team"] == constants.TEST_TEAM_NAME:
-        args.update({
-            "online-jar-fetch": os.path.join(constants.CHRONON_PATH, "scripts/fetch_online_staging_jar.py"),
-        })
+        args.update(
+            {
+                "online-jar-fetch": os.path.join(constants.CHRONON_PATH, "scripts/fetch_online_staging_jar.py"),
+            }
+        )
     return args
 
 
@@ -264,7 +263,8 @@ def dag_names(conf, mode, conf_type):
         if mode == "backfill":
             return f"chronon_staging_query_batch_{team}"
     raise ValueError(
-        f"Unable to define proper DAG name:\nconf_type: {conf_type}\nmode: {mode}\nconf: {json.dumps(conf, indent=2)}")
+        f"Unable to define proper DAG name:\nconf_type: {conf_type}\nmode: {mode}\nconf: {json.dumps(conf, indent=2)}"
+    )
 
 
 def task_names(conf, mode, conf_type):
@@ -311,13 +311,14 @@ def walk_and_define_tasks(mode, conf_type, repo, dag_constructor, dags=None, sil
     for root, dirs, files in os.walk(base):
         for name in files:
             full_path = os.path.join(root, name)
-            with open(full_path, 'r') as infile:
+            with open(full_path, "r") as infile:
                 try:
                     conf = json.load(infile)
                     # Basic Key Check to guarantee it's a Chronon Json.
                     assert (
-                        conf.get("metaData", {}).get("name") is not None and
-                        conf.get("metaData", {}).get("team") is not None)
+                        conf.get("metaData", {}).get("name") is not None
+                        and conf.get("metaData", {}).get("team") is not None
+                    )
                     if should_schedule(conf, mode, conf_type):
                         # Create DAG if not yet created.
                         dag_name = dag_names(conf, mode, conf_type)
@@ -344,13 +345,16 @@ def walk_and_define_tasks(mode, conf_type, repo, dag_constructor, dags=None, sil
                             extra_args=get_extra_args(mode, conf_type, common_env, conf),
                             task_id=task_names(conf, mode, conf_type),
                             on_success_callback=monitoring.update_datadog_counter_callback(
-                                conf, conf_type, "chronon.airflow.success", mode=mode),
+                                conf, conf_type, "chronon.airflow.success", mode=mode
+                            ),
                             on_failure_callback=monitoring.update_datadog_counter_callback(
-                                conf, conf_type, "chronon.airflow.failure", mode=mode),
+                                conf, conf_type, "chronon.airflow.failure", mode=mode
+                            ),
                             on_retry_callback=monitoring.update_datadog_counter_callback(
-                                conf, conf_type, "chronon.airflow.retry", mode=mode),
+                                conf, conf_type, "chronon.airflow.retry", mode=mode
+                            ),
                             params=params,
-                            dag=dag
+                            dag=dag,
                         )
                         # Build Upstream dependencies (Hive)
                         dependencies = extract_dependencies(conf, mode, conf_type, common_env, dag)
@@ -363,8 +367,9 @@ def walk_and_define_tasks(mode, conf_type, repo, dag_constructor, dags=None, sil
                     if not silent:
                         logger.exception(e)
                         logger.warning(f"Ignoring invalid json file: {name}")
-                except AssertionError as x:
+                except AssertionError:
                     if not silent:
                         logger.warning(
-                            f"[Chronon] Ignoring {conf_type} config as does not have required metaData: {name}")
+                            f"[Chronon] Ignoring {conf_type} config as does not have required metaData: {name}"
+                        )
     return dags

--- a/airflow/join_dag_constructor.py
+++ b/airflow/join_dag_constructor.py
@@ -1,14 +1,17 @@
-import helpers, constants
+from datetime import timedelta
+
+import constants
+import helpers
+
 from airflow.models import DAG
-from datetime import datetime, timedelta
 
 
 def dag_constructor(conf, mode, conf_type, team_conf):
     return DAG(
         helpers.dag_names(conf, mode, conf_type),
         **helpers.dag_default_args(
-            concurrency=constants.JOIN_CONCURRENCY,
-            schedule_interval=helpers.get_offline_schedule(conf)),
+            concurrency=constants.JOIN_CONCURRENCY, schedule_interval=helpers.get_offline_schedule(conf)
+        ),
         default_args=helpers.task_default_args(
             team_conf,
             conf["metaData"]["team"],

--- a/airflow/online_offline_consistency_dag_constructor.py
+++ b/airflow/online_offline_consistency_dag_constructor.py
@@ -1,9 +1,9 @@
-from constants import ZIPLINE_PATH
+from datetime import timedelta
+
 import helpers
+from constants import ZIPLINE_PATH
 
 from airflow.models import DAG
-
-from datetime import datetime, timedelta
 
 
 def dag_constructor(conf, mode, conf_type, team_conf):
@@ -20,6 +20,7 @@ def dag_constructor(conf, mode, conf_type, team_conf):
 
 
 all_dags = os_helpers.walk_and_define_tasks(
-    "consistency-metrics-compute", "joins", ZIPLINE_PATH, dag_constructor, dags={})
+    "consistency-metrics-compute", "joins", ZIPLINE_PATH, dag_constructor, dags={}
+)
 g = globals()
 g.update(all_dags)

--- a/airflow/staging_query_dag_constructor.py
+++ b/airflow/staging_query_dag_constructor.py
@@ -1,9 +1,9 @@
-from constants import CHRONON_PATH
+from datetime import timedelta
+
 import helpers
+from constants import CHRONON_PATH
 
 from airflow.models import DAG
-
-from datetime import datetime, timedelta
 
 
 def dag_constructor(conf, mode, conf_type, team_conf):

--- a/api/py/ai/__init__.py
+++ b/api/py/ai/__init__.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,4 +11,3 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-

--- a/api/py/ai/chronon/__init__.py
+++ b/api/py/ai/chronon/__init__.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +12,10 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-import ai.chronon.api.ttypes as ttypes
 import inspect
 import json
+
+import ai.chronon.api.ttypes as ttypes
 
 
 # Takes in an conf object class like GroupBy, Join and StagingQuery
@@ -23,16 +23,17 @@ import json
 # Remaining args will end up in object.metaData.customJson
 def _metadata_shim(conf_class):
     constructor_params = list(inspect.signature(conf_class.__init__).parameters.keys())
-    assert constructor_params[0] == "self", "First param should be 'self', found {}".format(
-        constructor_params[0])
+    assert constructor_params[0] == "self", "First param should be 'self', found {}".format(constructor_params[0])
     assert constructor_params[1] == "metaData", "Second param should be 'metaData', found {}".format(
-        constructor_params[1])
+        constructor_params[1]
+    )
     outer_params = constructor_params[2:]
     metadata_params = list(inspect.signature(ttypes.MetaData.__init__).parameters.keys())[1:]
     intersected_params = set(outer_params) & set(metadata_params)
     unioned_params = set(outer_params) | set(metadata_params)
     err_msg = "Cannot shim {}, because params: {} are intersecting with MetaData's params".format(
-        conf_class, intersected_params)
+        conf_class, intersected_params
+    )
     assert len(intersected_params) == 0, err_msg
 
     def shimmed_func(**kwargs):
@@ -41,6 +42,7 @@ def _metadata_shim(conf_class):
         custom_json_args = {key: value for key, value in kwargs.items() if key not in unioned_params}
         meta = ttypes.MetaData(customJson=json.dumps(custom_json_args), **meta_kwargs)
         return conf_class(metaData=meta, **outer_kwargs)
+
     return shimmed_func
 
 

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -12,12 +12,13 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-import ai.chronon.api.ttypes as ttypes
-import ai.chronon.utils as utils
-import logging
 import inspect
 import json
-from typing import List, Optional, Union, Dict, Callable, Tuple
+import logging
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+import ai.chronon.api.ttypes as ttypes
+import ai.chronon.utils as utils
 
 OperationType = int  # type(zthrift.Operation.FIRST)
 
@@ -79,9 +80,7 @@ class Operation:
     LAST_K = collector(ttypes.Operation.LAST_K)
     TOP_K = collector(ttypes.Operation.TOP_K)
     BOTTOM_K = collector(ttypes.Operation.BOTTOM_K)
-    APPROX_PERCENTILE = generic_collector(
-        ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=128
-    )
+    APPROX_PERCENTILE = generic_collector(ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=128)
 
 
 def Aggregations(**agg_dict):
@@ -104,13 +103,8 @@ def DefaultAggregation(keys, sources, operation=Operation.LAST, tags=None):
             "ds",
             query.timeColumn,
         ]
-        aggregate_columns += [
-            column for column in columns if column not in non_aggregate_columns
-        ]
-    return [
-        Aggregation(operation=operation, input_column=column, tags=tags)
-        for column in aggregate_columns
-    ]
+        aggregate_columns += [column for column in columns if column not in non_aggregate_columns]
+    return [Aggregation(operation=operation, input_column=column, tags=tags) for column in aggregate_columns]
 
 
 class TimeUnit:
@@ -200,8 +194,7 @@ def validate_group_by(group_by: ttypes.GroupBy):
     first_source_columns = set(utils.get_columns(sources[0]))
     # TODO undo this check after ml_models CI passes
     assert "ts" not in first_source_columns, (
-        "'ts' is a reserved key word for Chronon,"
-        " please specify the expression in timeColumn"
+        "'ts' is a reserved key word for Chronon," " please specify the expression in timeColumn"
     )
     for src in sources:
         query = utils.get_query(src)
@@ -211,19 +204,15 @@ def validate_group_by(group_by: ttypes.GroupBy):
                 "event source as it should be the same with timeColumn"
             )
             assert query.reversalColumn is None, (
-                "reversalColumn should not be specified for event source "
-                "as it won't have mutations"
+                "reversalColumn should not be specified for event source " "as it won't have mutations"
             )
             if group_by.accuracy != Accuracy.SNAPSHOT:
                 assert query.timeColumn is not None, (
-                    "please specify query.timeColumn for non-snapshot accurate "
-                    "group by with event source"
+                    "please specify query.timeColumn for non-snapshot accurate " "group by with event source"
                 )
         else:
             if contains_windowed_aggregation(aggregations):
-                assert (
-                    query.timeColumn
-                ), "Please specify timeColumn for entity source with windowed aggregations"
+                assert query.timeColumn, "Please specify timeColumn for entity source with windowed aggregations"
 
     column_set = None
     # all sources should select the same columns
@@ -246,10 +235,7 @@ Keys {unselected_keys}, are unselected in source
         has_mutations = (
             any(
                 [
-                    (
-                        s.entities.mutationTable is not None
-                        or s.entities.mutationTopic is not None
-                    )
+                    (s.entities.mutationTable is not None or s.entities.mutationTopic is not None)
                     for s in sources
                     if s.entities is not None
                 ]
@@ -276,9 +262,7 @@ Keys {unselected_keys}, are unselected in source
                     try:
                         percentile_array = json.loads(agg.argMap["percentiles"])
                         assert isinstance(percentile_array, list)
-                        assert all(
-                            [float(p) >= 0 and float(p) <= 1 for p in percentile_array]
-                        )
+                        assert all([float(p) >= 0 and float(p) <= 1 for p in percentile_array])
                     except Exception as e:
                         LOGGER.exception(e)
                         raise ValueError(
@@ -294,10 +278,7 @@ Keys {unselected_keys}, are unselected in source
             if agg.windows:
                 assert not (
                     # Snapshot accuracy.
-                    (
-                        (group_by.accuracy and group_by.accuracy == Accuracy.SNAPSHOT)
-                        or group_by.backfillStartDate
-                    )
+                    ((group_by.accuracy and group_by.accuracy == Accuracy.SNAPSHOT) or group_by.backfillStartDate)
                     and
                     # Hourly aggregation.
                     any([window.timeUnit == TimeUnit.HOURS for window in agg.windows])
@@ -309,9 +290,7 @@ Keys {unselected_keys}, are unselected in source
                 )
 
 
-_ANY_SOURCE_TYPE = Union[
-    ttypes.Source, ttypes.EventSource, ttypes.EntitySource, ttypes.JoinSource
-]
+_ANY_SOURCE_TYPE = Union[ttypes.Source, ttypes.EventSource, ttypes.EntitySource, ttypes.JoinSource]
 
 
 def _get_op_suffix(operation, argmap):
@@ -497,11 +476,7 @@ def GroupBy(
         query = (
             source.entities.query
             if source.entities is not None
-            else (
-                source.events.query
-                if source.events is not None
-                else source.joinSource.query
-            )
+            else (source.events.query if source.events is not None else source.joinSource.query)
         )
 
         if query.selects is None:
@@ -538,11 +513,7 @@ def GroupBy(
         sources = [sources]
     sources = [_sanitize_columns(_normalize_source(source)) for source in sources]
 
-    deps = [
-        dep
-        for src in sources
-        for dep in utils.get_dependencies(src, dependencies, lag=lag)
-    ]
+    deps = [dep for src in sources for dep in utils.get_dependencies(src, dependencies, lag=lag)]
 
     kwargs.update({"lag": lag})
     # get caller's filename to assign team

--- a/api/py/ai/chronon/join.py
+++ b/api/py/ai/chronon/join.py
@@ -12,17 +12,18 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from collections import Counter
-import ai.chronon.api.ttypes as api
-import ai.chronon.repo.extract_objects as eo
-import ai.chronon.utils as utils
-from ai.chronon.group_by import validate_group_by
 import copy
 import gc
 import importlib
 import json
 import logging
-from typing import List, Dict, Tuple
+from collections import Counter
+from typing import Dict, List, Tuple
+
+import ai.chronon.api.ttypes as api
+import ai.chronon.repo.extract_objects as eo
+import ai.chronon.utils as utils
+from ai.chronon.group_by import validate_group_by
 
 logging.basicConfig(level=logging.INFO)
 
@@ -66,15 +67,9 @@ def JoinPart(
             group_by_module_name = ref["__name__"]
             break
     if group_by_module_name:
-        logging.debug(
-            "group_by's module info from garbage collector {}".format(
-                group_by_module_name
-            )
-        )
+        logging.debug("group_by's module info from garbage collector {}".format(group_by_module_name))
         group_by_module = importlib.import_module(group_by_module_name)
-        __builtins__["__import__"] = eo.import_module_set_name(
-            group_by_module, api.GroupBy
-        )
+        __builtins__["__import__"] = eo.import_module_set_name(group_by_module, api.GroupBy)
     else:
         if not group_by.metaData.name:
             logging.error("No group_by file or custom group_by name found")
@@ -83,9 +78,7 @@ def JoinPart(
                 "You may pass it in via GroupBy.name. \n"
             )
     if key_mapping:
-        utils.check_contains(
-            key_mapping.values(), group_by.keyColumns, "key", group_by.metaData.name
-        )
+        utils.check_contains(key_mapping.values(), group_by.keyColumns, "key", group_by.metaData.name)
 
     join_part = api.JoinPart(groupBy=group_by, keyMapping=key_mapping, prefix=prefix)
     join_part.tags = tags
@@ -119,9 +112,7 @@ class DataType:
     # TIMESTAMP = api.TDataType(api.DataKind.TIMESTAMP)
 
     def MAP(key_type: api.TDataType, value_type: api.TDataType) -> api.TDataType:
-        assert key_type == api.TDataType(
-            api.DataKind.STRING
-        ), "key_type has to STRING for MAP types"
+        assert key_type == api.TDataType(api.DataKind.STRING), "key_type has to STRING for MAP types"
 
         return api.TDataType(
             api.DataKind.MAP,
@@ -129,9 +120,7 @@ class DataType:
         )
 
     def LIST(elem_type: api.TDataType) -> api.TDataType:
-        return api.TDataType(
-            api.DataKind.LIST, params=[api.DataField("elem", elem_type)]
-        )
+        return api.TDataType(api.DataKind.LIST, params=[api.DataField("elem", elem_type)])
 
     def STRUCT(name: str, *fields: FieldsType) -> api.TDataType:
         return api.TDataType(
@@ -290,18 +279,13 @@ def LabelPart(
                 and len(label.groupBy.aggregations[0].windows) == 1
             )
             assert valid_agg, (
-                "Too many aggregations or invalid windows found. "
-                "Single aggregation with one window allowed."
+                "Too many aggregations or invalid windows found. " "Single aggregation with one window allowed."
             )
-            valid_time_unit = (
-                label.groupBy.aggregations[0].windows[0].timeUnit == api.TimeUnit.DAYS
-            )
+            valid_time_unit = label.groupBy.aggregations[0].windows[0].timeUnit == api.TimeUnit.DAYS
             assert valid_time_unit, "Label aggregation window unit must be DAYS"
             window_size = label.groupBy.aggregations[0].windows[0].length
             if left_start_offset != window_size or left_start_offset != left_end_offset:
-                assert (
-                    left_start_offset == window_size and left_end_offset == window_size
-                ), (
+                assert left_start_offset == window_size and left_end_offset == window_size, (
                     "left_start_offset and left_end_offset will be inferred to be same as aggregation"
                     "window {window_size} and the incorrect values will be ignored. "
                 )
@@ -341,9 +325,7 @@ def Derivation(name: str, expression: str) -> api.Derivation:
     return api.Derivation(name=name, expression=expression)
 
 
-def BootstrapPart(
-    table: str, key_columns: List[str] = None, query: api.Query = None
-) -> api.BootstrapPart:
+def BootstrapPart(table: str, key_columns: List[str] = None, query: api.Query = None) -> api.BootstrapPart:
     """
     Bootstrap is the concept of using pre-computed feature values and skipping backfill computation during the
     training data generation phase. Bootstrap can be used for many purposes:
@@ -510,13 +492,10 @@ def Join(
     updated_left = copy.deepcopy(left)
     if left.events and left.events.query.selects:
         assert "ts" not in left.events.query.selects.keys(), (
-            "'ts' is a reserved key word for Chronon,"
-            " please specify the expression in timeColumn"
+            "'ts' is a reserved key word for Chronon," " please specify the expression in timeColumn"
         )
         # mapping ts to query.timeColumn to events only
-        updated_left.events.query.selects.update(
-            {"ts": updated_left.events.query.timeColumn}
-        )
+        updated_left.events.query.selects.update({"ts": updated_left.events.query.timeColumn})
     # name is set externally, cannot be set here.
     # root_keys = set(root_base_source.query.select.keys())
     # for join_part in right_parts:
@@ -534,13 +513,8 @@ def Join(
 
     left_dependencies = utils.get_dependencies(left, dependencies, lag=lag)
 
-    right_info = [
-        (join_part.groupBy.sources, join_part.groupBy.metaData)
-        for join_part in right_parts
-    ]
-    right_info = [
-        (source, meta_data) for (sources, meta_data) in right_info for source in sources
-    ]
+    right_info = [(join_part.groupBy.sources, join_part.groupBy.metaData) for join_part in right_parts]
+    right_info = [(source, meta_data) for (sources, meta_data) in right_info for source in sources]
     right_dependencies = [
         dep
         for (source, meta_data) in right_info
@@ -581,29 +555,21 @@ def Join(
         validate_group_by(join_part.groupBy)
     custom_json["join_part_tags"] = join_part_tags
 
-    consistency_sample_percent = (
-        consistency_sample_percent if check_consistency else None
-    )
+    consistency_sample_percent = consistency_sample_percent if check_consistency else None
 
     # external parts need to be unique on (prefix, part.source.metaData.name)
     if online_external_parts:
-        count_map = Counter(
-            [(part.prefix, part.source.metadata.name) for part in online_external_parts]
-        )
+        count_map = Counter([(part.prefix, part.source.metadata.name) for part in online_external_parts])
         has_duplicates = False
         for key, count in count_map.items():
             if count > 1:
                 has_duplicates = True
                 print(f"Found {count - 1} duplicate(s) for external part {key}")
-        assert (
-            has_duplicates is False
-        ), "Please address all the above mentioned duplicates."
+        assert has_duplicates is False, "Please address all the above mentioned duplicates."
 
     if bootstrap_from_log:
         has_logging = sample_percent > 0 and online
-        assert (
-            has_logging
-        ), "Join must be online with sample_percent set in order to use bootstrap_from_log option"
+        assert has_logging, "Join must be online with sample_percent set in order to use bootstrap_from_log option"
         bootstrap_parts = (bootstrap_parts or []) + [
             api.BootstrapPart(
                 # templated values will be replaced when metaData.name is set at the end
@@ -611,19 +577,13 @@ def Join(
             )
         ]
 
-    bootstrap_dependencies = (
-        []
-        if dependencies is not None
-        else utils.get_bootstrap_dependencies(bootstrap_parts)
-    )
+    bootstrap_dependencies = [] if dependencies is not None else utils.get_bootstrap_dependencies(bootstrap_parts)
 
     metadata = api.MetaData(
         online=online,
         production=production,
         customJson=json.dumps(custom_json),
-        dependencies=utils.dedupe_in_order(
-            left_dependencies + right_dependencies + bootstrap_dependencies
-        ),
+        dependencies=utils.dedupe_in_order(left_dependencies + right_dependencies + bootstrap_dependencies),
         outputNamespace=output_namespace,
         tableProperties=table_properties,
         modeToEnvMap=env,

--- a/api/py/ai/chronon/logger.py
+++ b/api/py/ai/chronon/logger.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,7 @@
 
 import logging
 
-LOG_FORMAT = '[%(asctime)-11s] %(levelname)s [%(filename)s:%(lineno)d] %(message)s'
+LOG_FORMAT = "[%(asctime)-11s] %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
 
 
 def get_logger(log_level=logging.INFO):

--- a/api/py/ai/chronon/query.py
+++ b/api/py/ai/chronon/query.py
@@ -12,8 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from typing import Dict, List
+
 import ai.chronon.api.ttypes as api
-from typing import List, Dict
 
 
 def Query(

--- a/api/py/ai/chronon/repo/__init__.py
+++ b/api/py/ai/chronon/repo/__init__.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-JOIN_FOLDER_NAME = 'joins'
-GROUP_BY_FOLDER_NAME = 'group_bys'
-STAGING_QUERY_FOLDER_NAME = 'staging_queries'
+JOIN_FOLDER_NAME = "joins"
+GROUP_BY_FOLDER_NAME = "group_bys"
+STAGING_QUERY_FOLDER_NAME = "staging_queries"
 # TODO - make team part of thrift API?
-TEAMS_FILE_PATH = 'teams.json'
+TEAMS_FILE_PATH = "teams.json"

--- a/api/py/ai/chronon/repo/explore.py
+++ b/api/py/ai/chronon/repo/explore.py
@@ -142,7 +142,12 @@ def build_entry(conf, index_spec, conf_type, root=CWD, teams=None):
         return None
 
     # derive python file path from the name & conf_type
-    (team, conf_module) = entry["name"][0].split(".", 1)
+    # when the name does not follow the <team>.<module> convention we use None for team
+    if len(entry["name"][0].split(".")) >= 2:
+        (team, conf_module) = entry["name"][0].split(".", 1)
+    else:
+        (team , conf_module) = ( None, entry["name"][0])
+
     # Update missing values with teams defaults.
     for field, mapped_field in DEFAULTS_SPEC.items():
         if field in entry and not entry[field]:
@@ -151,8 +156,9 @@ def build_entry(conf, index_spec, conf_type, root=CWD, teams=None):
     file_base = "/".join(conf_module.split(".")[:-1])
     py_file = file_base + ".py"
     init_file = file_base + "/__init__.py"
-    py_path = os.path.join(root, conf_type, team, py_file)
-    init_path = os.path.join(root, conf_type, team, init_file)
+    # create the path strings accounting for if `team` is missing in the name
+    py_path = os.path.join(*[x for x in [root, conf_type, team, py_file] if x])
+    init_path = os.path.join(*[x for x in [root, conf_type, team, init_file] if x])
     conf_path = py_path if os.path.exists(py_path) else init_path
     entry["json_file"] = os.path.join(root, "production", conf_type, team, conf_module)
     entry["file"] = conf_path

--- a/api/py/ai/chronon/repo/extract_objects.py
+++ b/api/py/ai/chronon/repo/extract_objects.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,20 +21,15 @@ import os
 from ai.chronon.logger import get_logger
 
 
-def from_folder(root_path: str,
-                full_path: str,
-                cls: type,
-                log_level=logging.INFO):
+def from_folder(root_path: str, full_path: str, cls: type, log_level=logging.INFO):
     """
     Recursively consumes a folder, and constructs a map
     Creates a map of object qualifier to
     """
-    if full_path.endswith('/'):
+    if full_path.endswith("/"):
         full_path = full_path[:-1]
 
-    python_files = glob.glob(
-        os.path.join(full_path, "**/*.py"),
-        recursive=True)
+    python_files = glob.glob(os.path.join(full_path, "**/*.py"), recursive=True)
     result = {}
     for f in python_files:
         try:
@@ -59,18 +53,14 @@ def import_module_set_name(module, cls):
     return module
 
 
-def from_file(root_path: str,
-              file_path: str,
-              cls: type,
-              log_level=logging.INFO):
+def from_file(root_path: str, file_path: str, cls: type, log_level=logging.INFO):
     logger = get_logger(log_level)
-    logger.debug(
-        "Loading objects of type {cls} from {file_path}".format(**locals()))
+    logger.debug("Loading objects of type {cls} from {file_path}".format(**locals()))
     # mod_qualifier includes team name and python script name without `.py`
     # this line takes the full file path as input, strips the root path on the left side
     # strips `.py` on the right side and finally replaces the slash sign to dot
     # eg: the output would be `team_name.python_script_name`
-    mod_qualifier = file_path[len(root_path.rstrip('/')) + 1:-3].replace("/", ".")
+    mod_qualifier = file_path[len(root_path.rstrip("/")) + 1 : -3].replace("/", ".")
     mod = importlib.import_module(mod_qualifier)
 
     # the key of result dict would be `team_name.python_script_name.[group_by_name|join_name|staging_query_name]`

--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -133,9 +133,7 @@ def retry_decorator(retries=3, backoff=20):
                     logging.exception(e)
                     sleep_time = attempt * backoff
                     logging.info(
-                        "[{}] Retry: {} out of {}/ Sleeping for {}".format(
-                            func.__name__, attempt, retries, sleep_time
-                        )
+                        "[{}] Retry: {} out of {}/ Sleeping for {}".format(func.__name__, attempt, retries, sleep_time)
                     )
                     time.sleep(sleep_time)
             return func(*args, **kwargs)
@@ -204,9 +202,7 @@ def download_jar(
     ), f"Received unsupported spark version {spark_version}. Supported spark versions are {SUPPORTED_SPARK}"
     scala_version = SCALA_VERSION_FOR_SPARK[spark_version]
     maven_url_prefix = os.environ.get("CHRONON_MAVEN_MIRROR_PREFIX", None)
-    default_url_prefix = (
-        "https://s01.oss.sonatype.org/service/local/repositories/public/content"
-    )
+    default_url_prefix = "https://s01.oss.sonatype.org/service/local/repositories/public/content"
     url_prefix = maven_url_prefix if maven_url_prefix else default_url_prefix
     base_url = "{}/ai/chronon/spark_{}_{}".format(url_prefix, jar_type, scala_version)
     print("Downloading jar from url: " + base_url)
@@ -215,17 +211,13 @@ def download_jar(
         if version == "latest":
             version = None
         if version is None:
-            metadata_content = check_output(
-                "curl -s {}/maven-metadata.xml".format(base_url)
-            )
+            metadata_content = check_output("curl -s {}/maven-metadata.xml".format(base_url))
             meta_tree = ET.fromstring(metadata_content)
             versions = [
                 node.text
                 for node in meta_tree.findall("./versioning/versions/")
                 if re.search(
-                    r"^\d+\.\d+\.\d+{}$".format(
-                        "\_{}\d*".format(release_tag) if release_tag else ""
-                    ),
+                    r"^\d+\.\d+\.\d+{}$".format("\_{}\d*".format(release_tag) if release_tag else ""),
                     node.text,
                 )
             ]
@@ -275,9 +267,7 @@ def set_runtime_env(args):
         if os.path.exists(teams_file):
             with open(teams_file, "r") as infile:
                 teams_json = json.load(infile)
-            environment["common_env"] = teams_json.get("default", {}).get(
-                "common_env", {}
-            )
+            environment["common_env"] = teams_json.get("default", {}).get("common_env", {})
             if args.conf and effective_mode:
                 try:
                     _, conf_type, team, _ = args.conf.split("/")[-4:]
@@ -296,42 +286,28 @@ def set_runtime_env(args):
                     context = args.env
                 else:
                     context = "dev"
-                logging.info(
-                    f"Context: {context} -- conf_type: {conf_type} -- team: {team}"
-                )
+                logging.info(f"Context: {context} -- conf_type: {conf_type} -- team: {team}")
                 conf_path = os.path.join(args.repo, args.conf)
                 if os.path.isfile(conf_path):
                     with open(conf_path, "r") as conf_file:
                         conf_json = json.load(conf_file)
-                    environment["conf_env"] = (
-                        conf_json.get("metaData")
-                        .get("modeToEnvMap", {})
-                        .get(effective_mode, {})
-                    )
+                    environment["conf_env"] = conf_json.get("metaData").get("modeToEnvMap", {}).get(effective_mode, {})
                     # Load additional args used on backfill.
                     if custom_json(conf_json) and effective_mode in ["backfill", "backfill-left", "backfill-final"]:
-                        environment["conf_env"][
-                            "CHRONON_CONFIG_ADDITIONAL_ARGS"
-                        ] = " ".join(custom_json(conf_json).get("additional_args", []))
+                        environment["conf_env"]["CHRONON_CONFIG_ADDITIONAL_ARGS"] = " ".join(
+                            custom_json(conf_json).get("additional_args", [])
+                        )
                     environment["cli_args"]["APP_NAME"] = APP_NAME_TEMPLATE.format(
                         mode=effective_mode,
                         conf_type=conf_type,
                         context=context,
                         name=conf_json["metaData"]["name"],
                     )
-                environment["team_env"] = (
-                    teams_json[team].get(context, {}).get(effective_mode, {})
-                )
+                environment["team_env"] = teams_json[team].get(context, {}).get(effective_mode, {})
                 # fall-back to prod env even in dev mode when dev env is undefined.
-                environment["production_team_env"] = (
-                    teams_json[team].get("production", {}).get(effective_mode, {})
-                )
+                environment["production_team_env"] = teams_json[team].get("production", {}).get(effective_mode, {})
                 # By default use production env.
-                environment["default_env"] = (
-                    teams_json.get("default", {})
-                    .get("production", {})
-                    .get(effective_mode, {})
-                )
+                environment["default_env"] = teams_json.get("default", {}).get("production", {}).get(effective_mode, {})
                 environment["cli_args"]["CHRONON_CONF_PATH"] = conf_path
     if args.app_name:
         environment["cli_args"]["APP_NAME"] = args.app_name
@@ -385,9 +361,7 @@ class Runner:
         # fetch online jar if necessary
         if (self.mode in ONLINE_MODES) and (not args.sub_help) and not valid_jar:
             print("Downloading online_jar")
-            self.online_jar = check_output("{}".format(args.online_jar_fetch)).decode(
-                "utf-8"
-            )
+            self.online_jar = check_output("{}".format(args.online_jar_fetch)).decode("utf-8")
             os.environ["CHRONON_ONLINE_JAR"] = self.online_jar
             print("Downloaded jar to {}".format(self.online_jar))
 
@@ -402,22 +376,14 @@ class Runner:
                 )
                 raise e
             possible_modes = list(ROUTES[self.conf_type].keys()) + UNIVERSAL_ROUTES
-            assert (
-                args.mode in possible_modes
-            ), "Invalid mode:{} for conf:{} of type:{}, please choose from {}".format(
+            assert args.mode in possible_modes, "Invalid mode:{} for conf:{} of type:{}, please choose from {}".format(
                 args.mode, self.conf, self.conf_type, possible_modes
             )
         else:
             self.conf_type = args.conf_type
         self.ds = args.end_ds if hasattr(args, "end_ds") and args.end_ds else args.ds
-        self.start_ds = (
-            args.start_ds if hasattr(args, "start_ds") and args.start_ds else None
-        )
-        self.parallelism = (
-            int(args.parallelism)
-            if hasattr(args, "parallelism") and args.parallelism
-            else 1
-        )
+        self.start_ds = args.start_ds if hasattr(args, "start_ds") and args.start_ds else None
+        self.parallelism = int(args.parallelism) if hasattr(args, "parallelism") and args.parallelism else 1
         self.jar_path = jar_path
         self.args = args.args if args.args else ""
         self.online_class = args.online_class
@@ -425,9 +391,9 @@ class Runner:
         if self.mode == "streaming":
             self.spark_submit = args.spark_streaming_submit_path
         elif self.mode == "info":
-            assert os.path.exists(
+            assert os.path.exists(args.render_info), "Invalid path for the render info script: {}".format(
                 args.render_info
-            ), "Invalid path for the render info script: {}".format(args.render_info)
+            )
             self.render_info = args.render_info
         else:
             self.spark_submit = args.spark_submit_path
@@ -455,16 +421,8 @@ class Runner:
                 self.app_name = self.app_name.replace(
                     "_streaming-client_", "_streaming_"
                 )  # If the job is running cluster mode we want to kill it.
-                print(
-                    "Checking to see if a streaming job by the name {} already exists".format(
-                        self.app_name
-                    )
-                )
-                running_apps = (
-                    check_output("{}".format(self.list_apps_cmd))
-                    .decode("utf-8")
-                    .split("\n")
-                )
+                print("Checking to see if a streaming job by the name {} already exists".format(self.app_name))
+                running_apps = check_output("{}".format(self.list_apps_cmd)).decode("utf-8").split("\n")
                 running_app_map = {}
                 for app in running_apps:
                     try:
@@ -486,9 +444,7 @@ class Runner:
                         )
                     )
                     if self.mode == "streaming":
-                        assert (
-                            len(filtered_apps) == 1
-                        ), "More than one found, please kill them all"
+                        assert len(filtered_apps) == 1, "More than one found, please kill them all"
                         print("All good. No need to start a new app.")
                         return
                     elif self.mode == "streaming-client":
@@ -503,9 +459,7 @@ class Runner:
                     jar=self.jar_path,
                     subcommand=ROUTES[self.conf_type][self.mode],
                     args=self._gen_final_args(),
-                    additional_args=os.environ.get(
-                        "CHRONON_CONFIG_ADDITIONAL_ARGS", ""
-                    ),
+                    additional_args=os.environ.get("CHRONON_CONFIG_ADDITIONAL_ARGS", ""),
                 )
                 command_list.append(command)
             else:
@@ -515,9 +469,7 @@ class Runner:
                         "To use parallelism, please specify --start-ds and --end-ds to "
                         "break down into multiple backfill jobs"
                     )
-                    date_ranges = split_date_range(
-                        self.start_ds, self.ds, self.parallelism
-                    )
+                    date_ranges = split_date_range(self.start_ds, self.ds, self.parallelism)
                     for start_ds, end_ds in date_ranges:
                         command = (
                             "bash {script} --class ai.chronon.spark.Driver {jar} {subcommand} {args} {additional_args}"
@@ -526,9 +478,7 @@ class Runner:
                             jar=self.jar_path,
                             subcommand=ROUTES[self.conf_type][self.mode],
                             args=self._gen_final_args(start_ds=start_ds, end_ds=end_ds),
-                            additional_args=os.environ.get(
-                                "CHRONON_CONFIG_ADDITIONAL_ARGS", ""
-                            ),
+                            additional_args=os.environ.get("CHRONON_CONFIG_ADDITIONAL_ARGS", ""),
                         )
                         command_list.append(command)
                 else:
@@ -539,19 +489,13 @@ class Runner:
                         jar=self.jar_path,
                         subcommand=ROUTES[self.conf_type][self.mode],
                         args=self._gen_final_args(self.start_ds),
-                        additional_args=os.environ.get(
-                            "CHRONON_CONFIG_ADDITIONAL_ARGS", ""
-                        ),
+                        additional_args=os.environ.get("CHRONON_CONFIG_ADDITIONAL_ARGS", ""),
                     )
                     command_list.append(command)
         if len(command_list) > 1:
             # parallel backfill mode
             with multiprocessing.Pool(processes=int(self.parallelism)) as pool:
-                logging.info(
-                    "Running args list {} with pool size {}".format(
-                        command_list, self.parallelism
-                    )
-                )
+                logging.info("Running args list {} with pool size {}".format(command_list, self.parallelism))
                 pool.map(check_call, command_list)
         elif len(command_list) == 1:
             check_call(command_list[0])
@@ -563,9 +507,7 @@ class Runner:
             online_jar=self.online_jar,
             online_class=self.online_class,
         )
-        override_start_partition_arg = (
-            " --start-partition-override=" + start_ds if start_ds else ""
-        )
+        override_start_partition_arg = " --start-partition-override=" + start_ds if start_ds else ""
         final_args = base_args + " " + str(self.args) + override_start_partition_arg
         return final_args
 
@@ -575,9 +517,7 @@ def split_date_range(start_date, end_date, parallelism):
     end_date = datetime.strptime(end_date, "%Y-%m-%d")
     if start_date > end_date:
         raise ValueError("Start date should be earlier than end date")
-    total_days = (
-        end_date - start_date
-    ).days + 1  # +1 to include the end_date in the range
+    total_days = (end_date - start_date).days + 1  # +1 to include the end_date in the range
 
     # Check if parallelism is greater than total_days
     if parallelism > total_days:
@@ -592,9 +532,7 @@ def split_date_range(start_date, end_date, parallelism):
             split_end = end_date
         else:
             split_end = split_start + timedelta(days=split_size - 1)
-        date_ranges.append(
-            (split_start.strftime("%Y-%m-%d"), split_end.strftime("%Y-%m-%d"))
-        )
+        date_ranges.append((split_start.strftime("%Y-%m-%d"), split_end.strftime("%Y-%m-%d")))
     return date_ranges
 
 
@@ -612,9 +550,7 @@ def set_defaults(parser):
         version=os.environ.get("VERSION"),
         spark_version=os.environ.get("SPARK_VERSION", "2.4.0"),
         spark_submit_path=os.path.join(chronon_repo_path, "scripts/spark_submit.sh"),
-        spark_streaming_submit_path=os.path.join(
-            chronon_repo_path, "scripts/spark_streaming.sh"
-        ),
+        spark_streaming_submit_path=os.path.join(chronon_repo_path, "scripts/spark_streaming.sh"),
         online_jar_fetch=os.path.join(chronon_repo_path, "scripts/fetch_online_jar.py"),
         conf_type="group_bys",
         online_args=os.environ.get("CHRONON_ONLINE_ARGS", ""),
@@ -639,9 +575,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--mode", choices=MODE_ARGS.keys())
     parser.add_argument("--ds", help="the end partition to backfill the data")
-    parser.add_argument(
-        "--app-name", help="app name. Default to {}".format(APP_NAME_TEMPLATE)
-    )
+    parser.add_argument("--app-name", help="app name. Default to {}".format(APP_NAME_TEMPLATE))
     parser.add_argument(
         "--start-ds",
         help="override the original start partition for a range backfill. "
@@ -657,21 +591,16 @@ if __name__ == "__main__":
     parser.add_argument("--repo", help="Path to chronon repo")
     parser.add_argument(
         "--online-jar",
-        help="Jar containing Online KvStore & Deserializer Impl. "
-        + "Used for streaming and metadata-upload mode.",
+        help="Jar containing Online KvStore & Deserializer Impl. " + "Used for streaming and metadata-upload mode.",
     )
     parser.add_argument(
         "--online-class",
         help="Class name of Online Impl. Used for streaming and metadata-upload mode.",
     )
     parser.add_argument("--version", help="Chronon version to use.")
-    parser.add_argument(
-        "--spark-version", help="Spark version to use for downloading jar."
-    )
+    parser.add_argument("--spark-version", help="Spark version to use for downloading jar.")
     parser.add_argument("--spark-submit-path", help="Path to spark-submit")
-    parser.add_argument(
-        "--spark-streaming-submit-path", help="Path to spark-submit for streaming"
-    )
+    parser.add_argument("--spark-streaming-submit-path", help="Path to spark-submit for streaming")
     parser.add_argument(
         "--online-jar-fetch",
         help="Path to script that can pull online jar. "
@@ -691,12 +620,8 @@ if __name__ == "__main__":
         help="Basic arguments that need to be supplied to all online modes",
     )
     parser.add_argument("--chronon-jar", help="Path to chronon OS jar")
-    parser.add_argument(
-        "--release-tag", help="Use the latest jar for a particular tag."
-    )
-    parser.add_argument(
-        "--list-apps", help="command/script to list running jobs on the scheduler"
-    )
+    parser.add_argument("--release-tag", help="Use the latest jar for a particular tag.")
+    parser.add_argument("--list-apps", help="command/script to list running jobs on the scheduler")
     parser.add_argument(
         "--render-info",
         help="Path to script rendering additional information of the given config. "

--- a/api/py/ai/chronon/repo/serializer.py
+++ b/api/py/ai/chronon/repo/serializer.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +13,19 @@
 #     limitations under the License.
 
 import json
-from ai.chronon.utils import JsonDiffer
-from thrift.Thrift import TType
-from thrift.protocol.TJSONProtocol import TSimpleJSONProtocolFactory, TJSONProtocolFactory
 
+from ai.chronon.utils import JsonDiffer
 from thrift import TSerialization
+from thrift.protocol.TJSONProtocol import (
+    TJSONProtocolFactory,
+    TSimpleJSONProtocolFactory,
+)
+from thrift.Thrift import TType
 
 
 class ThriftJSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
-        self._thrift_class = kwargs.pop('thrift_class')
+        self._thrift_class = kwargs.pop("thrift_class")
         super(ThriftJSONDecoder, self).__init__(*args, **kwargs)
 
     def decode(self, json_str):
@@ -31,8 +33,7 @@ class ThriftJSONDecoder(json.JSONDecoder):
             dct = json_str
         else:
             dct = super(ThriftJSONDecoder, self).decode(json_str)
-        return self._convert(dct, TType.STRUCT,
-                             (self._thrift_class, self._thrift_class.thrift_spec))
+        return self._convert(dct, TType.STRUCT, (self._thrift_class, self._thrift_class.thrift_spec))
 
     def _convert(self, val, ttype, ttype_info):
         if ttype == TType.STRUCT:
@@ -54,8 +55,12 @@ class ThriftJSONDecoder(json.JSONDecoder):
             ret = set([self._convert(x, element_ttype, element_ttype_info) for x in val])
         elif ttype == TType.MAP:
             (key_ttype, key_ttype_info, val_ttype, val_ttype_info, _) = ttype_info
-            ret = dict([(self._convert(k, key_ttype, key_ttype_info),
-                         self._convert(v, val_ttype, val_ttype_info)) for (k, v) in val.items()])
+            ret = dict(
+                [
+                    (self._convert(k, key_ttype, key_ttype_info), self._convert(v, val_ttype, val_ttype_info))
+                    for (k, v) in val.items()
+                ]
+            )
         elif ttype == TType.STRING:
             ret = str(val)
         elif ttype == TType.DOUBLE:
@@ -67,7 +72,7 @@ class ThriftJSONDecoder(json.JSONDecoder):
         elif ttype == TType.BOOL:
             ret = bool(val)
         else:
-            raise TypeError('Unrecognized thrift field type: %d' % ttype)
+            raise TypeError("Unrecognized thrift field type: %d" % ttype)
         return ret
 
 
@@ -77,11 +82,13 @@ def json2thrift(json_str, thrift_class):
 
 def file2thrift(path, thrift_class):
     try:
-        with open(path, 'r') as file:
+        with open(path, "r") as file:
             return json2thrift(file.read(), thrift_class)
     except json.decoder.JSONDecodeError as e:
-        raise Exception(f"Error decoding file into a {thrift_class.__name__}:  {path}. " +
-                        f"Please double check that {path} represents a valid {thrift_class.__name__}.") from e
+        raise Exception(
+            f"Error decoding file into a {thrift_class.__name__}:  {path}. "
+            + f"Please double check that {path} represents a valid {thrift_class.__name__}."
+        ) from e
 
 
 def thrift_json(obj):
@@ -101,7 +108,9 @@ def thrift_simple_json_protected(obj, obj_type) -> str:
     actual = thrift_simple_json(thrift_obj)
     differ = JsonDiffer()
     diff = differ.diff(serialized, actual)
-    assert len(diff) == 0, f"""Serialization can't be reversed
+    assert (
+        len(diff) == 0
+    ), f"""Serialization can't be reversed
 diff: \n{diff}
 original: \n{serialized}
 """

--- a/api/py/ai/chronon/repo/teams.py
+++ b/api/py/ai/chronon/repo/teams.py
@@ -18,7 +18,7 @@
 import json
 
 # `default` team in teams.json contains default values.
-DEFAULT_CONF_TEAM = 'default'
+DEFAULT_CONF_TEAM = "default"
 
 loaded_jsons = {}
 

--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -19,25 +19,23 @@ import json
 import logging
 import os
 import re
-from ai.chronon.api.ttypes import \
-    GroupBy, Join, Source, Derivation, ExternalPart
+from collections import defaultdict
+from typing import Dict, List, Set
+
+from ai.chronon.api.ttypes import Derivation, ExternalPart, GroupBy, Join, Source
 from ai.chronon.group_by import get_output_col_names
 from ai.chronon.logger import get_logger
-from ai.chronon.repo import JOIN_FOLDER_NAME, \
-    GROUP_BY_FOLDER_NAME
-from ai.chronon.repo.serializer import \
-    thrift_simple_json, file2thrift
-from collections import defaultdict
-from typing import List, Dict, Set
+from ai.chronon.repo import GROUP_BY_FOLDER_NAME, JOIN_FOLDER_NAME
+from ai.chronon.repo.serializer import file2thrift, thrift_simple_json
 
 # Fields that indicate stutus of the entities.
-SKIPPED_FIELDS = frozenset(['metaData'])
-EXTERNAL_KEY = 'onlineExternalParts'
+SKIPPED_FIELDS = frozenset(["metaData"])
+EXTERNAL_KEY = "onlineExternalParts"
 
 
 def _filter_skipped_fields_from_join(json_obj: Dict, skipped_fields):
-    for join_part in json_obj['joinParts']:
-        group_by = join_part['groupBy']
+    for join_part in json_obj["joinParts"]:
+        group_by = join_part["groupBy"]
         for field in skipped_fields:
             group_by.pop(field, None)
     if EXTERNAL_KEY in json_obj:
@@ -55,7 +53,7 @@ def extract_json_confs(obj_class: type, path: str) -> List[object]:
     result = []
     for sub_root, sub_dirs, sub_files in os.walk(path):
         for f in sub_files:
-            if not f.startswith('.'):  # ignore hidden files - such as .DS_Store
+            if not f.startswith("."):  # ignore hidden files - such as .DS_Store
                 obj = file2thrift(os.path.join(sub_root, f), obj_class)
                 if is_valid_conf(obj):
                     result.append(obj)
@@ -195,32 +193,33 @@ class ChrononRepoValidator(object):
         # we keep the objs in the list not in  a set since thrift does not
         # implement __hash__ for ttypes object.
         self.old_group_bys = extract_json_confs(
-            GroupBy,
-            os.path.join(self.chronon_root_path, self.output_root, GROUP_BY_FOLDER_NAME))
+            GroupBy, os.path.join(self.chronon_root_path, self.output_root, GROUP_BY_FOLDER_NAME)
+        )
         self.old_joins = extract_json_confs(
-            Join,
-            os.path.join(self.chronon_root_path, self.output_root, JOIN_FOLDER_NAME))
+            Join, os.path.join(self.chronon_root_path, self.output_root, JOIN_FOLDER_NAME)
+        )
 
-        self.old_objs['GroupBy'] = self.old_group_bys
-        self.old_objs['Join'] = self.old_joins
+        self.old_objs["GroupBy"] = self.old_group_bys
+        self.old_objs["Join"] = self.old_joins
 
     def _get_old_obj(self, obj_class: type, obj_name: str) -> object:
         """
         returns:
            materialized version of the obj given the object's name.
         """
-        return next(
-            (x for x in self.old_objs[obj_class.__name__] if x.metaData and x.metaData.name == obj_name),
-            None
-        )
+        return next((x for x in self.old_objs[obj_class.__name__] if x.metaData and x.metaData.name == obj_name), None)
 
     def _get_old_joins_with_group_by(self, group_by: GroupBy) -> List[Join]:
         """
         returns:
             materialized joins including the group_by as dicts.
         """
-        return [join for join in self.old_joins if join.joinParts is not None and
-                group_by.metaData.name in [rp.groupBy.metaData.name for rp in join.joinParts]]
+        return [
+            join
+            for join in self.old_joins
+            if join.joinParts is not None
+            and group_by.metaData.name in [rp.groupBy.metaData.name for rp in join.joinParts]
+        ]
 
     def can_skip_materialize(self, obj: object) -> List[str]:
         """
@@ -233,8 +232,9 @@ class ChrononRepoValidator(object):
                 reasons.append("GroupBys should not be materialized if batch upload job is not needed")
             # Otherwise group_bys included in online join or are marked explicitly
             # online itself are materialized.
-            elif not any(join.metaData.online for join in self._get_old_joins_with_group_by(obj)) \
-                    and not is_batch_upload_needed(obj):
+            elif not any(
+                join.metaData.online for join in self._get_old_joins_with_group_by(obj)
+            ) and not is_batch_upload_needed(obj):
                 reasons.append("is not marked online/production nor is included in any online join")
         return reasons
 
@@ -251,15 +251,9 @@ class ChrononRepoValidator(object):
             return self._validate_join(obj)
         return []
 
-    def _has_diff(
-            self,
-            obj: object,
-            old_obj: object,
-            skipped_fields=SKIPPED_FIELDS) -> bool:
-        new_json = {k: v for k, v in json.loads(thrift_simple_json(obj)).items()
-                    if k not in skipped_fields}
-        old_json = {k: v for k, v in json.loads(thrift_simple_json(old_obj)).items()
-                    if k not in skipped_fields}
+    def _has_diff(self, obj: object, old_obj: object, skipped_fields=SKIPPED_FIELDS) -> bool:
+        new_json = {k: v for k, v in json.loads(thrift_simple_json(obj)).items() if k not in skipped_fields}
+        old_json = {k: v for k, v in json.loads(thrift_simple_json(old_obj)).items() if k not in skipped_fields}
         if isinstance(obj, Join):
             _filter_skipped_fields_from_join(new_json, skipped_fields)
             _filter_skipped_fields_from_join(old_json, skipped_fields)
@@ -296,11 +290,14 @@ class ChrononRepoValidator(object):
                 if derivation.expression not in pre_derived_cols and derivation.expression not in ("ds", "ts"):
                     errors.append(
                         "Incorrect derivation expression {}, expression not found in pre-derived columns {}".format(
-                            derivation.expression, pre_derived_cols))
+                            derivation.expression, pre_derived_cols
+                        )
+                    )
             if derivation.name != "*":
                 if derivation.name in derived_columns:
                     errors.append(
-                        "Incorrect derivation name {} due to output column name conflict".format(derivation.name))
+                        "Incorrect derivation name {} due to output column name conflict".format(derivation.name)
+                    )
                 else:
                     derived_columns.add(derivation.name)
         return errors
@@ -314,26 +311,34 @@ class ChrononRepoValidator(object):
           list of validation errors.
         """
         included_group_bys = [rp.groupBy for rp in join.joinParts]
-        offline_included_group_bys = [gb.metaData.name for gb in included_group_bys
-                                      if not gb.metaData or gb.metaData.online is False]
+        offline_included_group_bys = [
+            gb.metaData.name for gb in included_group_bys if not gb.metaData or gb.metaData.online is False
+        ]
         errors = []
-        old_group_bys = [group_by for group_by in included_group_bys
-                         if self._get_old_obj(GroupBy, group_by.metaData.name)]
-        non_prod_old_group_bys = [group_by.metaData.name for group_by in old_group_bys
-                                  if group_by.metaData.production is False]
+        old_group_bys = [
+            group_by for group_by in included_group_bys if self._get_old_obj(GroupBy, group_by.metaData.name)
+        ]
+        non_prod_old_group_bys = [
+            group_by.metaData.name for group_by in old_group_bys if group_by.metaData.production is False
+        ]
         # Check if the underlying groupBy is valid
         group_by_errors = [self._validate_group_by(group_by) for group_by in included_group_bys]
-        errors += [f"join {join.metaData.name}'s underlying {error}"
-                   for errors in group_by_errors for error in errors]
+        errors += [f"join {join.metaData.name}'s underlying {error}" for errors in group_by_errors for error in errors]
         # Check if the production join is using non production groupBy
         if join.metaData.production and non_prod_old_group_bys:
-            errors.append("join {} is production but includes the following non production group_bys: {}".format(
-                join.metaData.name, ', '.join(non_prod_old_group_bys)))
+            errors.append(
+                "join {} is production but includes the following non production group_bys: {}".format(
+                    join.metaData.name, ", ".join(non_prod_old_group_bys)
+                )
+            )
         # Check if the online join is using the offline groupBy
         if join.metaData.online:
             if offline_included_group_bys:
-                errors.append("join {} is online but includes the following offline group_bys: {}".format(
-                    join.metaData.name, ', '.join(offline_included_group_bys)))
+                errors.append(
+                    "join {} is online but includes the following offline group_bys: {}".format(
+                        join.metaData.name, ", ".join(offline_included_group_bys)
+                    )
+                )
         # Only validate the join derivation when the underlying groupBy is valid
         group_by_correct = all(not errors for errors in group_by_errors)
         if join.derivations and group_by_correct:
@@ -364,16 +369,16 @@ class ChrononRepoValidator(object):
         if group_by.metaData.online is False and online_joins:
             errors.append(
                 "group_by {} is explicitly marked offline but included in "
-                "the following online joins: {}".format(
-                    group_by.metaData.name, ", ".join(online_joins)))
+                "the following online joins: {}".format(group_by.metaData.name, ", ".join(online_joins))
+            )
         # group by that are marked explicitly non-production should not be
         # present in materialized production joins.
         if prod_joins:
             if group_by.metaData.production is False:
                 errors.append(
                     "group_by {} is explicitly marked as non-production but included in the following production "
-                    "joins: {}".format(
-                        group_by.metaData.name, ', '.join(prod_joins)))
+                    "joins: {}".format(group_by.metaData.name, ", ".join(prod_joins))
+                )
             # if the group by is included in any of materialized production join,
             # set it to production in the materialized output.
             else:
@@ -391,6 +396,5 @@ class ChrononRepoValidator(object):
         for source in group_by.sources:
             src: Source = source
             if src.events and src.events.isCumulative and (src.events.query.timeColumn is None):
-                errors.append(
-                    "Please set query.timeColumn for Cumulative Events Table: {}".format(src.events.table))
+                errors.append("Please set query.timeColumn for Cumulative Events Table: {}".format(src.events.table))
         return errors

--- a/api/py/setup.py
+++ b/api/py/setup.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,7 @@
 
 import os
 import re
+
 from setuptools import find_packages, setup
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -28,6 +28,8 @@ with open(os.path.join(current_dir, "requirements/base.in"), "r") as infile:
 
 __version__ = "local"
 __branch__ = "main"
+
+
 def get_version():
     version_str = os.environ.get("CHRONON_VERSION_STR", __version__)
     branch_str = os.environ.get("CHRONON_BRANCH_STR", __branch__)
@@ -35,24 +37,20 @@ def get_version():
     version_str = version_str.replace("-SNAPSHOT", ".dev")
     # If the prefix is the branch name, then convert it as suffix after '+' to make it Python PEP440 complaint
     if version_str.startswith(branch_str + "-"):
-        version_str = "{}+{}".format(
-            version_str.replace(branch_str + "-", ""),
-            branch_str
-        )
+        version_str = "{}+{}".format(version_str.replace(branch_str + "-", ""), branch_str)
 
     # Replace multiple continuous '-' or '_' with a single period '.'.
     # In python version string, the label identifier that comes after '+', is all separated by periods '.'
-    version_str = re.sub(r'[-_]+', '.', version_str)
+    version_str = re.sub(r"[-_]+", ".", version_str)
 
     return version_str
 
+
 setup(
-    classifiers=[
-        "Programming Language :: Python :: 3.7"
-    ],
+    classifiers=["Programming Language :: Python :: 3.7"],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    scripts=['ai/chronon/repo/explore.py', 'ai/chronon/repo/compile.py', 'ai/chronon/repo/run.py'],
+    scripts=["ai/chronon/repo/explore.py", "ai/chronon/repo/compile.py", "ai/chronon/repo/run.py"],
     description="Chronon python API library",
     include_package_data=True,
     install_requires=basic_requirements,
@@ -65,5 +63,5 @@ setup(
     python_requires=">=3.7",
     url=None,
     version=get_version(),
-    zip_safe=False
+    zip_safe=False,
 )

--- a/api/py/test/conftest.py
+++ b/api/py/test/conftest.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-import pytest
 import os
+
+import pytest
 
 
 @pytest.fixture
@@ -24,21 +24,22 @@ def rootdir():
 
 @pytest.fixture
 def teams_json(rootdir):
-    return os.path.join(rootdir, 'sample/teams.json')
+    return os.path.join(rootdir, "sample/teams.json")
 
 
 @pytest.fixture
 def repo(rootdir):
-    return os.path.join(rootdir, 'sample/')
+    return os.path.join(rootdir, "sample/")
 
 
 @pytest.fixture
 def test_online_group_by(repo):
-    return os.path.join(repo, 'production/group_bys/sample_team/event_sample_group_by.v1')
+    return os.path.join(repo, "production/group_bys/sample_team/event_sample_group_by.v1")
 
 
 @pytest.fixture
 def sleepless():
     def justpass(seconds):
         pass
+
     return justpass

--- a/api/py/test/sample/group_bys/kaggle/clicks.py
+++ b/api/py/test/sample/group_bys/kaggle/clicks.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +12,16 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
-from ai.chronon.query import Query, select
+from ai.chronon.api.ttypes import EventSource, Source
 from ai.chronon.group_by import (
-    GroupBy,
+    Accuracy,
     Aggregation,
+    GroupBy,
     Operation,
-    Window,
     TimeUnit,
-    Accuracy
+    Window,
 )
+from ai.chronon.query import Query, select
 from ai.chronon.utils import get_staging_query_output_table_name
 from staging_queries.kaggle.outbrain import base_table
 
@@ -45,31 +44,27 @@ the fields that we care about (`ad_id`, `clicked`, and `ts` columns), it will mi
 
 source = Source(
     events=EventSource(
-        table=get_staging_query_output_table_name(base_table), # Here we use the staging query output table because it has the necessary fields, but for a true streaming source we would likely use a log table
-        topic="some_topic", # You would set your streaming source topic here
-        query=Query(
-            selects=select("ad_id", "clicked"),
-            time_column="ts")
-    ))
+        table=get_staging_query_output_table_name(
+            base_table
+        ),  # Here we use the staging query output table because it has the necessary fields, but for a true streaming source we would likely use a log table
+        topic="some_topic",  # You would set your streaming source topic here
+        query=Query(selects=select("ad_id", "clicked"), time_column="ts"),
+    )
+)
 
 ad_streaming = GroupBy(
     sources=[source],
-    keys=["ad_id"], # We use the ad_id column as our primary key
-    aggregations=[Aggregation(
-            input_column="clicked",
-            operation=Operation.SUM,
-            windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
+    keys=["ad_id"],  # We use the ad_id column as our primary key
+    aggregations=[
+        Aggregation(
+            input_column="clicked", operation=Operation.SUM, windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
         ),
         Aggregation(
-            input_column="clicked",
-            operation=Operation.COUNT,
-            windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
+            input_column="clicked", operation=Operation.COUNT, windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
         ),
         Aggregation(
-            input_column="clicked",
-            operation=Operation.AVERAGE,
-            windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
-        )
+            input_column="clicked", operation=Operation.AVERAGE, windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
+        ),
     ],
-    accuracy=Accuracy.TEMPORAL # Here we use temporal accuracy so that training data backfills mimic streaming updates
+    accuracy=Accuracy.TEMPORAL,  # Here we use temporal accuracy so that training data backfills mimic streaming updates
 )

--- a/api/py/test/sample/group_bys/kaggle/outbrain.py
+++ b/api/py/test/sample/group_bys/kaggle/outbrain.py
@@ -1,5 +1,3 @@
-
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +12,15 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
-from ai.chronon.query import Query, select
 from ai.chronon.group_by import (
-    GroupBy,
+    Accuracy,
     Aggregation,
+    GroupBy,
     Operation,
-    Window,
     TimeUnit,
-    Accuracy
+    Window,
 )
-
 from sources.kaggle.outbrain import outbrain_left_events
-from ai.chronon.utils import get_staging_query_output_table_name
-from staging_queries.kaggle.outbrain import base_table
 
 """
 This file defines a number of GroupBys in a more programatic way, leveraging helper functions that act
@@ -48,21 +41,16 @@ def ctr_group_by(*keys, accuracy):
     return GroupBy(
         sources=[outbrain_left_events(*(list(keys) + ["clicked"]))],
         keys=list(keys),
-        aggregations=[Aggregation(
-                input_column="clicked",
-                operation=Operation.SUM,
-                windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
+        aggregations=[
+            Aggregation(
+                input_column="clicked", operation=Operation.SUM, windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
             ),
             Aggregation(
-                input_column="clicked",
-                operation=Operation.COUNT,
-                windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
+                input_column="clicked", operation=Operation.COUNT, windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
             ),
             Aggregation(
-                input_column="clicked",
-                operation=Operation.AVERAGE,
-                windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
-            )
+                input_column="clicked", operation=Operation.AVERAGE, windows=[Window(length=3, timeUnit=TimeUnit.DAYS)]
+            ),
         ],
         accuracy=accuracy,
     )

--- a/api/py/test/sample/group_bys/quickstart/purchases.py
+++ b/api/py/test/sample/group_bys/quickstart/purchases.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.api.ttypes import EventSource, Source
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from ai.chronon.query import Query, select
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit
-)
 
 """
 This GroupBy aggregates metrics about a user's previous purchases in various windows.
@@ -30,34 +23,32 @@ This GroupBy aggregates metrics about a user's previous purchases in various win
 # This source is raw purchase events. Every time a user makes a purchase, it will be one entry in this source.
 source = Source(
     events=EventSource(
-        table="data.purchases", # This points to the log table in the warehouse with historical purchase events, updated in batch daily
-        topic=None, # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
+        table="data.purchases",  # This points to the log table in the warehouse with historical purchase events, updated in batch daily
+        topic=None,  # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
         query=Query(
-            selects=select("user_id","purchase_price"), # Select the fields we care about
-            time_column="ts") # The event time
-    ))
+            selects=select("user_id", "purchase_price"), time_column="ts"  # Select the fields we care about
+        ),  # The event time
+    )
+)
 
-window_sizes = [Window(length=day, timeUnit=TimeUnit.DAYS) for day in [3, 14, 30]] # Define some window sizes to use below
+window_sizes = [
+    Window(length=day, timeUnit=TimeUnit.DAYS) for day in [3, 14, 30]
+]  # Define some window sizes to use below
 
 v1 = GroupBy(
     sources=[source],
-    keys=["user_id"], # We are aggregating by user
+    keys=["user_id"],  # We are aggregating by user
     online=True,
-    aggregations=[Aggregation(
-            input_column="purchase_price",
-            operation=Operation.SUM,
-            windows=window_sizes
-        ), # The sum of purchases prices in various windows
+    aggregations=[
         Aggregation(
-            input_column="purchase_price",
-            operation=Operation.COUNT,
-            windows=window_sizes
-        ), # The count of purchases in various windows
+            input_column="purchase_price", operation=Operation.SUM, windows=window_sizes
+        ),  # The sum of purchases prices in various windows
         Aggregation(
-            input_column="purchase_price",
-            operation=Operation.AVERAGE,
-            windows=window_sizes
-        ), # The average purchases by user in various windows
+            input_column="purchase_price", operation=Operation.COUNT, windows=window_sizes
+        ),  # The count of purchases in various windows
+        Aggregation(
+            input_column="purchase_price", operation=Operation.AVERAGE, windows=window_sizes
+        ),  # The average purchases by user in various windows
         Aggregation(
             input_column="purchase_price",
             operation=Operation.LAST_K(10),

--- a/api/py/test/sample/group_bys/quickstart/returns.py
+++ b/api/py/test/sample/group_bys/quickstart/returns.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.api.ttypes import EventSource, Source
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from ai.chronon.query import Query, select
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-    Accuracy,
-)
 
 """
 This GroupBy aggregates metrics about a user's previous purchases in various windows.
@@ -30,34 +22,30 @@ This GroupBy aggregates metrics about a user's previous purchases in various win
 
 source = Source(
     events=EventSource(
-        table="data.returns", # This points to the log table with historical return events
+        table="data.returns",  # This points to the log table with historical return events
         topic="events.returns/fields=ts,return_id,user_id,product_id,refund_amt/host=kafka/port=9092",
         query=Query(
-            selects=select("user_id","refund_amt"), # Select the fields we care about
-            time_column="ts") # The event time
-    ))
+            selects=select("user_id", "refund_amt"), time_column="ts"  # Select the fields we care about
+        ),  # The event time
+    )
+)
 
-window_sizes = [Window(length=day, timeUnit=TimeUnit.DAYS) for day in [3, 14, 30]] # Define some window sizes to use below
+window_sizes = [
+    Window(length=day, timeUnit=TimeUnit.DAYS) for day in [3, 14, 30]
+]  # Define some window sizes to use below
 
 v1 = GroupBy(
     sources=[source],
-    keys=["user_id"], # We are aggregating by user
+    keys=["user_id"],  # We are aggregating by user
     online=True,
-    aggregations=[Aggregation(
-            input_column="refund_amt",
-            operation=Operation.SUM,
-            windows=window_sizes
-        ), # The sum of purchases prices in various windows
+    aggregations=[
         Aggregation(
-            input_column="refund_amt",
-            operation=Operation.COUNT,
-            windows=window_sizes
-        ), # The count of purchases in various windows
+            input_column="refund_amt", operation=Operation.SUM, windows=window_sizes
+        ),  # The sum of purchases prices in various windows
         Aggregation(
-            input_column="refund_amt",
-            operation=Operation.AVERAGE,
-            windows=window_sizes
-        ),
+            input_column="refund_amt", operation=Operation.COUNT, windows=window_sizes
+        ),  # The count of purchases in various windows
+        Aggregation(input_column="refund_amt", operation=Operation.AVERAGE, windows=window_sizes),
         Aggregation(
             input_column="refund_amt",
             operation=Operation.LAST_K(2),

--- a/api/py/test/sample/group_bys/quickstart/schema.py
+++ b/api/py/test/sample/group_bys/quickstart/schema.py
@@ -1,7 +1,6 @@
-from ai.chronon.group_by import GroupBy, Aggregation, Operation
-from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.api.ttypes import EventSource, Source
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
 from ai.chronon.query import Query, select
-
 
 logging_schema_source = Source(
     events=EventSource(
@@ -9,7 +8,7 @@ logging_schema_source = Source(
         query=Query(
             selects=select(
                 schema_hash="decode(unbase64(key_base64), 'utf-8')",
-                schema_value="decode(unbase64(value_base64), 'utf-8')"
+                schema_value="decode(unbase64(value_base64), 'utf-8')",
             ),
             wheres=["name='SCHEMA_PUBLISH_EVENT'"],
             time_column="ts_millis",
@@ -20,12 +19,7 @@ logging_schema_source = Source(
 v1 = GroupBy(
     keys=["schema_hash"],
     sources=logging_schema_source,
-    aggregations=[
-        Aggregation(
-            input_column="schema_value",
-            operation=Operation.LAST
-        )
-    ],
+    aggregations=[Aggregation(input_column="schema_value", operation=Operation.LAST)],
     online=False,
-    backfill_start_date="2023-04-09"
+    backfill_start_date="2023-04-09",
 )

--- a/api/py/test/sample/group_bys/quickstart/users.py
+++ b/api/py/test/sample/group_bys/quickstart/users.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EntitySource
+from ai.chronon.api.ttypes import EntitySource, Source
+from ai.chronon.group_by import GroupBy
 from ai.chronon.query import Query, select
-from ai.chronon.group_by import (
-    GroupBy,
-)
 
 """
 The primary key for this GroupBy is the same as the primary key of the source table. Therefore,
@@ -26,15 +23,16 @@ it doesn't perform any aggregation, but just extracts user fields as features.
 
 source = Source(
     entities=EntitySource(
-        snapshotTable="data.users", # This points to a table that contains daily snapshots of the entire product catalog
+        snapshotTable="data.users",  # This points to a table that contains daily snapshots of the entire product catalog
         query=Query(
-            selects=select("user_id","account_created_ds","email_verified"), # Select the fields we care about
-        )
-    ))
+            selects=select("user_id", "account_created_ds", "email_verified"),  # Select the fields we care about
+        ),
+    )
+)
 
 v1 = GroupBy(
     sources=[source],
-    keys=["user_id"], # Primary key is the same as the primary key for the source table
-    aggregations=None, # In this case, there are no aggregations or windows to define
+    keys=["user_id"],  # Primary key is the same as the primary key for the source table
+    aggregations=None,  # In this case, there are no aggregations or windows to define
     online=True,
-) 
+)

--- a/api/py/test/sample/group_bys/sample_team/entity_sample_group_by_from_module.py
+++ b/api/py/test/sample/group_bys/sample_team/entity_sample_group_by_from_module.py
@@ -16,15 +16,8 @@ Sample group by
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-)
-
 
 v1 = GroupBy(
     sources=test_sources.entity_source,

--- a/api/py/test/sample/group_bys/sample_team/event_sample_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/event_sample_group_by.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    TimeUnit,
-    Window,
-)
-
 
 v1 = GroupBy(
     sources=test_sources.event_source,
@@ -31,18 +23,15 @@ v1 = GroupBy(
             input_column="event",
             operation=Operation.SUM,
             windows=[Window(length=7, timeUnit=TimeUnit.DAYS)],
-            tags={"DETAILED_TYPE": "CONTINUOUS"}
+            tags={"DETAILED_TYPE": "CONTINUOUS"},
         ),
+        Aggregation(input_column="event", operation=Operation.SUM),
         Aggregation(
             input_column="event",
-            operation=Operation.SUM
+            operation=Operation.APPROX_PERCENTILE([0.99, 0.95, 0.5], k=200),  # p99, p95, Median
         ),
-        Aggregation(
-            input_column="event",
-            operation=Operation.APPROX_PERCENTILE([0.99, 0.95, 0.5], k=200), # p99, p95, Median
-        )
     ],
     online=True,
     output_namespace="sample_namespace",
-    tags={"TO_DEPRECATE": True}
+    tags={"TO_DEPRECATE": True},
 )

--- a/api/py/test/sample/group_bys/sample_team/group_by_with_kwargs.py
+++ b/api/py/test/sample/group_bys/sample_team/group_by_with_kwargs.py
@@ -16,15 +16,8 @@ Sample group by
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-)
-
 
 v1 = GroupBy(
     sources=[

--- a/api/py/test/sample/group_bys/sample_team/mutation_sample_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/mutation_sample_group_by.py
@@ -16,14 +16,8 @@ Temporal entity sample group by
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Accuracy, Aggregation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Accuracy,
-)
-
 
 v0 = GroupBy(
     sources=test_sources.entity_source,

--- a/api/py/test/sample/group_bys/sample_team/sample_chaining_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_chaining_group_by.py
@@ -16,53 +16,46 @@ Sample Chaining Group By with join as a source
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import (
-    event_sample_group_by,
-    entity_sample_group_by_from_module,
-    group_by_with_kwargs,
-)
-
-from ai.chronon.join import Join, JoinPart
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Accuracy,
-    Operation,
-)
 from ai.chronon.api import ttypes
-from ai.chronon.query import (
-    Query,
-    select,
+from ai.chronon.group_by import Accuracy, Aggregation, GroupBy, Operation
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, select
+from group_bys.sample_team import (
+    entity_sample_group_by_from_module,
+    event_sample_group_by,
 )
+from sources import test_sources
 
 parent_join = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
     ],
     online=True,
-    check_consistency=True
+    check_consistency=True,
 )
 
 chaining_group_by_v1 = GroupBy(
-    sources=ttypes.Source(joinSource=ttypes.JoinSource(
-        join=parent_join,
-        query=Query(
-            selects=select(
-                event="event_expr",
-                group_by_subject="group_by_expr",
+    sources=ttypes.Source(
+        joinSource=ttypes.JoinSource(
+            join=parent_join,
+            query=Query(
+                selects=select(
+                    event="event_expr",
+                    group_by_subject="group_by_expr",
+                ),
+                start_partition="2023-04-15",
+                time_column="ts",
             ),
-            start_partition="2023-04-15",
-            time_column="ts",
-        ))),
+        )
+    ),
     keys=["user_id"],
     aggregations=[
         Aggregation(input_column="event", operation=Operation.LAST),
@@ -70,9 +63,6 @@ chaining_group_by_v1 = GroupBy(
     accuracy=Accuracy.TEMPORAL,
     online=True,
     production=True,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     output_namespace="test_namespace",
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, Derivation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Derivation
-)
-
 
 v1 = GroupBy(
     sources=test_sources.staging_entities,
@@ -30,10 +23,7 @@ v1 = GroupBy(
         Aggregation(input_column="viewed_unique_count_1d", operation=Operation.SUM),
     ],
     production=False,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     output_namespace="sample_namespace",
 )
 
@@ -47,14 +37,5 @@ require_backfill = GroupBy(
     production=False,
     output_namespace="sample_namespace",
     backfill_start_date="2023-01-01",
-    derivations=[
-        Derivation(
-            name="derived_field",
-            expression=""
-        ),
-        Derivation(
-            name="*",
-            expression="*"
-        )
-    ]
+    derivations=[Derivation(name="derived_field", expression=""), Derivation(name="*", expression="*")],
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_from_join_part.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_from_join_part.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,27 +12,17 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Derivation,
-    Accuracy,
-)
-from joins.sample_team.sample_join import v1
+from ai.chronon.group_by import Accuracy, Aggregation, GroupBy, Operation
 from ai.chronon.utils import join_part_output_table_name
-
+from joins.sample_team.sample_join import v1
+from sources import test_sources
 
 v1 = GroupBy(
     sources=test_sources.basic_event_source(join_part_output_table_name(v1, v1.joinParts[0], True)),
     keys=["s2CellId", "place_id"],
     aggregations=[Aggregation("some_column", operation=Operation.LAST)],
     production=False,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     accuracy=Accuracy.SNAPSHOT,
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_from_module.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_from_module.py
@@ -16,15 +16,8 @@ Sample group by
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-)
-
 
 v1 = GroupBy(
     sources=[

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_group_by.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +12,10 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Derivation
-)
 from ai.chronon import utils
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
 from group_bys.sample_team.sample_group_by import require_backfill
-
+from sources import test_sources
 
 v1 = GroupBy(
     sources=test_sources.basic_event_source(utils.group_by_output_table_name(require_backfill, True)),
@@ -32,9 +25,6 @@ v1 = GroupBy(
     ],
     production=False,
     backfill_start_date="2022-01-01",
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_missing_input_column.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_missing_input_column.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-)
-
 
 v1 = GroupBy(
     sources=test_sources.staging_entities,
@@ -29,10 +23,7 @@ v1 = GroupBy(
         Aggregation(operation=Operation.COUNT),
     ],
     production=False,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     online=True,
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_with_derivations.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_with_derivations.py
@@ -12,15 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, Derivation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-    Derivation
-)
 
 v1 = GroupBy(
     sources=test_sources.staging_entities,
@@ -30,15 +23,7 @@ v1 = GroupBy(
         Aggregation(input_column="viewed_unique_count", operation=Operation.SUM),
     ],
     production=False,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
-    derivations=[
-        Derivation(
-            name="impressed_unique_count_1d_new_name",
-            expression="impressed_unique_count_sum"
-        )
-    ],
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
+    derivations=[Derivation(name="impressed_unique_count_1d_new_name", expression="impressed_unique_count_sum")],
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_with_incorrect_derivations.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_with_incorrect_derivations.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, Derivation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Derivation
-)
-
 
 v1 = GroupBy(
     sources=test_sources.staging_entities,
@@ -30,15 +23,7 @@ v1 = GroupBy(
         Aggregation(input_column="viewed_unique_count_1d", operation=Operation.SUM),
     ],
     production=False,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
-    derivations=[
-        Derivation(
-            name="impressed_unique_count_1d_new_name",
-            expression="wrong_name"
-        )
-    ],
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
+    derivations=[Derivation(name="impressed_unique_count_1d_new_name", expression="wrong_name")],
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/group_bys/sample_team/sample_non_prod_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_non_prod_group_by.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,24 +12,17 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-)
-
 
 v1 = GroupBy(
     sources=test_sources.event_source,
     keys=["group_by_subject"],
     aggregations=[
         Aggregation(input_column="event", operation=Operation.SUM, windows=[Window(7, TimeUnit.DAYS)]),
-        Aggregation(input_column="event", operation=Operation.SUM)
+        Aggregation(input_column="event", operation=Operation.SUM),
     ],
     online=False,
     production=False,
-    output_namespace="sample_namespace"
+    output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/joins/kaggle/outbrain.py
+++ b/api/py/test/sample/joins/kaggle/outbrain.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +13,11 @@
 #     limitations under the License.
 
 from ai.chronon.join import Join, JoinPart
-from group_bys.kaggle.outbrain import ad_doc, ad_uuid, ad_platform
-from sources.kaggle.outbrain import outbrain_left_events
 from group_bys.kaggle.clicks import ad_streaming
+from group_bys.kaggle.outbrain import ad_doc, ad_platform, ad_uuid
+from sources.kaggle.outbrain import outbrain_left_events
 
 training_set = Join(  # left equi join
-    left=outbrain_left_events(
-        "uuid", "display_id", "ad_id", "document_id", "clicked", "geo_location", "platform"),
-    right_parts=[JoinPart(group_by=group_by) for group_by in [ad_doc, ad_uuid, ad_streaming, ad_platform]]
+    left=outbrain_left_events("uuid", "display_id", "ad_id", "document_id", "clicked", "geo_location", "platform"),
+    right_parts=[JoinPart(group_by=group_by) for group_by in [ad_doc, ad_uuid, ad_streaming, ad_platform]],
 )

--- a/api/py/test/sample/joins/quickstart/training_set.py
+++ b/api/py/test/sample/joins/quickstart/training_set.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.api.ttypes import EventSource, Source
 from ai.chronon.join import Join, JoinPart
-from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
-
 from group_bys.quickstart.purchases import v1 as purchases_v1
 from group_bys.quickstart.returns import v1 as returns_v1
 from group_bys.quickstart.users import v1 as users
@@ -27,20 +25,25 @@ and timestamps for which features will be computed.
 """
 source = Source(
     events=EventSource(
-        table="data.checkouts", 
+        table="data.checkouts",
         query=Query(
-            selects=select("user_id"), # The primary key used to join various GroupBys together
+            selects=select("user_id"),  # The primary key used to join various GroupBys together
             time_column="ts",
-            ) # The event time used to compute feature values as-of
-    ))
+        ),  # The event time used to compute feature values as-of
+    )
+)
 
-v1 = Join(  
+v1 = Join(
     left=source,
-    right_parts=[JoinPart(group_by=group_by) for group_by in [purchases_v1, returns_v1, users]] # Include the three GroupBys
+    right_parts=[
+        JoinPart(group_by=group_by) for group_by in [purchases_v1, returns_v1, users]
+    ],  # Include the three GroupBys
 )
 
 v2 = Join(
     left=source,
-    right_parts=[JoinPart(group_by=group_by) for group_by in [purchases_v1, returns_v1]], # Include the two online GroupBys
+    right_parts=[
+        JoinPart(group_by=group_by) for group_by in [purchases_v1, returns_v1]
+    ],  # Include the two online GroupBys
     online=True,
 )

--- a/api/py/test/sample/joins/sample_team/sample_backfill_mutation_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_backfill_mutation_join.py
@@ -16,14 +16,12 @@ Sample entity temporal accurate backfill (mutation)
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import mutation_sample_group_by
 from ai.chronon.join import Join, JoinPart
-
+from group_bys.sample_team import mutation_sample_group_by
+from sources import test_sources
 
 v0 = Join(
     left=test_sources.event_source,
     right_parts=[JoinPart(group_by=mutation_sample_group_by.v0)],
     online=False,
 )
-

--- a/api/py/test/sample/joins/sample_team/sample_chaining_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_chaining_join.py
@@ -16,36 +16,26 @@ Sample Chaining Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import (
-    event_sample_group_by,
-    entity_sample_group_by_from_module,
-    group_by_with_kwargs,
-)
-
-from ai.chronon.join import Join, JoinPart
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Accuracy,
-    Operation,
-)
 from ai.chronon.api import ttypes
-from ai.chronon.query import (
-    Query,
-    select,
+from ai.chronon.group_by import Accuracy, Aggregation, GroupBy, Operation
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, select
+from group_bys.sample_team import (
+    entity_sample_group_by_from_module,
+    event_sample_group_by,
 )
+from sources import test_sources
 
 parent_join = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
     ],
     online=True,
@@ -55,16 +45,19 @@ parent_join = Join(
 
 chaining_group_by_v1 = GroupBy(
     name="sample_team.sample_chaining_group_by",
-    sources=ttypes.Source(joinSource=ttypes.JoinSource(
-        join=parent_join,
-        query=Query(
-            selects=select(
-                event="event_expr",
-                group_by_subject="group_by_expr",
+    sources=ttypes.Source(
+        joinSource=ttypes.JoinSource(
+            join=parent_join,
+            query=Query(
+                selects=select(
+                    event="event_expr",
+                    group_by_subject="group_by_expr",
+                ),
+                start_partition="2023-04-15",
+                time_column="ts",
             ),
-            start_partition="2023-04-15",
-            time_column="ts",
-        ))),
+        )
+    ),
     keys=["user_id"],
     aggregations=[
         Aggregation(input_column="event", operation=Operation.LAST),
@@ -72,10 +65,7 @@ chaining_group_by_v1 = GroupBy(
     accuracy=Accuracy.TEMPORAL,
     online=True,
     production=True,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     output_namespace="sample_namespace",
 )
 
@@ -84,15 +74,11 @@ v1 = Join(
     right_parts=[
         JoinPart(
             group_by=chaining_group_by_v1,
-            key_mapping={'subject': 'user_id'},
+            key_mapping={"subject": "user_id"},
         ),
     ],
-    additional_args={
-        'custom_arg': 'custom_value'
-    },
-    additional_env={
-        'custom_env': 'custom_env_value'
-    },
+    additional_args={"custom_arg": "custom_value"},
+    additional_env={"custom_env": "custom_env_value"},
     online=True,
-    check_consistency=True
+    check_consistency=True,
 )

--- a/api/py/test/sample/joins/sample_team/sample_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_join.py
@@ -12,26 +12,18 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
+from ai.chronon.join import Join, JoinPart
 from group_bys.sample_team import sample_group_by, sample_group_by_group_by
-from ai.chronon.join import (
-    Join,
-    JoinPart,
-)
-
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.staging_entities,
     right_parts=[JoinPart(group_by=sample_group_by.v1, tags={"experimental": True})],
-    table_properties={
-        "config_json": """{"sample_key": "sample_value"}"""
-    },
+    table_properties={"config_json": """{"sample_key": "sample_value"}"""},
     output_namespace="sample_namespace",
     tags={"business_relevance": "personalization"},
     env={
-        "backfill": {
-            "EXECUTOR_MEMORY": "9G"
-        },
+        "backfill": {"EXECUTOR_MEMORY": "9G"},
     },
 )
 
@@ -40,7 +32,7 @@ never = Join(
     right_parts=[JoinPart(group_by=sample_group_by.v1, tags={"experimental": True})],
     output_namespace="sample_namespace",
     tags={"business_relevance": "personalization"},
-    offline_schedule='@never',
+    offline_schedule="@never",
 )
 
 group_by_of_group_by = Join(

--- a/api/py/test/sample/joins/sample_team/sample_join_bootstrap.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_bootstrap.py
@@ -16,32 +16,31 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
+from ai.chronon.join import BootstrapPart, Join, JoinPart
+from ai.chronon.query import Query, select
+from ai.chronon.utils import get_join_output_table_name
 from group_bys.sample_team import (
-    event_sample_group_by,
     entity_sample_group_by_from_module,
+    event_sample_group_by,
     group_by_with_kwargs,
 )
-
-from ai.chronon.join import Join, JoinPart, BootstrapPart
-from ai.chronon.query import Query, select
-from ai.chronon.utils import get_join_output_table_name, get_staging_query_output_table_name
+from sources import test_sources
 
 v1_join_parts = [
     JoinPart(
         group_by=event_sample_group_by.v1,
-        key_mapping={'subject': 'group_by_subject'},
+        key_mapping={"subject": "group_by_subject"},
     ),
     JoinPart(
         group_by=entity_sample_group_by_from_module.v1,
-        key_mapping={'subject': 'group_by_subject'},
+        key_mapping={"subject": "group_by_subject"},
     ),
 ]
 
 v2_join_parts = [
     JoinPart(
         group_by=group_by_with_kwargs.v1,
-        key_mapping={'subject': 'group_by_subject'},
+        key_mapping={"subject": "group_by_subject"},
     ),
 ]
 
@@ -57,12 +56,12 @@ v1 = Join(
             "chronon_db.test_bootstrap_table",
             key_columns=["request_id"],
             query=Query(
-                start_partition='2022-01-01',
-                end_partition='2022-02-01',
+                start_partition="2022-01-01",
+                end_partition="2022-02-01",
                 selects=select(field_a="field_a", field_b="field_b"),
-            )
+            ),
         )
-    ]
+    ],
 )
 
 v2 = Join(
@@ -73,11 +72,6 @@ v2 = Join(
     row_ids=["request_id"],
     bootstrap_from_log=True,
     bootstrap_parts=[
-        BootstrapPart(
-            table=get_join_output_table_name(v1, full_name=True),
-            query=Query(
-                end_partition="2023-01-01"
-            )
-        )
-    ]
+        BootstrapPart(table=get_join_output_table_name(v1, full_name=True), query=Query(end_partition="2023-01-01"))
+    ],
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_derivation.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_derivation.py
@@ -16,36 +16,30 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
+from ai.chronon.join import Derivation, Join, JoinPart
 from group_bys.sample_team import (
-    event_sample_group_by,
     entity_sample_group_by_from_module,
-    group_by_with_kwargs,
+    event_sample_group_by,
 )
-
-from ai.chronon.join import Join, JoinPart, Derivation
-
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
-        )
+            key_mapping={"subject": "group_by_subject"},
+        ),
     ],
     derivations=[
         Derivation(
             name="derived_field",
-            expression="sample_team_event_sample_group_by_v1_event_sum_7d / sample_team_entity_sample_group_by_from_module_v1_entity_last"
+            expression="sample_team_event_sample_group_by_v1_event_sum_7d / sample_team_entity_sample_group_by_from_module_v1_entity_last",
         ),
-        Derivation(
-            name="*",
-            expression="*"
-        )
-    ]
+        Derivation(name="*", expression="*"),
+    ],
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
@@ -16,17 +16,16 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from group_bys.sample_team import sample_group_by
-from sources import test_sources
-
 from ai.chronon.join import (
-    Join,
-    JoinPart,
+    ContextualSource,
+    DataType,
     ExternalPart,
     ExternalSource,
-    DataType,
-    ContextualSource
+    Join,
+    JoinPart,
 )
+from group_bys.sample_team import sample_group_by
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.staging_entities,
@@ -36,14 +35,12 @@ v1 = Join(
             ExternalSource(
                 name="test_external_source",
                 team="chronon",
-                key_fields=[
-                    ("key", DataType.LONG)
-                ],
+                key_fields=[("key", DataType.LONG)],
                 value_fields=[
                     ("value_str", DataType.STRING),
                     ("value_long", DataType.LONG),
-                    ("value_bool", DataType.BOOLEAN)
-                ]
+                    ("value_bool", DataType.BOOLEAN),
+                ],
             )
         ),
         ExternalPart(
@@ -52,12 +49,10 @@ v1 = Join(
                     ("context_str", DataType.STRING),
                     ("context_long", DataType.LONG),
                 ],
-                team="chronon"
+                team="chronon",
             )
-        )
+        ),
     ],
-    table_properties={
-        "config_json": """{"sample_key": "sample_value"}"""
-    },
-    output_namespace="sample_namespace"
+    table_properties={"config_json": """{"sample_key": "sample_value"}"""},
+    output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_from_group_by_from_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_from_group_by_from_join.py
@@ -12,13 +12,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
+from ai.chronon.join import Join, JoinPart
 from group_bys.sample_team import sample_group_by_from_join_part
-from ai.chronon.join import (
-    Join,
-    JoinPart,
-)
-
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.staging_entities,

--- a/api/py/test/sample/joins/sample_team/sample_join_from_module.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_from_module.py
@@ -16,30 +16,25 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
 from ai.chronon.join import Join, JoinPart
 from group_bys.sample_team import (
-    sample_group_by_from_module,
     entity_sample_group_by_from_module,
+    sample_group_by_from_module,
 )
-
+from sources import test_sources
 
 v1 = Join(
-    left = test_sources.staging_entities,
+    left=test_sources.staging_entities,
     right_parts=[
         JoinPart(
             group_by=sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
-        )
+            key_mapping={"subject": "group_by_subject"},
+        ),
     ],
-    additional_args={
-        'custom_arg': 'custom_value'
-    },
-    additional_env={
-        'custom_env': 'custom_env_value'
-    },
+    additional_args={"custom_arg": "custom_value"},
+    additional_env={"custom_env": "custom_env_value"},
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_from_module_skipped.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_from_module_skipped.py
@@ -16,18 +16,16 @@ Sample Non Production Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import sample_non_prod_group_by
-
 from ai.chronon.join import Join, JoinPart
-
+from group_bys.sample_team import sample_non_prod_group_by
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=sample_non_prod_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
     ],
     online=True,

--- a/api/py/test/sample/joins/sample_team/sample_join_from_shorthand.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_from_shorthand.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +12,10 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.join import JoinPart, Join
-from ai.chronon.query import Query, select
+from ai.chronon.join import Join
 from sources import test_sources
 
-
 v1 = Join(
-    left = test_sources.entity_source,
+    left=test_sources.entity_source,
     right_parts=[],
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_with_derivations_on_external_parts.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_with_derivations_on_external_parts.py
@@ -16,49 +16,44 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import (
-    event_sample_group_by,
-    entity_sample_group_by_from_module,
-    group_by_with_kwargs,
-)
-
 from ai.chronon.join import (
-    Join,
-    JoinPart,
+    ContextualSource,
+    DataType,
+    Derivation,
     ExternalPart,
     ExternalSource,
-    DataType,
-    ContextualSource,
-    Derivation
+    Join,
+    JoinPart,
 )
-
+from group_bys.sample_team import (
+    entity_sample_group_by_from_module,
+    event_sample_group_by,
+)
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
-        )
+            key_mapping={"subject": "group_by_subject"},
+        ),
     ],
     online_external_parts=[
         ExternalPart(
             ExternalSource(
                 name="test_external_source",
                 team="chronon",
-                key_fields=[
-                    ("key", DataType.LONG)
-                ],
+                key_fields=[("key", DataType.LONG)],
                 value_fields=[
                     ("value_str", DataType.STRING),
                     ("value_long", DataType.LONG),
-                    ("value_bool", DataType.BOOLEAN)
-                ]
+                    ("value_bool", DataType.BOOLEAN),
+                ],
             )
         ),
         ExternalPart(
@@ -67,24 +62,16 @@ v1 = Join(
                     ("context_str", DataType.STRING),
                     ("context_long", DataType.LONG),
                 ],
-                team="chronon"
+                team="chronon",
             )
-        )
+        ),
     ],
     derivations=[
         *[
-            Derivation(name=c, expression=f"ext_test_external_source_{c}") for c in [
-                "value_str", "value_long", "value_bool"
-            ]
+            Derivation(name=c, expression=f"ext_test_external_source_{c}")
+            for c in ["value_str", "value_long", "value_bool"]
         ],
-        *[
-            Derivation(name=c, expression=f"ext_contextual_{c}") for c in [
-                "context_str", "context_long"
-            ]
-        ],
-        Derivation(
-            name="*",
-            expression="*"
-        )
-    ]
+        *[Derivation(name=c, expression=f"ext_contextual_{c}") for c in ["context_str", "context_long"]],
+        Derivation(name="*", expression="*"),
+    ],
 )

--- a/api/py/test/sample/joins/sample_team/sample_label_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_label_join.py
@@ -16,17 +16,10 @@ Sample Label Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import (
-    event_sample_group_by,
-    entity_sample_group_by_from_module,
-    group_by_with_kwargs,
-)
-
+from ai.chronon.group_by import GroupBy
 from ai.chronon.join import Join, JoinPart, LabelPart
-from ai.chronon.group_by import (
-    GroupBy,
-)
+from group_bys.sample_team import event_sample_group_by, group_by_with_kwargs
+from sources import test_sources
 
 label_part_group_by = GroupBy(
     name="sample_label_group_by",
@@ -42,27 +35,22 @@ v1 = Join(
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=group_by_with_kwargs.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
     ],
-    label_part=LabelPart([
-            JoinPart(
-                group_by=label_part_group_by
-            ),
+    label_part=LabelPart(
+        [
+            JoinPart(group_by=label_part_group_by),
         ],
         left_start_offset=30,
         left_end_offset=10,
-        label_offline_schedule="@weekly"
-        ),
-    additional_args={
-        'custom_arg': 'custom_value'
-    },
-    additional_env={
-        'custom_env': 'custom_env_value'
-    },
-    online=False
+        label_offline_schedule="@weekly",
+    ),
+    additional_args={"custom_arg": "custom_value"},
+    additional_env={"custom_env": "custom_env_value"},
+    online=False,
 )

--- a/api/py/test/sample/joins/sample_team/sample_label_join_with_agg.py
+++ b/api/py/test/sample/joins/sample_team/sample_label_join_with_agg.py
@@ -16,21 +16,10 @@ Sample Label Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.sample_team import (
-    event_sample_group_by,
-    entity_sample_group_by_from_module,
-    group_by_with_kwargs,
-)
-
+from ai.chronon.group_by import Aggregation, GroupBy, Operation, TimeUnit, Window
 from ai.chronon.join import Join, JoinPart, LabelPart
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-)
+from group_bys.sample_team import event_sample_group_by, group_by_with_kwargs
+from sources import test_sources
 
 label_part_group_by = GroupBy(
     name="sample_label_group_by",
@@ -48,27 +37,22 @@ v1 = Join(
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=group_by_with_kwargs.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
     ],
-    label_part=LabelPart([
-            JoinPart(
-                group_by=label_part_group_by
-            ),
+    label_part=LabelPart(
+        [
+            JoinPart(group_by=label_part_group_by),
         ],
         left_start_offset=7,
         left_end_offset=7,
-        label_offline_schedule="@weekly"
-        ),
-    additional_args={
-        'custom_arg': 'custom_value'
-    },
-    additional_env={
-        'custom_env': 'custom_env_value'
-    },
-    online=False
+        label_offline_schedule="@weekly",
+    ),
+    additional_args={"custom_arg": "custom_value"},
+    additional_env={"custom_env": "custom_env_value"},
+    online=False,
 )

--- a/api/py/test/sample/joins/sample_team/sample_online_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_online_join.py
@@ -16,36 +16,32 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
+from ai.chronon.join import Join, JoinPart
 from group_bys.sample_team import (
-    event_sample_group_by,
     entity_sample_group_by_from_module,
+    event_sample_group_by,
     group_by_with_kwargs,
 )
-
-from ai.chronon.join import Join, JoinPart
-
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=group_by_with_kwargs.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
     ],
-    additional_args=['--step-days 14'],
-    additional_env={
-        'custom_env': 'custom_env_value'
-    },
+    additional_args=["--step-days 14"],
+    additional_env={"custom_env": "custom_env_value"},
     online=True,
-    check_consistency=True
+    check_consistency=True,
 )

--- a/api/py/test/sample/production/joins/sample_team/sample_chaining_join.parent_join
+++ b/api/py/test/sample/production/joins/sample_team/sample_chaining_join.parent_join
@@ -44,9 +44,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -111,10 +108,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v1
@@ -44,9 +44,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -111,10 +108,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v2
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v2
@@ -46,9 +46,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -113,10 +110,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },
@@ -174,10 +167,6 @@
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
             "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_join_derivation.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_derivation.v1
@@ -42,9 +42,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -109,10 +106,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
@@ -114,10 +114,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_join_with_derivations_on_external_parts.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_with_derivations_on_external_parts.v1
@@ -42,9 +42,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -109,10 +106,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_label_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_label_join.v1
@@ -42,9 +42,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -109,10 +106,6 @@
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
             "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_label_join_with_agg.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_label_join_with_agg.v1
@@ -42,9 +42,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -109,10 +106,6 @@
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
             "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/production/joins/sample_team/sample_online_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_online_join.v1
@@ -45,9 +45,6 @@
           "dependencies": [
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
           "outputNamespace": "sample_namespace",
           "team": "sample_team",
           "offlineSchedule": "@daily"
@@ -112,10 +109,6 @@
             "{\"name\": \"wait_for_sample_table.sample_entity_snapshot_ds\", \"spec\": \"sample_table.sample_entity_snapshot/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
             "{\"name\": \"wait_for_sample_table.sample_entity_mutations_ds\", \"spec\": \"sample_table.sample_entity_mutations/ds={{ ds }}/hr=00:00\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },
@@ -173,10 +166,6 @@
             "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
             "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
           ],
-          "tableProperties": {
-            "source": "chronon"
-          },
-          "outputNamespace": "chronon_db",
           "team": "sample_team",
           "offlineSchedule": "@daily"
         },

--- a/api/py/test/sample/scripts/fetch_online_jar.py
+++ b/api/py/test/sample/scripts/fetch_online_jar.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 # TODO: Implement how to fetch your jar for online implementation of ai.chronon.online.Api interface/trait
-# For example some companies host their jars on artifactory and you can pull from there 
+# For example some companies host their jars on artifactory and you can pull from there
 # We expect the output of this script to be a string path to where the file is downloaded
-
 
 
 #     Copyright (C) 2023 The Chronon Authors.
@@ -20,9 +19,9 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from urllib.request import urlretrieve
-import os
 import logging
+import os
+from urllib.request import urlretrieve
 
 
 def download():

--- a/api/py/test/sample/scripts/yarn_list.py
+++ b/api/py/test/sample/scripts/yarn_list.py
@@ -10,7 +10,6 @@
 # **********************************************
 
 
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,34 +25,28 @@
 #     limitations under the License.
 
 import json
-import os
 import subprocess
 from shlex import split
-import sys
 
-
-ACTIVE_APP_STATUS = ['SUBMITTED', 'ACCEPTED', 'RUNNING']
+ACTIVE_APP_STATUS = ["SUBMITTED", "ACCEPTED", "RUNNING"]
 
 # TODO: REPLACE WITH path to your YARN
-YARN_EXECUTABLE = '/usr/bin/yarn'
+YARN_EXECUTABLE = "/usr/bin/yarn"
 
 # TODO: REPLACE WITH path to your cluster confs
-EMR_HADOOP_CONF_PATH_TEMPLATE = '/etc/emr/{emr_cluster}/hadoop/conf'
+EMR_HADOOP_CONF_PATH_TEMPLATE = "/etc/emr/{emr_cluster}/hadoop/conf"
 
 YARN_TIMEOUT_SECONDS = 120
 
 
 # returns list of active yarn apps on a cluster
 def get_active_applications(
-        emr_cluster,
-        yarn_executable=YARN_EXECUTABLE,
-        timeout=YARN_TIMEOUT_SECONDS,
-        ssh_command=None):
+    emr_cluster, yarn_executable=YARN_EXECUTABLE, timeout=YARN_TIMEOUT_SECONDS, ssh_command=None
+):
     hadoop_conf = EMR_HADOOP_CONF_PATH_TEMPLATE.format(emr_cluster=emr_cluster)
-    emr_application_list_cmd = '{yarn_executable} --config {hadoop_conf} application -list'.format(
-            hadoop_conf=hadoop_conf,
-            yarn_executable=yarn_executable
-        )
+    emr_application_list_cmd = "{yarn_executable} --config {hadoop_conf} application -list".format(
+        hadoop_conf=hadoop_conf, yarn_executable=yarn_executable
+    )
     if ssh_command:
         emr_application_list_cmd = "{} {}".format(ssh_command, emr_application_list_cmd)
     print("Running yarn list command: {}".format(emr_application_list_cmd))
@@ -61,8 +54,8 @@ def get_active_applications(
     if isinstance(output, bytes):
         output = output.decode()
     yarn_apps = []
-    for app_listing in output.strip().split('\n')[2:]:
-        tokens = [app_listing.strip() for app_listing in app_listing.split('\t')]
+    for app_listing in output.strip().split("\n")[2:]:
+        tokens = [app_listing.strip() for app_listing in app_listing.split("\t")]
         app_id = tokens[0]
         job = {
             "app_id": app_id,
@@ -72,7 +65,7 @@ def get_active_applications(
             "queue": tokens[4],
             "status": tokens[5],
             "tracking_url": "{}/proxy/{}/".format(tokens[8], tokens[0]),
-            "kill_cmd": '{yarn_executable} --config {hadoop_conf} application -kill {app_id}'.format(**locals())
+            "kill_cmd": "{yarn_executable} --config {hadoop_conf} application -kill {app_id}".format(**locals()),
         }
         yarn_apps.append(job)
     result = []

--- a/api/py/test/sample/sources/kaggle/outbrain.py
+++ b/api/py/test/sample/sources/kaggle/outbrain.py
@@ -1,5 +1,3 @@
-
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.api.ttypes import EventSource, Source
 from ai.chronon.query import Query, select
 from ai.chronon.utils import get_staging_query_output_table_name
 from staging_queries.kaggle.outbrain import base_table
@@ -25,14 +23,17 @@ Sources allow one-to-one transformations (i.e. row level transformations like RO
 Sources are used as components in GroupBys (which can define aggregations on top of a source for a given primary key), or as the left side of a Join.
 """
 
+
 def outbrain_left_events(*columns):
     """
     Defines a source based off of the output table of the `base_table` StagingQuery.
     """
-    return Source(events=EventSource(
-        table=get_staging_query_output_table_name(base_table),
-        query=Query(
-            selects=select(*columns),
-            time_column="ts",
-        ),
-    ))
+    return Source(
+        events=EventSource(
+            table=get_staging_query_output_table_name(base_table),
+            query=Query(
+                selects=select(*columns),
+                time_column="ts",
+            ),
+        )
+    )

--- a/api/py/test/sample/sources/test_sources.py
+++ b/api/py/test/sample/sources/test_sources.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,19 +12,32 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.query import (
-    Query,
-    select,
-)
-from ai.chronon.utils import get_staging_query_output_table_name
 from ai.chronon.api import ttypes
-
+from ai.chronon.query import Query, select
+from ai.chronon.utils import get_staging_query_output_table_name
 from staging_queries.sample_team import sample_staging_query
 
 
 def basic_event_source(table):
-    return ttypes.Source(events=ttypes.EventSource(
-        table=table,
+    return ttypes.Source(
+        events=ttypes.EventSource(
+            table=table,
+            query=Query(
+                selects=select(
+                    event="event_expr",
+                    group_by_subject="group_by_expr",
+                ),
+                start_partition="2021-04-09",
+                time_column="ts",
+            ),
+        )
+    )
+
+
+# Sample Event Source used in tests.
+event_source = ttypes.Source(
+    events=ttypes.EventSource(
+        table="sample_namespace.sample_table_group_by",
         query=Query(
             selects=select(
                 event="event_expr",
@@ -34,89 +46,92 @@ def basic_event_source(table):
             start_partition="2021-04-09",
             time_column="ts",
         ),
-    ))
-
-
-# Sample Event Source used in tests.
-event_source = ttypes.Source(events=ttypes.EventSource(
-    table="sample_namespace.sample_table_group_by",
-    query=Query(
-        selects=select(
-            event="event_expr",
-            group_by_subject="group_by_expr",
-        ),
-        start_partition="2021-04-09",
-        time_column="ts",
-    ),
-))
+    )
+)
 
 # Sample Entity Source
-entity_source = ttypes.Source(entities=ttypes.EntitySource(
-    snapshotTable="sample_table.sample_entity_snapshot",
-    # hr partition is not necessary - just to demo that we support various 
-    # partitioning schemes
-    mutationTable="sample_table.sample_entity_mutations/hr=00:00",
-    mutationTopic="sample_topic",
-    query=Query(
-        start_partition='2021-03-01',
-        selects=select(
-            group_by_subject='group_by_subject_expr',
-            entity='entity_expr',
+entity_source = ttypes.Source(
+    entities=ttypes.EntitySource(
+        snapshotTable="sample_table.sample_entity_snapshot",
+        # hr partition is not necessary - just to demo that we support various
+        # partitioning schemes
+        mutationTable="sample_table.sample_entity_mutations/hr=00:00",
+        mutationTopic="sample_topic",
+        query=Query(
+            start_partition="2021-03-01",
+            selects=select(
+                group_by_subject="group_by_subject_expr",
+                entity="entity_expr",
+            ),
+            time_column="ts",
         ),
-        time_column="ts"
-    ),
-))
+    )
+)
 
-batch_entity_source = ttypes.Source(entities=ttypes.EntitySource(
-    snapshotTable="sample_table.sample_entity_snapshot",
-    query=Query(
-        start_partition='2021-03-01',
-        selects=select(
-            group_by_subject='group_by_subject_expr',
-            entity='entity_expr',
+batch_entity_source = ttypes.Source(
+    entities=ttypes.EntitySource(
+        snapshotTable="sample_table.sample_entity_snapshot",
+        query=Query(
+            start_partition="2021-03-01",
+            selects=select(
+                group_by_subject="group_by_subject_expr",
+                entity="entity_expr",
+            ),
+            time_column="ts",
         ),
-        time_column="ts"
-    ),
-))
+    )
+)
 
 # Sample Entity Source derived from a staging query.
-staging_entities=ttypes.Source(entities=ttypes.EntitySource(
-    snapshotTable="sample_namespace.{}".format(get_staging_query_output_table_name(sample_staging_query.v1)),
-    query=Query(
-        start_partition='2021-03-01',
-        selects=select(**{
-            'impressed_unique_count_1d': 'impressed_unique_count_1d',
-            'viewed_unique_count_1d': 'viewed_unique_count_1d',
-            's2CellId': 's2CellId',
-            'place_id': 'place_id'
-        })
+staging_entities = ttypes.Source(
+    entities=ttypes.EntitySource(
+        snapshotTable="sample_namespace.{}".format(get_staging_query_output_table_name(sample_staging_query.v1)),
+        query=Query(
+            start_partition="2021-03-01",
+            selects=select(
+                **{
+                    "impressed_unique_count_1d": "impressed_unique_count_1d",
+                    "viewed_unique_count_1d": "viewed_unique_count_1d",
+                    "s2CellId": "s2CellId",
+                    "place_id": "place_id",
+                }
+            ),
+        ),
     )
-))
+)
 
 
 # A Source that was deprecated but still relevant (requires stitching).
-events_until_20210409 = ttypes.Source(events=ttypes.EventSource(
-    table="sample_namespace.sample_table_group_by",
-    query=Query(
-        start_partition='2021-03-01',
-        end_partition='2021-04-09',
-        selects=select(**{
-            'group_by_subject': 'group_by_subject_expr_old_version',
-            'event': 'event_expr_old_version',
-        }),
-        time_column="UNIX_TIMESTAMP(ts) * 1000"
-    ),
-))
+events_until_20210409 = ttypes.Source(
+    events=ttypes.EventSource(
+        table="sample_namespace.sample_table_group_by",
+        query=Query(
+            start_partition="2021-03-01",
+            end_partition="2021-04-09",
+            selects=select(
+                **{
+                    "group_by_subject": "group_by_subject_expr_old_version",
+                    "event": "event_expr_old_version",
+                }
+            ),
+            time_column="UNIX_TIMESTAMP(ts) * 1000",
+        ),
+    )
+)
 
 # The new source
-events_after_20210409 = ttypes.Source(events=ttypes.EventSource(
-    table="sample_namespace.another_sample_table_group_by",
-    query=Query(
-        start_partition='2021-03-01',
-        selects=select(**{
-            'group_by_subject': 'possibly_different_group_by_subject_expr',
-            'event': 'possibly_different_event_expr',
-        }),
-        time_column="__timestamp"
-    ),
-))
+events_after_20210409 = ttypes.Source(
+    events=ttypes.EventSource(
+        table="sample_namespace.another_sample_table_group_by",
+        query=Query(
+            start_partition="2021-03-01",
+            selects=select(
+                **{
+                    "group_by_subject": "possibly_different_group_by_subject_expr",
+                    "event": "possibly_different_event_expr",
+                }
+            ),
+            time_column="__timestamp",
+        ),
+    )
+)

--- a/api/py/test/sample/staging_queries/kaggle/outbrain.py
+++ b/api/py/test/sample/staging_queries/kaggle/outbrain.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import StagingQuery, MetaData
+from ai.chronon.api.ttypes import MetaData, StagingQuery
 
 base_table = StagingQuery(
     query="""
@@ -36,7 +35,7 @@ base_table = StagingQuery(
         AND ABS(HASH(events.display_id)) % 100  < 5
     """,
     metaData=MetaData(
-        name='outbrain_left',
+        name="outbrain_left",
         outputNamespace="default",
-    )
+    ),
 )

--- a/api/py/test/sample/staging_queries/sample_team/sample_staging_query.py
+++ b/api/py/test/sample/staging_queries/sample_team/sample_staging_query.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import StagingQuery, MetaData
+from ai.chronon.api.ttypes import MetaData, StagingQuery
 
 query = """
 SELECT
@@ -34,11 +33,11 @@ v1 = StagingQuery(
         "CREATE TEMPORARY FUNCTION S2_CELL AS 'com.sample.hive.udf.S2CellId'",
     ],
     metaData=MetaData(
-        name='sample_staging_query',
+        name="sample_staging_query",
         outputNamespace="sample_namespace",
         dependencies=["sample_namespace.sample_table/ds={{ ds }}"],
         tableProperties={
             "sample_config_json": """{"sample_key": "sample value}""",
-        }
-    )
+        },
+    ),
 )

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -22,30 +22,21 @@ from click.testing import CliRunner
 
 def test_basic_compile():
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team/'
-    ])
+    result = runner.invoke(extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/"])
     assert result.exit_code == 0
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team'
-    ])
+    result = runner.invoke(extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team"])
     assert result.exit_code == 0
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team/sample_join.py'
-    ])
+    result = runner.invoke(
+        extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/sample_join.py"]
+    )
     assert result.exit_code == 0
 
 
 def test_debug_compile():
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team/',
-        '--debug'
-    ])
+    result = runner.invoke(
+        extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/", "--debug"]
+    )
     assert result.exit_code == 0
 
 
@@ -54,9 +45,12 @@ def test_failed_compile():
     Should fail as it fails to find teams.
     """
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--input_path=joins/sample_team/',
-    ])
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--input_path=joins/sample_team/",
+        ],
+    )
     assert result.exit_code != 0
 
 
@@ -65,9 +59,12 @@ def test_failed_compile_missing_input_column():
     Should raise errors as we are trying to create aggregations without input column.
     """
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=group_bys/sample_team/sample_group_by_missing_input_column.py',
-        '--debug'
-    ])
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=group_bys/sample_team/sample_group_by_missing_input_column.py",
+            "--debug",
+        ],
+    )
     assert result.exit_code != 0

--- a/api/py/test/test_decorator.py
+++ b/api/py/test/test_decorator.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,25 +12,24 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.repo.run import retry_decorator
-
 import pytest
+from ai.chronon.repo.run import retry_decorator
 
 
 def generator():
-    """ Simple generator to have a changing variable. """
+    """Simple generator to have a changing variable."""
     for i in range(10):
         yield i
 
 
 @pytest.fixture
 def generated():
-    """ Build fixture for generator so it can increment on subsequent calls """
+    """Build fixture for generator so it can increment on subsequent calls"""
     return generator()
 
 
 def fail_x_times(generated, x):
-    """ Function that will fail x times before succeeding given the same generator. """
+    """Function that will fail x times before succeeding given the same generator."""
     y = next(generated)
     if y < x:
         raise ValueError(f"Value was {y}")
@@ -40,7 +38,7 @@ def fail_x_times(generated, x):
 
 @retry_decorator(1, 1)
 def fail_x_times_and_succeed(generated, x):
-    """ Decorated function that will succeed after failing once. """
+    """Decorated function that will succeed after failing once."""
     fail_x_times(generated, x)
 
 
@@ -48,4 +46,3 @@ def test_retry(generated):
     with pytest.raises(Exception):
         fail_x_times(generated, 3)
     fail_x_times_and_succeed(generated, 3)
-

--- a/api/py/test/test_explore.py
+++ b/api/py/test/test_explore.py
@@ -16,18 +16,18 @@ Run the flow for materialize.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.repo.explore import (
-    load_team_data,
-    build_index,
-    enrich_with_joins,
-    display_entries,
-    find_in_index,
-    GB_INDEX_SPEC,
-    JOIN_INDEX_SPEC,
-)
+import os
 
 import pytest
-import os
+from ai.chronon.repo.explore import (
+    GB_INDEX_SPEC,
+    JOIN_INDEX_SPEC,
+    build_index,
+    display_entries,
+    enrich_with_joins,
+    find_in_index,
+    load_team_data,
+)
 
 
 @pytest.mark.parametrize("keyword", ["event", "entity"])

--- a/api/py/test/test_group_by.py
+++ b/api/py/test/test_group_by.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +12,11 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-import pytest, json
+import json
 
+import pytest
 from ai.chronon import group_by, query
-from ai.chronon.group_by import GroupBy, TimeUnit, Window, Aggregation
 from ai.chronon.api import ttypes
-from ai.chronon.api.ttypes import EventSource, EntitySource, Operation
 
 
 @pytest.fixture
@@ -49,11 +47,7 @@ def event_source(table):
         table=table,
         query=ttypes.Query(
             startPartition="2020-04-09",
-            selects={
-                "subject": "subject_sql",
-                "event_id": "event_sql",
-                "cnt": 1
-            },
+            selects={"subject": "subject_sql", "event_id": "event_sql", "cnt": 1},
             timeColumn="CAST(ts AS DOUBLE)",
         ),
     )
@@ -68,11 +62,7 @@ def entity_source(snapshotTable, mutationTable):
         mutationTable=mutationTable,
         query=ttypes.Query(
             startPartition="2020-04-09",
-            selects={
-                "subject": "subject_sql",
-                "event_id": "event_sql",
-                "cnt": 1
-            },
+            selects={"subject": "subject_sql", "event_id": "event_sql", "cnt": 1},
             timeColumn="CAST(ts AS DOUBLE)",
             mutationTimeColumn="__mutationTs",
             reversalColumn="is_reverse",
@@ -84,15 +74,9 @@ def test_pretty_window_str(days_unit, hours_unit):
     """
     Test pretty window utils.
     """
-    window = ttypes.Window(
-        length=7,
-        timeUnit=days_unit
-    )
+    window = ttypes.Window(length=7, timeUnit=days_unit)
     assert group_by.window_to_str_pretty(window) == "7 days"
-    window = ttypes.Window(
-        length=2,
-        timeUnit=hours_unit
-    )
+    window = ttypes.Window(length=2, timeUnit=hours_unit)
     assert group_by.window_to_str_pretty(window) == "2 hours"
 
 
@@ -108,7 +92,7 @@ def test_select():
     """
     Test select builder
     """
-    assert query.select('subject', event="event_expr") == {"subject": "subject", "event": "event_expr"}
+    assert query.select("subject", event="event_expr") == {"subject": "subject", "event": "event_expr"}
 
 
 def test_contains_windowed_aggregation(sum_op, min_op, days_unit):
@@ -117,16 +101,12 @@ def test_contains_windowed_aggregation(sum_op, min_op, days_unit):
     """
     assert not group_by.contains_windowed_aggregation([])
     aggregations = [
-        ttypes.Aggregation(inputColumn='event', operation=sum_op),
-        ttypes.Aggregation(inputColumn='event', operation=min_op),
+        ttypes.Aggregation(inputColumn="event", operation=sum_op),
+        ttypes.Aggregation(inputColumn="event", operation=min_op),
     ]
     assert not group_by.contains_windowed_aggregation(aggregations)
     aggregations.append(
-        ttypes.Aggregation(
-            inputColumn='event',
-            operation=sum_op,
-            windows=[ttypes.Window(length=7, timeUnit=days_unit)]
-        )
+        ttypes.Aggregation(inputColumn="event", operation=sum_op, windows=[ttypes.Window(length=7, timeUnit=days_unit)])
     )
     assert group_by.contains_windowed_aggregation(aggregations)
 
@@ -176,8 +156,7 @@ def test_validator_ok():
 
 
 def test_generic_collector():
-    aggregation = group_by.Aggregation(
-        input_column="test", operation=group_by.Operation.APPROX_PERCENTILE([0.4, 0.2]))
+    aggregation = group_by.Aggregation(input_column="test", operation=group_by.Operation.APPROX_PERCENTILE([0.4, 0.2]))
     assert aggregation.argMap == {"k": "128", "percentiles": "[0.4, 0.2]"}
 
 
@@ -185,21 +164,11 @@ def test_select_sanitization():
     gb = group_by.GroupBy(
         sources=[
             ttypes.EventSource(  # No selects are spcified
-                table="event_table1",
-                query=query.Query(
-                    selects=None,
-                    time_column="ts"
-                )
+                table="event_table1", query=query.Query(selects=None, time_column="ts")
             ),
             ttypes.EntitySource(  # Some selects are specified
-                snapshotTable="entity_table1",
-                query=query.Query(
-                    selects={
-                        "key1": "key1_sql",
-                        "event_id": "event_sql"
-                    }
-                )
-            )
+                snapshotTable="entity_table1", query=query.Query(selects={"key1": "key1_sql", "event_id": "event_sql"})
+            ),
         ],
         keys=["key1", "key2"],
         aggregations=group_by.Aggregations(
@@ -222,19 +191,20 @@ def test_snapshot_with_hour_aggregation():
                 ttypes.EntitySource(  # Some selects are specified
                     snapshotTable="entity_table1",
                     query=query.Query(
-                        selects={
-                            "key1": "key1_sql",
-                            "event_id": "event_sql"
-                        },
+                        selects={"key1": "key1_sql", "event_id": "event_sql"},
                         time_column="ts",
-                    )
+                    ),
                 )
             ],
             keys=["key1"],
             aggregations=group_by.Aggregations(
-                random=ttypes.Aggregation(inputColumn="event_id", operation=ttypes.Operation.SUM, windows=[
-                    ttypes.Window(1, ttypes.TimeUnit.HOURS),
-                ]),
+                random=ttypes.Aggregation(
+                    inputColumn="event_id",
+                    operation=ttypes.Operation.SUM,
+                    windows=[
+                        ttypes.Window(1, ttypes.TimeUnit.HOURS),
+                    ],
+                ),
             ),
             backfill_start_date="2021-01-04",
         )
@@ -242,17 +212,9 @@ def test_snapshot_with_hour_aggregation():
 
 def test_additional_metadata():
     gb = group_by.GroupBy(
-        sources=[
-            ttypes.EventSource(
-                table="event_table1",
-                query=query.Query(
-                    selects=None,
-                    time_column="ts"
-                )
-            )
-        ],
+        sources=[ttypes.EventSource(table="event_table1", query=query.Query(selects=None, time_column="ts"))],
         keys=["key1", "key2"],
         aggregations=[group_by.Aggregation(input_column="event_id", operation=ttypes.Operation.SUM)],
-        tags={"to_deprecate": True}
+        tags={"to_deprecate": True},
     )
-    assert json.loads(gb.metaData.customJson)['groupby_tags']['to_deprecate']
+    assert json.loads(gb.metaData.customJson)["groupby_tags"]["to_deprecate"]

--- a/api/py/test/test_join.py
+++ b/api/py/test/test_join.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +12,11 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.join import Join
-from ai.chronon.group_by import GroupBy
-from ai.chronon.api import ttypes as api
-
-import pytest
 import json
+
+from ai.chronon.api import ttypes as api
+from ai.chronon.group_by import GroupBy
+from ai.chronon.join import Join
 
 
 def event_source(table):
@@ -61,12 +59,14 @@ def test_deduped_dependencies():
     """
     join = Join(
         left=event_source("sample_namespace.sample_table"),
-        right_parts=[right_part(event_source("sample_namespace.another_table"))])
+        right_parts=[right_part(event_source("sample_namespace.another_table"))],
+    )
     assert len(join.metaData.dependencies) == 2
 
     join = Join(
         left=event_source("sample_namespace.sample_table"),
-        right_parts=[right_part(event_source("sample_namespace.sample_table"))])
+        right_parts=[right_part(event_source("sample_namespace.sample_table"))],
+    )
     assert len(join.metaData.dependencies) == 1
 
 
@@ -74,9 +74,9 @@ def test_additional_args_to_custom_json():
     join = Join(
         left=event_source("sample_namespace.sample_table"),
         right_parts=[right_part(event_source("sample_namespace.sample_table"))],
-        team_override="some_other_team_value"
+        team_override="some_other_team_value",
     )
-    assert json.loads(join.metaData.customJson)['team_override'] == "some_other_team_value"
+    assert json.loads(join.metaData.customJson)["team_override"] == "some_other_team_value"
 
 
 def test_dependencies_propagation():
@@ -89,20 +89,14 @@ def test_dependencies_propagation():
         sources=[event_source("table_2")],
         keys=["subject"],
         aggregations=[],
-        dependencies=["table_2/ds={{ ds }}/key=value"]
+        dependencies=["table_2/ds={{ ds }}/key=value"],
     )
-    join = Join(
-        left=event_source("left_1"),
-        right_parts=[api.JoinPart(gb1), api.JoinPart(gb2)]
-    )
+    join = Join(left=event_source("left_1"), right_parts=[api.JoinPart(gb1), api.JoinPart(gb2)])
 
-    actual = [
-        (json.loads(dep)["name"], json.loads(dep)["spec"])
-        for dep in join.metaData.dependencies
-    ]
+    actual = [(json.loads(dep)["name"], json.loads(dep)["spec"]) for dep in join.metaData.dependencies]
     expected = [
         ("wait_for_left_1_ds", "left_1/ds={{ ds }}"),
         ("wait_for_table_1_ds", "table_1/ds={{ ds }}"),
-        ("wait_for_table_2_ds_ds_key_value", "table_2/ds={{ ds }}/key=value")
+        ("wait_for_table_2_ds_ds_key_value", "table_2/ds={{ ds }}/key=value"),
     ]
     assert expected == actual

--- a/api/py/test/test_run.py
+++ b/api/py/test/test_run.py
@@ -69,18 +69,12 @@ def test_download_jar(monkeypatch, sleepless):
 
     monkeypatch.setattr(time, "sleep", sleepless)
     monkeypatch.setattr(run, "download_only_once", mock_cmd)
-    jar_path = run.download_jar(
-        "version", jar_type="uber", release_tag=None, spark_version="2.4.0"
-    )
+    jar_path = run.download_jar("version", jar_type="uber", release_tag=None, spark_version="2.4.0")
     assert jar_path == "/tmp/spark_uber_2.11-version-assembly.jar"
-    jar_path = run.download_jar(
-        "version", jar_type="uber", release_tag=None, spark_version="3.1.1"
-    )
+    jar_path = run.download_jar("version", jar_type="uber", release_tag=None, spark_version="3.1.1")
     assert jar_path == "/tmp/spark_uber_2.12-version-assembly.jar"
     with pytest.raises(Exception):
-        run.download_jar(
-            "version", jar_type="uber", release_tag=None, spark_version="2.1.0"
-        )
+        run.download_jar("version", jar_type="uber", release_tag=None, spark_version="2.1.0")
 
 
 def test_environment(teams_json, repo, parser, test_conf_location):
@@ -106,9 +100,7 @@ def test_environment(teams_json, repo, parser, test_conf_location):
 
     # If app_name can be passed from cli.
     reset_env(default_environment)
-    run.set_runtime_env(
-        parser.parse_args(args=["--mode", "metadata-export", "--app-name", "fake-name"])
-    )
+    run.set_runtime_env(parser.parse_args(args=["--mode", "metadata-export", "--app-name", "fake-name"]))
     assert os.environ["APP_NAME"] == "fake-name"
 
     # Check default backfill for a team sets parameters accordingly.
@@ -136,10 +128,7 @@ def test_environment(teams_json, repo, parser, test_conf_location):
     # from common env.
     assert os.environ["VERSION"] == "latest"
     # derived from args.
-    assert (
-        os.environ["APP_NAME"]
-        == "chronon_joins_backfill_production_sample_team.sample_online_join.v1"
-    )
+    assert os.environ["APP_NAME"] == "chronon_joins_backfill_production_sample_team.sample_online_join.v1"
     # from additional_args
     assert os.environ["CHRONON_CONFIG_ADDITIONAL_ARGS"] == "--step-days 14"
 
@@ -238,17 +227,13 @@ def test_environment(teams_json, repo, parser, test_conf_location):
 def test_property_default_update(repo, parser, test_conf_location):
     reset_env(DEFAULT_ENVIRONMENT.copy())
     assert "VERSION" not in os.environ
-    args, _ = parser.parse_known_args(
-        args=["--mode", "backfill", "--conf", test_conf_location, "--repo", repo]
-    )
+    args, _ = parser.parse_known_args(args=["--mode", "backfill", "--conf", test_conf_location, "--repo", repo])
     assert args.version is None
     run.set_runtime_env(args)
     assert "VERSION" in os.environ
     assert args.version is None
     run.set_defaults(parser)
-    reparsed, _ = parser.parse_known_args(
-        args=["--mode", "backfill", "--conf", test_conf_location, "--repo", repo]
-    )
+    reparsed, _ = parser.parse_known_args(args=["--mode", "backfill", "--conf", test_conf_location, "--repo", repo])
     assert reparsed.version is not None
 
 
@@ -256,9 +241,7 @@ def test_render_info_setting_update(repo, parser, test_conf_location):
     default_environment = DEFAULT_ENVIRONMENT.copy()
 
     run.set_defaults(parser)
-    args, _ = parser.parse_known_args(
-        args=["--mode", "info", "--conf", test_conf_location, "--repo", repo]
-    )
+    args, _ = parser.parse_known_args(args=["--mode", "info", "--conf", test_conf_location, "--repo", repo])
     run.set_defaults(parser)
     assert args.render_info == os.path.join(".", run.RENDER_INFO_DEFAULT_SCRIPT)
 
@@ -266,9 +249,7 @@ def test_render_info_setting_update(repo, parser, test_conf_location):
     run.set_runtime_env(args)
     os.environ["CHRONON_REPO_PATH"] = repo
     run.set_defaults(parser)
-    args, _ = parser.parse_known_args(
-        args=["--mode", "info", "--conf", test_conf_location, "--repo", repo]
-    )
+    args, _ = parser.parse_known_args(args=["--mode", "info", "--conf", test_conf_location, "--repo", repo])
     assert args.render_info == os.path.join(repo, run.RENDER_INFO_DEFAULT_SCRIPT)
 
     reset_env(default_environment)
@@ -301,9 +282,7 @@ def test_render_info(repo, parser, test_conf_location, monkeypatch):
     monkeypatch.setattr(run, "check_call", mock_check_call)
     monkeypatch.setattr(os.path, "exists", mock_exists)
     run.set_defaults(parser)
-    args, _ = parser.parse_known_args(
-        args=["--mode", "info", "--conf", test_conf_location, "--repo", repo]
-    )
+    args, _ = parser.parse_known_args(args=["--mode", "info", "--conf", test_conf_location, "--repo", repo])
 
     args.args = _
     runner = run.Runner(args, "some.jar")

--- a/api/py/test/test_teams.py
+++ b/api/py/test/test_teams.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.repo import teams
 import pytest
+from ai.chronon.repo import teams
 
 
 def test_existence(teams_json):

--- a/api/py/test/test_utils.py
+++ b/api/py/test/test_utils.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +13,11 @@
 #     limitations under the License.
 
 import os
-import json
-from ai.chronon.repo.serializer import json2thrift, file2thrift
-from ai.chronon import utils
+
 import ai.chronon.api.ttypes as api
 import pytest
+from ai.chronon import utils
+from ai.chronon.repo.serializer import file2thrift, json2thrift
 
 
 @pytest.fixture
@@ -28,6 +27,7 @@ def event_group_by():
     This is an event source, not streaming
     """
     from sample.group_bys.sample_team.sample_group_by_from_module import v1
+
     return v1
 
 
@@ -43,57 +43,65 @@ def event_source(event_group_by):
 @pytest.fixture
 def group_by_requiring_backfill():
     from sample.group_bys.sample_team.sample_group_by import require_backfill
-    #utils.__set_name(group_by_requiring_backfill, api.GroupBy, "group")
+
+    # utils.__set_name(group_by_requiring_backfill, api.GroupBy, "group")
     return require_backfill
 
 
 @pytest.fixture
 def online_group_by_requiring_streaming():
     from sample.group_bys.sample_team.entity_sample_group_by_from_module import v1
+
     return v1
 
 
 @pytest.fixture
 def basic_staging_query():
     from sample.staging_queries.sample_team.sample_staging_query import v1
+
     return v1
 
 
 @pytest.fixture
 def basic_join():
     from sample.joins.sample_team.sample_join import v1
+
     return v1
 
 
 @pytest.fixture
 def never_scheduled_join():
     from sample.joins.sample_team.sample_join import never
+
     return never
 
 
 @pytest.fixture
 def consistency_check_join():
     from sample.joins.sample_team.sample_join import consistency_check
+
     return consistency_check
 
 
 @pytest.fixture
 def no_log_flattener_join():
     from sample.joins.sample_team.sample_join import no_log_flattener
+
     return no_log_flattener
 
 
 @pytest.fixture
 def label_part_join():
     from sample.joins.sample_team.sample_label_join import v1
+
     return v1
 
 
 def test_edit_distance():
-    assert utils.edit_distance('test', 'test') == 0
-    assert utils.edit_distance('test', 'testy') > 0
+    assert utils.edit_distance("test", "test") == 0
+    assert utils.edit_distance("test", "testy") > 0
     assert utils.edit_distance("test", "testing") <= (
-            utils.edit_distance("test", "tester") + utils.edit_distance("tester", "testing")
+        utils.edit_distance("test", "tester") + utils.edit_distance("tester", "testing")
     )
 
 
@@ -112,10 +120,7 @@ def test_dedupe_in_order():
     assert utils.dedupe_in_order([2, 1, 3, 1, 3, 2]) == [2, 1, 3]
 
 
-def test_get_applicable_mode_for_group_bys(
-        group_by_requiring_backfill,
-        online_group_by_requiring_streaming
-):
+def test_get_applicable_mode_for_group_bys(group_by_requiring_backfill, online_group_by_requiring_streaming):
     modes = utils.get_applicable_modes(group_by_requiring_backfill)
     assert "backfill" in modes
     assert "upload" not in modes
@@ -132,11 +137,7 @@ def test_get_applicable_mode_for_staging_query(basic_staging_query):
 
 
 def test_get_applicable_mode_for_joins(
-        basic_join,
-        never_scheduled_join,
-        consistency_check_join,
-        no_log_flattener_join,
-        label_part_join
+    basic_join, never_scheduled_join, consistency_check_join, no_log_flattener_join, label_part_join
 ):
     modes = utils.get_applicable_modes(basic_join)
     assert "backfill" in modes
@@ -162,11 +163,8 @@ def test_get_applicable_mode_for_joins(
     assert "label-join" in modes
 
 
-def test_get_related_table_names_for_group_bys(
-        group_by_requiring_backfill,
-        online_group_by_requiring_streaming
-):
-    with open('test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1') as conf_file:
+def test_get_related_table_names_for_group_bys(group_by_requiring_backfill, online_group_by_requiring_streaming):
+    with open("test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1") as conf_file:
         json = conf_file.read()
         group_by = json2thrift(json, api.GroupBy)
         tables = utils.get_related_table_names(group_by)
@@ -174,7 +172,7 @@ def test_get_related_table_names_for_group_bys(
 
 
 def test_get_related_table_names_for_group_bys():
-    with open('test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1') as conf_file:
+    with open("test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1") as conf_file:
         json = conf_file.read()
         group_by = json2thrift(json, api.GroupBy)
         tables = utils.get_related_table_names(group_by)
@@ -190,7 +188,7 @@ def test_get_related_table_names_for_group_bys():
 
 
 def test_get_related_table_names_for_simple_joins():
-    with open('test/sample/production/joins/sample_team/sample_join.v1') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_join.v1") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -208,7 +206,7 @@ def test_get_related_table_names_for_simple_joins():
 
 
 def test_get_related_table_names_for_label_joins():
-    with open('test/sample/production/joins/sample_team/sample_label_join.v1') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_label_join.v1") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -227,7 +225,7 @@ def test_get_related_table_names_for_label_joins():
 
 
 def test_get_related_table_names_for_consistency_joins():
-    with open('test/sample/production/joins/sample_team/sample_join.consistency_check') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_join.consistency_check") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -246,7 +244,7 @@ def test_get_related_table_names_for_consistency_joins():
 
 
 def test_get_related_table_names_for_bootstrap_joins():
-    with open('test/sample/production/joins/sample_team/sample_join_bootstrap.v1') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_join_bootstrap.v1") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -265,7 +263,8 @@ def test_get_related_table_names_for_bootstrap_joins():
 
 
 @pytest.mark.parametrize(
-    "materialized_group_by,table_name", [
+    "materialized_group_by,table_name",
+    [
         ("entity_sample_group_by_from_module.v1", "chronon_db.sample_team_entity_sample_group_by_from_module_v1"),
         ("event_sample_group_by.v1", "sample_namespace.sample_team_event_sample_group_by_v1"),
         ("group_by_with_kwargs.v1", "chronon_db.sample_team_group_by_with_kwargs_v1"),
@@ -278,9 +277,12 @@ def test_group_by_table_names(repo, materialized_group_by, table_name):
 
 
 @pytest.mark.parametrize(
-    "materialized_join,table_name", [
-        ("sample_chaining_join.v1",
-         "chronon_db.sample_team_sample_chaining_join_v1_sample_team_sample_chaining_group_by"),
+    "materialized_join,table_name",
+    [
+        (
+            "sample_chaining_join.v1",
+            "chronon_db.sample_team_sample_chaining_join_v1_sample_team_sample_chaining_group_by",
+        ),
         ("sample_join.v1", "sample_namespace.sample_team_sample_join_v1_sample_team_sample_group_by_v1"),
     ],
 )

--- a/api/py/test/test_validator.py
+++ b/api/py/test/test_validator.py
@@ -17,38 +17,40 @@ Forcing validator to fail some tests
 #     limitations under the License.
 
 import pytest
-
 from ai.chronon.repo import validator
 
 
 @pytest.fixture
 def zvalidator():
-    return validator.ChrononRepoValidator(
-        chronon_root_path='test/sample',
-        output_root='production'
-    )
+    return validator.ChrononRepoValidator(chronon_root_path="test/sample", output_root="production")
 
 
 @pytest.fixture
 def valid_online_join(zvalidator):
-    return sorted([
-        join for join in zvalidator.old_joins if join.metaData.online is True
-    ], key=lambda x: x.metaData.name)[0]
+    return sorted(
+        [join for join in zvalidator.old_joins if join.metaData.online is True], key=lambda x: x.metaData.name
+    )[0]
 
 
 @pytest.fixture
 def valid_online_group_by(valid_online_join):
-    return sorted([
-        jp.groupBy for jp in valid_online_join.joinParts if jp.groupBy.metaData.online is True
-    ], key=lambda x: x.metaData.name)[0]
+    return sorted(
+        [jp.groupBy for jp in valid_online_join.joinParts if jp.groupBy.metaData.online is True],
+        key=lambda x: x.metaData.name,
+    )[0]
 
 
 @pytest.fixture
 def valid_events_group_by(zvalidator):
-    return sorted([
-        jp.groupBy for join in zvalidator.old_joins for jp in join.joinParts
-        if any([src.events is not None for src in jp.groupBy.sources])
-    ], key=lambda x: x.metaData.name)[0]
+    return sorted(
+        [
+            jp.groupBy
+            for join in zvalidator.old_joins
+            for jp in join.joinParts
+            if any([src.events is not None for src in jp.groupBy.sources])
+        ],
+        key=lambda x: x.metaData.name,
+    )[0]
 
 
 def test_validate_group_by_online(zvalidator, valid_online_group_by):
@@ -114,24 +116,32 @@ def test_validate_cumulative_source_no_timequery(zvalidator, valid_events_group_
 
 
 def test_validate_group_by_with_incorrect_derivations(zvalidator):
-    from sample.group_bys.sample_team.sample_group_by_with_incorrect_derivations import v1
+    from sample.group_bys.sample_team.sample_group_by_with_incorrect_derivations import (
+        v1,
+    )
+
     errors = zvalidator._validate_group_by(v1)
-    assert(len(errors) > 0)
+    assert len(errors) > 0
 
 
 def test_validate_group_by_with_derivations(zvalidator):
     from sample.group_bys.sample_team.sample_group_by_with_derivations import v1
+
     errors = zvalidator._validate_group_by(v1)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_validate_join_with_derivations(zvalidator):
     from sample.joins.sample_team.sample_join_derivation import v1
+
     errors = zvalidator._validate_join(v1)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_validate_join_with_derivations_on_external_parts(zvalidator):
-    from sample.joins.sample_team.sample_join_with_derivations_on_external_parts import v1
+    from sample.joins.sample_team.sample_join_with_derivations_on_external_parts import (
+        v1,
+    )
+
     errors = zvalidator._validate_join(v1)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/docs/examples/main.py
+++ b/docs/examples/main.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,57 +13,57 @@
 #     limitations under the License.
 
 from ai.chronon import query
+from ai.chronon.api.ttypes import (
+    Aggregation,
+    EntitySource,
+    EventSource,
+    JoinPart,
+    Operation,
+)
 from ai.chronon.group_by import GroupBy, TimeUnit, Window
-from ai.chronon.api.ttypes import EventSource, EntitySource, Aggregation, Operation, JoinPart
-
 from ai.chronon.join import Join
 
 ratings_features = GroupBy(
-      sources=[
-          EntitySource(
-              snapshotTable="item_info.ratings_snapshots_table",
-              mutationsTable="item_info.ratings_mutations_table",
-              mutationsTopic="ratings_mutations_topic",
-              query=query.Query(
-                  selects={
-                      "rating": "CAST(rating as DOUBLE)",
-                  }))
-      ],
-      keys=["item"],
-      aggregations=[Aggregation(
-        operation=Operation.AVERAGE,
-        windows=[Window(length=90, timeUnit=TimeUnit.DAYS)]),
-      ])
+    sources=[
+        EntitySource(
+            snapshotTable="item_info.ratings_snapshots_table",
+            mutationsTable="item_info.ratings_mutations_table",
+            mutationsTopic="ratings_mutations_topic",
+            query=query.Query(
+                selects={
+                    "rating": "CAST(rating as DOUBLE)",
+                }
+            ),
+        )
+    ],
+    keys=["item"],
+    aggregations=[
+        Aggregation(operation=Operation.AVERAGE, windows=[Window(length=90, timeUnit=TimeUnit.DAYS)]),
+    ],
+)
 
 
 view_features = GroupBy(
-      sources=[
-          EventSource(
-              table="user_activity.user_views_table",
-              topic="user_views_stream",
-              query=query.Query(
-                  selects={
-                      "view": "if(context['activity_type'] = 'item_view', 1 , 0)",
-                  },
-                  wheres=["user != null"]))
-      ],
-      keys=["user", "item"],
-      aggregations=[
-          Aggregation(
-            operation=Operation.COUNT,
-            windows=[Window(length=5, timeUnit=TimeUnit.HOURS)]),
-      ])
+    sources=[
+        EventSource(
+            table="user_activity.user_views_table",
+            topic="user_views_stream",
+            query=query.Query(
+                selects={
+                    "view": "if(context['activity_type'] = 'item_view', 1 , 0)",
+                },
+                wheres=["user != null"],
+            ),
+        )
+    ],
+    keys=["user", "item"],
+    aggregations=[
+        Aggregation(operation=Operation.COUNT, windows=[Window(length=5, timeUnit=TimeUnit.HOURS)]),
+    ],
+)
 
 item_rec_features = Join(
-    left=EventSource(
-        table="user_activity.view_purchases",
-        query=query.Query(
-            start_partition='2021-06-30'
-        )
-    ),
+    left=EventSource(table="user_activity.view_purchases", query=query.Query(start_partition="2021-06-30")),
     # keys are automatically mapped from left to right_parts
-    right_parts=[
-        JoinPart(groupBy=view_features),
-        JoinPart(groupBy=ratings_features)
-    ]
+    right_parts=[JoinPart(groupBy=view_features), JoinPart(groupBy=ratings_features)],
 )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,9 +90,7 @@ html_theme_options = {
     # "navbar_end": ["navbar-icon-links.html", "search-field.html"]
 }
 
-html_sidebars = {
-    "**": ["navbar-logo.html", "search-field.html", "sbt-sidebar-nav.html"]
-}
+html_sidebars = {"**": ["navbar-logo.html", "search-field.html", "sbt-sidebar-nav.html"]}
 html_title = "Chronon"
 html_static_path = ["_static"]
 html_css_files = ["chronon.css"]


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

- Users reported seeing the following errors when trying to setup locally for first time. 

```
teams=teams)
  File "/opt/homebrew/bin/explore.py", line 145, in build_entry
    (team, conf_module) = entry["name"][0].split(".", 1)
ValueError: not enough values to unpack (expected 2, got 1)
```

The problematic input was a string of the form
`my_long_group_by_name_without_periods`
instead of the expected
`team_namespace.my_group_by_name`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

- Unblock new users running through the first-time setup and `explore.py` commands. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

