### PR TITLE
Adding Timestamp Check to GroupBy Analyzer

### DIFF
--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -33,7 +33,7 @@ The analyzer will compute the following information by simply taking a Chronon c
 * Output schemas - to quickly validate the sql statements and understand the output schema.
 * Timestamp Validations for GroupBy configs
   * Confirms that timestamp columns are not all NULLs
-  * Confirms that timestamp columns are in epoch milliseconds in the range between 1970-01-01 and 2099-01-01
+  * Confirms that timestamp columns are in epoch milliseconds in the range between 1971-01-01 and 2099-01-01
 * Validations for JOIN config - to make sure the join conf is valid for backfill. Here is a list of items we validate:
   * Confirm Join keys are matching on the left and right side
   * Confirm you have access to all the tables involved in the join

--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -31,6 +31,9 @@ The analyzer will compute the following information by simply taking a Chronon c
 * A simple count of items by year - to sanity check the timestamps.
 * A row count - to give users a sense of how large the data is.
 * Output schemas - to quickly validate the sql statements and understand the output schema.
+* Timestamp Validations for GroupBy configs
+  * Confirms that timestamp columns are not all NULLs
+  * Confirms that timestamp columns are in epoch milliseconds in the range between 1970-01-01 and 2099-01-01
 * Validations for JOIN config - to make sure the join conf is valid for backfill. Here is a list of items we validate:
   * Confirm Join keys are matching on the left and right side
   * Confirm you have access to all the tables involved in the join

--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -49,7 +49,7 @@ run.py --mode=analyze --conf=production/joins/<path_to_conf_file> --enable-hitte
 
 Optional parameters:
 
-`--endable-hitter`: enable skewed data analysis - include the heavy hitter analysis in output, only output schema if not specified
+`--enable-hitter`: enable skewed data analysis - include the heavy hitter analysis in output, only output schema if not specified
 
 `--start-date` : Finds heavy hitters & time-distributions for a specified start date. Default 3 days prior to "today"
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -187,8 +187,7 @@ class Analyzer(tableUtils: TableUtils,
                      prefix: String = "",
                      includeOutputTableName: Boolean = false,
                      enableHitter: Boolean = false,
-                     validationAssert: Boolean = false
-                    ): (Array[AggregationMetadata], Map[String, DataType]) = {
+                     validationAssert: Boolean = false): (Array[AggregationMetadata], Map[String, DataType]) = {
     groupByConf.setups.foreach(tableUtils.sql)
     val groupBy = GroupBy.from(groupByConf, range, tableUtils, computeDependency = enableHitter, finalize = true)
     val name = "group_by/" + prefix + groupByConf.metaData.name
@@ -244,7 +243,8 @@ class Analyzer(tableUtils: TableUtils,
     }
 
     if (validationAssert) {
-      assert(checkTs == "Acceptable Timestamp Input", "[ERROR]: GroupBy validation failed. Please check that source has valid timestamps.")
+      assert(checkTs == "Acceptable Timestamp Input",
+             "[ERROR]: GroupBy validation failed. Please check that source has valid timestamps.")
     }
 
     val aggMetadata = if (groupByConf.aggregations != null) {
@@ -504,14 +504,16 @@ class Analyzer(tableUtils: TableUtils,
   def runTimestampCheck(df: DataFrame, sampleFraction: Double = 0.1): String = {
 
     // if timestamp column is present, sample if the timestamp values are not null
-    val checkTs = if ( df.schema.fieldNames.contains(Constants.TimeColumn) ) {
+    val checkTs = if (df.schema.fieldNames.contains(Constants.TimeColumn)) {
       val sumNotNulls = df
         .sample(sampleFraction)
         .agg(
           sum(when(col(Constants.TimeColumn).isNull, lit(0)).otherwise(lit(1))).cast(StringType).as("notNullCount")
         )
         .select(col("notNullCount"))
-        .rdd.collect()(0)(0).toString
+        .rdd
+        .collect()(0)(0)
+        .toString
       sumNotNulls
     } else {
       "No Ts Column"
@@ -519,7 +521,7 @@ class Analyzer(tableUtils: TableUtils,
 
     val tsStatus = checkTs match {
       case "0" => "Only Null Values" // this will trigger an assertion error
-      case _ => "Acceptable Timestamp Input"
+      case _   => "Acceptable Timestamp Input"
     }
 
     tsStatus

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -244,7 +244,7 @@ class Analyzer(tableUtils: TableUtils,
     }
 
     if (validationAssert) {
-      assert(checkTs == "Valid Timestamp Input", "ERROR: GroupBy validation failed. Please check that source has valid timestamps.")
+      assert(checkTs == "Acceptable Timestamp Input", "[ERROR]: GroupBy validation failed. Please check that source has valid timestamps.")
     }
 
     val aggMetadata = if (groupByConf.aggregations != null) {
@@ -517,12 +517,12 @@ class Analyzer(tableUtils: TableUtils,
       "No Ts Column"
     }
 
-    val tsStat = checkTs match {
-      case "0" => "Only Null Values"
-      case _ => "Valid Timestamp Input"
+    val tsStatus = checkTs match {
+      case "0" => "Only Null Values" // this will trigger an assertion error
+      case _ => "Acceptable Timestamp Input"
     }
 
-    tsStat
+    tsStatus
   }
 
   def run(): Unit =

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -195,10 +195,20 @@ class Analyzer(tableUtils: TableUtils,
     val timestampChecks = runTimestampChecks(groupBy.inputDf)
     if (timestampChecks("TsColumn") == "Has Ts Column") {
       // do timestamp checks
-      assert(timestampChecks("NullCheck") != "0",
-             "[ERROR]: GroupBy validation failed. Please check that source has non-null timestamps.")
-      assert(timestampChecks("BadRangeCheck") == "0",
-             "[ERROR]: GroupBy validation failed. Please check that source has valid epoch millisecond timestamps.")
+      assert(
+        timestampChecks("NullCheck") != "0",
+        s"""[ERROR]: GroupBy validation failed.
+                 | Please check that source has non-null timestamps.
+                 | check notNullCount: ${timestampChecks("NullCheck")}
+                 | """.stripMargin
+      )
+      assert(
+        timestampChecks("BadRangeCheck") == "0",
+        s"""[ERROR]: GroupBy validation failed.
+                 | Please check that source has valid epoch millisecond timestamps.
+                 | badRangeCount: ${timestampChecks("BadRangeCheck")}
+                 | """.stripMargin
+      )
 
       logger.info(s"""ANALYSIS TIMESTAMP completed for group_by/${name}.
            |check ts column: ${timestampChecks("TsColumn")}

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -505,14 +505,14 @@ class Analyzer(tableUtils: TableUtils,
 
     // if timestamp column is present, sample if the timestamp values are not null
     val checkTs = if ( df.schema.fieldNames.contains(Constants.TimeColumn) ) {
-      val sumNulls = df
+      val sumNotNulls = df
         .sample(sampleFraction)
         .agg(
           sum(when(col(Constants.TimeColumn).isNull, lit(0)).otherwise(lit(1))).cast(StringType).as("notNullCount")
         )
         .select(col("notNullCount"))
         .rdd.collect()(0)(0).toString
-      sumNulls
+      sumNotNulls
     } else {
       "No Ts Column"
     }

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -527,7 +527,8 @@ class Analyzer(tableUtils: TableUtils,
     val hasTimestamp = df.schema.fieldNames.contains(Constants.TimeColumn)
     val mapTimestampChecks = if (hasTimestamp) {
       // set max sample to 1000 rows if larger input is provided
-      val sampleN = if (sampleNumber > 1000) {1000} else {sampleNumber}
+      val sampleN = if (sampleNumber > 1000) { 1000 }
+      else { sampleNumber }
       dataFrameToMap(
         df.limit(sampleN)
           .agg(

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -537,7 +537,7 @@ class Analyzer(tableUtils: TableUtils,
               .cast(StringType)
               .as("notNullCount"),
             // assumes that we have valid unix milliseconds between the date range of
-            // 1971-01-01 00:00:00 (0L) to 2099-12-31 23:59:59 (4102473599999L)
+            // 1971-01-01 00:00:00 (31536000000L) to 2099-12-31 23:59:59 (4102473599999L)
             // will return 0 if all values are within the range
             sum(when(col(Constants.TimeColumn).between(31536000000L, 4102473599999L), lit(0)).otherwise(lit(1)))
               .cast(StringType)

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -522,12 +522,14 @@ class Analyzer(tableUtils: TableUtils,
 
   // For groupBys validate if the timestamp provided produces some values
   // if all values are null this should be flagged as an error
-  def runTimestampChecks(df: DataFrame, sampleFraction: Double = 0.1): Map[String, String] = {
+  def runTimestampChecks(df: DataFrame, sampleNumber: Int = 1000): Map[String, String] = {
 
     val hasTimestamp = df.schema.fieldNames.contains(Constants.TimeColumn)
     val mapTimestampChecks = if (hasTimestamp) {
+      // set max sample to 1000 rows if larger input is provided
+      val sampleN = if (sampleNumber > 1000) {1000} else {sampleNumber}
       dataFrameToMap(
-        df.sample(sampleFraction)
+        df.limit(sampleN)
           .agg(
             // will return 0 if all values are null
             sum(when(col(Constants.TimeColumn).isNull, lit(0)).otherwise(lit(1)))
@@ -547,7 +549,6 @@ class Analyzer(tableUtils: TableUtils,
         "noTsColumn" -> "No Timestamp Column"
       )
     }
-
     mapTimestampChecks
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -537,9 +537,9 @@ class Analyzer(tableUtils: TableUtils,
               .cast(StringType)
               .as("notNullCount"),
             // assumes that we have valid unix milliseconds between the date range of
-            // 1970-01-01 00:00:00 (0L) to 2099-12-31 23:59:59 (4102473599999L)
+            // 1971-01-01 00:00:00 (0L) to 2099-12-31 23:59:59 (4102473599999L)
             // will return 0 if all values are within the range
-            sum(when(col(Constants.TimeColumn).between(0L, 4102473599999L), lit(0)).otherwise(lit(1)))
+            sum(when(col(Constants.TimeColumn).between(31536000000L, 4102473599999L), lit(0)).otherwise(lit(1)))
               .cast(StringType)
               .as("badRangeCount")
           )

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -221,25 +221,24 @@ class AnalyzerTest {
     analyzer.analyzeJoin(joinConf, validationAssert = true)
   }
 
-  @Test(expected = classOf[java.lang.AssertionError])
-  def testGroupByAnalyzerValidationTimestampCheck(): Unit = {
-
-    // left side
-    val tableGroupBy = getViewsGroupBy("group_by_analyzer_test.test_1", Operation.SUM, source = getTestGBSourceWithTs())
-
-    val itemQueries = List(Column("item", api.StringType, 100), Column("guest", api.StringType, 100))
-    val itemQueriesTable = s"$namespace.test_table"
-    DataFrameGen
-      .events(spark, itemQueries, 500, partitions = 100)
-      .save(itemQueriesTable)
-
-    val start = tableUtils.partitionSpec.minus(today, new Window(10, TimeUnit.DAYS))
-
-    //run analyzer and validate data availability
-    val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
-    analyzer.analyzeGroupBy(tableGroupBy, enableHitter = true, validationAssert = true)
-
-  }
+//  def testGroupByAnalyzerValidationTimestampCheck(): Unit = {
+//
+//    // left side
+//    val tableGroupBy = getViewsGroupBy("group_by_analyzer_test.test_1", Operation.SUM, source = getTestGBSourceWithTs())
+//
+//    val itemQueries = List(Column("item", api.StringType, 100), Column("guest", api.StringType, 100))
+//    val itemQueriesTable = s"$namespace.test_table"
+//    DataFrameGen
+//      .events(spark, itemQueries, 500, partitions = 100)
+//      .save(itemQueriesTable)
+//
+//    val start = tableUtils.partitionSpec.minus(today, new Window(10, TimeUnit.DAYS))
+//
+//    //run analyzer and validate data availability
+//    val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
+//    analyzer.analyzeGroupBy(tableGroupBy, enableHitter = true, validationAssert = true)
+//
+//  }
 
 
   def getTestGBSource(): api.Source = {

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -221,24 +221,25 @@ class AnalyzerTest {
     analyzer.analyzeJoin(joinConf, validationAssert = true)
   }
 
-//  def testGroupByAnalyzerValidationTimestampCheck(): Unit = {
-//
-//    // left side
-//    val tableGroupBy = getViewsGroupBy("group_by_analyzer_test.test_1", Operation.SUM, source = getTestGBSourceWithTs())
-//
-//    val itemQueries = List(Column("item", api.StringType, 100), Column("guest", api.StringType, 100))
-//    val itemQueriesTable = s"$namespace.test_table"
-//    DataFrameGen
-//      .events(spark, itemQueries, 500, partitions = 100)
-//      .save(itemQueriesTable)
-//
-//    val start = tableUtils.partitionSpec.minus(today, new Window(10, TimeUnit.DAYS))
-//
-//    //run analyzer and validate data availability
-//    val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
-//    analyzer.analyzeGroupBy(tableGroupBy, enableHitter = true, validationAssert = true)
-//
-//  }
+  @Test
+  def testGroupByAnalyzerValidationTimestampCheck(): Unit = {
+
+    // left side
+    val tableGroupBy = getViewsGroupBy("group_by_analyzer_test.test_1", Operation.SUM, source = getTestGBSourceWithTs())
+
+    val itemQueries = List(Column("item", api.StringType, 100), Column("guest", api.StringType, 100))
+    val itemQueriesTable = s"$namespace.test_table"
+    DataFrameGen
+      .events(spark, itemQueries, 500, partitions = 100)
+      .save(itemQueriesTable)
+
+    val start = tableUtils.partitionSpec.minus(today, new Window(10, TimeUnit.DAYS))
+
+    //run analyzer and validate data availability
+    val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
+    analyzer.analyzeGroupBy(tableGroupBy, enableHitter = true, validationAssert = true)
+
+  }
 
 
   def getTestGBSource(): api.Source = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- This PR adds checks on timestamps in a GroupBy source 
    1. If it contains all contains NULLs in the timestamp column -> fail
    2. If it contains any timestamps out of epoch miillsec range (1971 - 2099)  -> fail
        (31536000000L (which is milliseconds of 1971-01-01 00:00:00 UTC) to 
         2099-12-31 23:59:59 (4102473599999L)
- The Analyzer class' method `analyzeGroupBy` will run the above checks all the time. 
- Checks will only run when `ts` column is provided. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- For temporal GroupBys if an incorrect timestamp field is provided (for e.g. UNIX_TIMESTAMP(ts_start, 'yyyy-MM-dd') -> NULL), this option will ensure that we catch such cases. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

Integration test with `CAST(NULL AS BIGINT)` for timestamp field
```
[2024-07-27 02:01:33] {Analyzer:193} - Running GroupBy analysis for group_by/airbnb_org.response_configs.invitations_by_referral.v3 ...
Exception in thread "main" java.lang.AssertionError: assertion failed: [ERROR]: GroupBy validation failed.
 Please check that source has non-null timestamps.
 check notNullCount: 0
 ```
 
 Integration test with `UNIX_TIMESTAMP(updated_at, 'yyyy-MM-dd HH:mm:ss.SSS') * 1000000` for timestamp field 
 ```
 [2024-07-27 02:05:25] {Analyzer:193} - Running GroupBy analysis for group_by/airbnb_org.response_configs.invitations_by_referral.v3 ...
Exception in thread "main" java.lang.AssertionError: assertion failed: [ERROR]: GroupBy validation failed.
 Please check that source has valid epoch millisecond timestamps.
 badRangeCount: 127
 ```

## Checklist
- [ ] Documentation update

## Reviewers

