### PR TITLE
Adding Timestamp Check to Join Analyzer

### DIFF
--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -31,7 +31,7 @@ The analyzer will compute the following information by simply taking a Chronon c
 * A simple count of items by year - to sanity check the timestamps.
 * A row count - to give users a sense of how large the data is.
 * Output schemas - to quickly validate the sql statements and understand the output schema.
-* Timestamp Validations for GroupBy configs
+* Timestamp Validations for configs for GroupBys and Joins (with EventSources) 
   * Confirms that timestamp columns are not all NULLs
   * Confirms that timestamp columns are in epoch milliseconds in the range between 1971-01-01 and 2099-01-01
 * Validations for JOIN config - to make sure the join conf is valid for backfill. Here is a list of items we validate:

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -530,6 +530,13 @@ class Analyzer(tableUtils: TableUtils,
     mapTimestampChecks
   }
 
+  /**
+    * This method can be used to trigger the assertion checks
+    * or print the summary stats once the timestamp checks have been run
+    * @param timestampCheckMap
+    * @param configType
+    * @param configName
+    */
   def validateTimestampChecks(timestampCheckMap: Map[String, String], configType: String, configName: String): Unit = {
 
     if (!timestampCheckMap.contains("noTsColumn")) {

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -18,7 +18,6 @@ package ai.chronon.spark.test
 
 import ai.chronon.aggregator.test.Column
 import ai.chronon.api
-import ai.chronon.api.Builders.{ContextualSource, Query}
 import ai.chronon.api._
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.{Analyzer, Join, SparkSessionBuilder, TableUtils}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

- This PR adds checks on timestamps in a Join source
   - we run the exact same checks as added in this PR:
   - https://github.com/airbnb/chronon/pull/794

The Analyzer class' method analyzeJoin will run the mentioned checks all the time.
Checks will only run when ts column is provided.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
For Joins with an incorrect timestamp field is provided (for e.g. UNIX_TIMESTAMP(ts_start, 'yyyy-MM-dd') -> NULL), this option will ensure that we catch such cases.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

** successful run ** 
```
[2024-08-06 17:07:06] {Analyzer:330} - ANALYSIS TIMESTAMP completed for join/joins/help_center.help_center_article_browse_user.v1.
check notNullCount: 1000
check badRangeCount: 0
```

** "CAST(NULL AS BIGINT)" **
```
Exception in thread "main" java.lang.AssertionError: assertion failed: [ERROR]: Join validation failed.
 Please check that left source has non-null timestamps.
 check notNullCount: 0
```

** "ts_unixtime*1000" **
```
Exception in thread "main" java.lang.AssertionError: assertion failed: [ERROR]: Join validation failed.
 Please check that left source has valid epoch millisecond timestamps.
 badRangeCount: 1000
```

** integration test post refactor copy-paste code **
```
[2024-08-06 21:45:55] {Analyzer:561} - ANALYSIS TIMESTAMP completed for group_by/ispp_user_recent_reservations_guest_reservations_v1ispp.user_recent_reservations.guest_reservations_v1.
check notNullCount: 1000
check badRangeCount: 0
```


## Checklist
- [x] Documentation update

## Reviewers

