### PR TITLE
refactor: join backfill refactor

### DIFF
--- a/api/py/ai/chronon/constants.py
+++ b/api/py/ai/chronon/constants.py
@@ -1,5 +1,0 @@
-from ai.chronon.scheduler.adapters.airflow_adapter import AirflowAdapter
-
-ADAPTERS = {
-    "airflow": AirflowAdapter,
-}

--- a/api/py/ai/chronon/repo/join_backfill.py
+++ b/api/py/ai/chronon/repo/join_backfill.py
@@ -86,7 +86,7 @@ class JoinBackfill:
     def command_template(self, config_path: str, extra_args: dict):
         if self.start_date:
             extra_args.update({"start_ds": self.start_date})
-        return f"""python3 /tmp/run.py --conf=/tmp/{config_path} --ds={self.end_date} \
+        return f"""run.py --conf={config_path} --ds={self.end_date} \
 {dict_to_bash_commands(extra_args)}"""
 
     def run_join_part(self, join_name: dict, join_part: str):

--- a/api/py/ai/chronon/repo/join_backfill.py
+++ b/api/py/ai/chronon/repo/join_backfill.py
@@ -31,8 +31,8 @@ class JoinBackfill:
         start_date: str,
         end_date: str,
         config_path: str,
-        extra_args: dict = {},
-        settings: dict = DEFAULT_SPARK_SETTINGS,
+        extra_args: dict = None,
+        settings: dict = None,
     ):
         self.dag_id = "_".join(
             map(
@@ -42,8 +42,8 @@ class JoinBackfill:
         self.start_date = start_date
         self.end_date = end_date
         self.config_path = config_path
-        self.extra_args = extra_args
-        self.settings = settings
+        self.extra_args = extra_args or {}
+        self.settings = settings or DEFAULT_SPARK_SETTINGS
         with open(self.config_path, "r") as file:
             config = file.read()
         self.join = convert_json_to_obj(json.loads(config))

--- a/api/py/ai/chronon/repo/join_backfill.py
+++ b/api/py/ai/chronon/repo/join_backfill.py
@@ -1,9 +1,9 @@
 import json
 import os
-from typing import Optional
 
 from ai.chronon.scheduler.interfaces.flow import Flow
 from ai.chronon.scheduler.interfaces.node import Node
+from ai.chronon.scheduler.interfaces.orchestrator import WorkflowOrchestrator
 from ai.chronon.utils import (
     convert_json_to_obj,
     dict_to_bash_commands,
@@ -31,6 +31,7 @@ class JoinBackfill:
         start_date: str,
         end_date: str,
         config_path: str,
+        extra_args: dict = {},
         settings: dict = DEFAULT_SPARK_SETTINGS,
     ):
         self.dag_id = "_".join(
@@ -41,6 +42,7 @@ class JoinBackfill:
         self.start_date = start_date
         self.end_date = end_date
         self.config_path = config_path
+        self.extra_args = extra_args
         self.settings = settings
         with open(self.config_path, "r") as file:
             config = file.read()
@@ -84,6 +86,7 @@ class JoinBackfill:
         return f"{dict_to_exports(settings)}"
 
     def command_template(self, config_path: str, extra_args: dict):
+        extra_args.update(self.extra_args)
         if self.start_date:
             extra_args.update({"start_ds": self.start_date})
         return f"""run.py --conf={config_path} --ds={self.end_date} \
@@ -118,11 +121,7 @@ class JoinBackfill:
             + self.command_template(config_path=get_config_path(join_name), extra_args={"mode": "backfill-final"})
         )
 
-    def run(self, orchestrator: str, overrides: Optional[dict] = None):
-        from ai.chronon.constants import ADAPTERS
-
-        ADAPTERS.update(overrides)
-        orchestrator = ADAPTERS[orchestrator](dag_id=self.dag_id, start_date=self.start_date)
+    def run(self, orchestrator: WorkflowOrchestrator):
         orchestrator.setup()
         orchestrator.build_dag_from_flow(self.build_flow())
         orchestrator.trigger_run()


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- remove tmp prefix in order to make the command more general. `/tmp/` prefix was used in Airflow. 
- add `extra_args` for extra arguments in run.py
- remove the dependency on adapters in JoinBackfill


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @yuli-han @pengyu-hou 
