### PR TITLE
fix: owningTeam is null when team_override is not set

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -143,7 +143,7 @@ object Extensions {
     }
 
     def owningTeam: String = {
-      val teamOverride = Try(customJsonLookUp(Constants.TeamOverride).asInstanceOf[String]).toOption
+      val teamOverride = Option(Try(customJsonLookUp(Constants.TeamOverride).asInstanceOf[String]).getOrElse(null))
       teamOverride.getOrElse(metaData.team)
     }
   }

--- a/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
@@ -54,6 +54,22 @@ class ExtensionsTest {
       metadata.team
     )
 
+    val metadata2 =
+      Builders.MetaData(
+        customJson = "{\"check_consistency\": true, \"lag\": 0}",
+        team = "chronon"
+      )
+
+    assertEquals(
+      "chronon",
+      metadata2.owningTeam
+    )
+
+    assertEquals(
+      "chronon",
+      metadata2.team
+    )
+
     val metadata3 =
       Builders.MetaData(
         customJson = null,

--- a/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
@@ -53,6 +53,22 @@ class ExtensionsTest {
       "chronon",
       metadata.team
     )
+
+    val metadata3 =
+      Builders.MetaData(
+        customJson = null,
+        team = "chronon"
+      )
+
+    assertEquals(
+      "chronon",
+      metadata3.owningTeam
+    )
+
+    assertEquals(
+      "chronon",
+      metadata3.team
+    )
   }
 
   @Test

--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -206,7 +206,7 @@ object Metrics {
       assert(
         environment != null,
         "Environment needs to be set - group_by.upload, group_by.streaming, join.fetching, group_by.fetching, group_by.offline etc")
-      val buffer = new Array[String](7 + joinNames.length)
+      val buffer = new Array[String](8 + joinNames.length)
       var counter = 0
 
       def addTag(key: String, value: String): Unit = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

1. Fix owningTeam. Currently if team_override is not set, owningTeam is null. 
2. Increase buffer of metrics. It's not a blocker now because StagingQuery is usually non-null at the same when GB/join is non-null

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

bug fixes. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pengyu-hou @donghanz @yuli-han 
