### PR TITLE
fix: bug in new flow mode with bootstrap & derivation

### DIFF
--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/FrequentItemsTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/FrequentItemsTest.scala
@@ -22,11 +22,13 @@ class FrequentItemsTest extends TestCase {
 
     val result = items.finalize(ir)
 
-    assertEquals(toHashMap(Map(
-      "4" -> 4,
-      "3" -> 3,
-      "2" -> 2
-    )), result)
+    assertEquals(toHashMap(
+                   Map(
+                     "4" -> 4,
+                     "3" -> 3,
+                     "2" -> 2
+                   )),
+                 result)
   }
 
   def testLessItemsThanSize(): Unit = {
@@ -42,11 +44,13 @@ class FrequentItemsTest extends TestCase {
 
     val result = items.finalize(ir)
 
-    assertEquals(toHashMap(Map(
-      "3" -> 3L,
-      "2" -> 2L,
-      "1" -> 1L
-    )), result)
+    assertEquals(toHashMap(
+                   Map(
+                     "3" -> 3L,
+                     "2" -> 2L,
+                     "1" -> 1L
+                   )),
+                 result)
   }
 
   def testZeroSize(): Unit = {
@@ -115,23 +119,25 @@ class FrequentItemsTest extends TestCase {
     assertEquals(expectedStringValues, actualStringValues)
   }
 
-   def testBulkMerge(): Unit = {
-     val sketch = new FrequentItems[String](3)
+  def testBulkMerge(): Unit = {
+    val sketch = new FrequentItems[String](3)
 
-     val irs = Seq(
-       toSketch(Map("3" -> 3)),
-       toSketch(Map("2" -> 2)),
-       toSketch(Map("1" -> 1)),
-     ).map(i => i._2).iterator
+    val irs = Seq(
+      toSketch(Map("3" -> 3)),
+      toSketch(Map("2" -> 2)),
+      toSketch(Map("1" -> 1))
+    ).map(i => i._2).iterator
 
-     val ir = sketch.bulkMerge(irs)
+    val ir = sketch.bulkMerge(irs)
 
-     assertEquals(toHashMap(Map(
-       "3" -> 3,
-       "2" -> 2,
-       "1" -> 1
-     )), sketch.finalize(ir))
-   }
+    assertEquals(toHashMap(
+                   Map(
+                     "3" -> 3,
+                     "2" -> 2,
+                     "1" -> 1
+                   )),
+                 sketch.finalize(ir))
+  }
 
   private def toSketch[T: FrequentItemsFriendly](counts: Map[T, Int]): (FrequentItems[T], ItemsSketchIR[T]) = {
     val sketch = new FrequentItems[T](4)

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -122,7 +122,9 @@ object BootstrapInfo {
       .map(schema => SparkConversions.toChrononSchema(schema))
       .map(_.map(field => StructField(field._1, field._2)))
       .getOrElse(Array.empty[StructField])
-    val baseFields = joinParts.flatMap(_.valueSchema) ++ externalParts.flatMap(_.valueSchema) ++ leftFields
+    val baseFieldsWithoutLeft = joinParts.flatMap(_.valueSchema) ++ externalParts.flatMap(_.valueSchema)
+    val baseFields =
+      baseFieldsWithoutLeft ++ leftFields.filterNot(lf => baseFieldsWithoutLeft.exists(bf => bf.name == lf.name))
     val sparkSchema = StructType(SparkConversions.fromChrononSchema(api.StructType("", baseFields.toArray)))
 
     val baseDf = tableUtils.sparkSession.createDataFrame(

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -61,8 +61,8 @@ class AnalyzerTest {
       externalSource = Builders.ContextualSource(
         fields = Array(
           StructField("reservation", StringType),
-          StructField("rule_name", StringType),
-        ),
+          StructField("rule_name", StringType)
+        )
       )
     )
 

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -342,9 +342,10 @@ class GroupByTest {
 
     val columns = aggregationsMetadata.map(a => a.name -> a.columnType).toMap
     assertEquals(Map(
-      "time_spent_ms" -> LongType,
-      "price" -> DoubleType
-    ), columns)
+                   "time_spent_ms" -> LongType,
+                   "price" -> DoubleType
+                 ),
+                 columns)
   }
 
   // test that OrderByLimit and OrderByLimitTimed serialization works well with Spark's data type
@@ -414,8 +415,8 @@ class GroupByTest {
     tableUtils.createDatabase(namespace)
     DataFrameGen.events(spark, sourceSchema, count = 1000, partitions = 200).save(sourceTable)
     val source = Builders.Source.events(
-      query =
-        Builders.Query(selects = Builders.Selects("ts", "item", "time_spent_ms", "price"), startPartition = startPartition),
+      query = Builders.Query(selects = Builders.Selects("ts", "item", "time_spent_ms", "price"),
+                             startPartition = startPartition),
       table = sourceTable
     )
     (source, endPartition)
@@ -647,13 +648,13 @@ class GroupByTest {
           new Window(15, TimeUnit.DAYS),
           new Window(60, TimeUnit.DAYS)
         )
-      ),
+      )
     )
     backfill(name = "unit_test_group_by_descriptive_stats",
-      source = source,
-      endPartition = endPartition,
-      namespace = namespace,
-      tableUtils = tableUtils,
-      additionalAgg = aggs)
+             source = source,
+             endPartition = endPartition,
+             namespace = namespace,
+             tableUtils = tableUtils,
+             additionalAgg = aggs)
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinFlowTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinFlowTest.scala
@@ -49,7 +49,7 @@ class JoinFlowTest {
       .where(col("user").isNotNull)
       .save(transactionsTable)
 
-    val joinPart = Builders.JoinPart(groupBy = Builders.GroupBy(
+    val joinPart: JoinPart = Builders.JoinPart(groupBy = Builders.GroupBy(
       keyColumns = Seq("user"),
       sources = Seq(
         Builders.Source.events(

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinFlowTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinFlowTest.scala
@@ -1,0 +1,123 @@
+package ai.chronon.spark.test;
+
+import ai.chronon.aggregator.test.Column
+import ai.chronon.api
+import ai.chronon.api.Extensions._
+import ai.chronon.api._
+import ai.chronon.spark.Extensions._
+import ai.chronon.spark.{Join, _}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import org.junit.Assert._
+import org.junit.Test
+
+class JoinFlowTest {
+
+  val spark: SparkSession = SparkSessionBuilder.build("JoinFlowTest", local = true)
+  private val tableUtils = TableUtils(spark)
+
+  private val namespace = "test_namespace_joinflowtest"
+  tableUtils.createDatabase(namespace)
+
+  @Test
+  def testBootstrapAndDerivation(): Unit = {
+    // in JoinBackfill Flow mode, left, rights and final steps are triggered by separate Driver mode
+
+    val prefix = "test_bootstrap_and_derivation"
+
+    // left part
+    val querySchema = Seq(Column("user", api.LongType, 100))
+    val queryTable = s"$namespace.${prefix}_left_table"
+    DataFrameGen
+      .events(spark, querySchema, 200, partitions = 5)
+      .where(col("user").isNotNull)
+      .dropDuplicates("user")
+      .save(queryTable)
+    val querySource = Builders.Source.events(
+      table = queryTable,
+      query = Builders.Query(Builders.Selects("user"), timeColumn = "ts")
+    )
+
+    // right part
+    val transactionSchema = Seq(
+      Column("user", LongType, 100),
+      Column("amount", LongType, 1000)
+    )
+    val transactionsTable = s"$namespace.${prefix}_transactions"
+    DataFrameGen
+      .events(spark, transactionSchema, 1200, partitions = 30)
+      .where(col("user").isNotNull)
+      .save(transactionsTable)
+
+    val joinPart = Builders.JoinPart(groupBy = Builders.GroupBy(
+      keyColumns = Seq("user"),
+      sources = Seq(
+        Builders.Source.events(
+          query = Builders.Query(
+            selects = Builders.Selects("amount"),
+            timeColumn = "ts"
+          ),
+          table = transactionsTable
+        )),
+      aggregations = Seq(
+        Builders.Aggregation(operation = Operation.SUM,
+                             inputColumn = "amount",
+                             windows = Seq(new Window(7, TimeUnit.DAYS), new Window(14, TimeUnit.DAYS)))),
+      accuracy = Accuracy.SNAPSHOT,
+      metaData = Builders.MetaData(name = s"join_test.${prefix}_txn", namespace = namespace, team = "chronon")
+    ))
+
+    // bootstrap part
+    val bootstrapSourceTable = s"$namespace.${prefix}_bootstrap_source"
+    spark
+      .table(queryTable)
+      .sample(0.5)
+      .withColumn(s"${joinPart.fullPrefix}_amount_sum_7d", lit(0).cast("long"))
+      .withColumn(s"${joinPart.fullPrefix}_amount_sum_14d", lit(0).cast("long"))
+      .save(bootstrapSourceTable)
+    val bootstrapPart = Builders.BootstrapPart(
+      table = bootstrapSourceTable,
+      keyColumns = Seq("user"),
+      query = Builders.Query(
+        Builders.Selects("user", s"${joinPart.fullPrefix}_amount_sum_7d", s"${joinPart.fullPrefix}_amount_sum_14d"))
+    )
+
+    // derivations
+    val derivations = Seq(
+      Builders.Derivation(
+        name = s"${joinPart.fullPrefix}_amount_sum_7d",
+        expression = s"COALESCE(${joinPart.fullPrefix}_amount_sum_7d, 0)"
+      ),
+      Builders.Derivation(
+        name = s"${joinPart.fullPrefix}_amount_sum_14d",
+        expression = s"COALESCE(${joinPart.fullPrefix}_amount_sum_14d, 0)"
+      )
+    )
+
+    // join
+    val join = Builders.Join(
+      left = querySource,
+      joinParts = Seq(joinPart),
+      bootstrapParts = Seq(bootstrapPart),
+      rowIds = Seq("user"),
+      derivations = derivations,
+      metaData = Builders.MetaData(name = s"unit_test.${prefix}_join", namespace = namespace, team = "chronon")
+    )
+
+    val endDs = tableUtils.partitions(queryTable).max
+    val joinJob = new Join(join, endDs, tableUtils)
+
+    // compute left
+    joinJob.computeLeft()
+    assertTrue(tableUtils.tableExists(join.metaData.bootstrapTable))
+
+    // compute right
+    val joinPartJob = new Join(join, endDs, tableUtils, selectedJoinParts = Some(List(joinPart.fullPrefix)))
+    joinPartJob.computeJoinOpt(useBootstrapForLeft = true)
+    assertTrue(tableUtils.tableExists(join.partOutputTable(joinPart)))
+
+    // compute final
+    joinJob.computeFinal()
+    assertTrue(tableUtils.tableExists(join.metaData.outputTable))
+  }
+}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

In join_part mode we overwrite join.left with bootstrap table before proceeding to the join_part backfill. However, bootstrap table and left table are NOT expected to have the same schema where there is an actual bootstrap_part in the join. The bootstrap table is expected to contain the joined result between left and various bootstrap_parts. 

The current code uses bootstrap_table's schema as left_schema when calculating BootstrapInfo, causing an issue in later logic. The new logic fixes it to restore to using left_table's schema as left_schema. 

We also add a safety check within BootstrapInfo.from for valid cases where left columns and base columns may overlap. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers


@donghanz @pengyu-hou @yuli-han 