### PR TITLE
fix: downgrade caffeine to 2.8.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -310,7 +310,7 @@ lazy val online = project
       "com.datadoghq" % "java-dogstatsd-client" % "2.7",
       "org.rogach" %% "scallop" % "4.0.1",
       "net.jodah" % "typetools" % "0.4.1",
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5"
     ),
     libraryDependencies ++= fromMatrix(scalaVersion.value, "spark-all", "scala-parallel-collections", "netty-buffer"),
     version := git.versionProperty.value
@@ -328,7 +328,7 @@ lazy val online_unshaded = (project in file("online"))
       "com.datadoghq" % "java-dogstatsd-client" % "2.7",
       "org.rogach" %% "scallop" % "4.0.1",
       "net.jodah" % "typetools" % "0.4.1",
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5"
     ),
     libraryDependencies ++= fromMatrix(scalaVersion.value,
                                        "jackson",


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
downgrade caffeine from 2.9.3. to 2.8.5 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

dependency conflict of an upstream library org.checkerframework:checker-qual 3.4.1 vs 3.19.0 used by airbnb

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@caiocamatta-stripe @yuli-han @pengyu-hou 
