### PR TITLE
Add Project Management Committee (PMC) List

### DIFF
--- a/PROJECT_MANAGEMENT_COMMITTEE
+++ b/PROJECT_MANAGEMENT_COMMITTEE
@@ -1,0 +1,17 @@
+# Airbnb (8 seats)
+<>
+<>
+<>
+<>
+<>
+<>
+<>
+<>
+
+# Stripe (6 seats)
+Ben Mears
+Caio Camatta
+Cam Weston
+Jeff Brooks
+Jeremy Robin
+Piyush Narang

--- a/PROJECT_MANAGEMENT_COMMITTEE
+++ b/PROJECT_MANAGEMENT_COMMITTEE
@@ -1,12 +1,12 @@
 # Airbnb (8 seats)
-<>
-<>
-<>
-<>
-<>
-<>
-<>
-<>
+Donghan Zhang
+Haozhen Ding
+Pengyu Hou
+Praveen Kundurthy
+Rohit Girme
+Sophie Wang
+Vamsee Yarlagadda
+Yuli Han
 
 # Stripe (6 seats)
 Ben Mears


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Add a file with the current list of Project Management Committee (PMC) members.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
The existence of a PMC, and the responsibilities of its members, was discussed by Stripe and Airbnb before open-sourcing Chronon. This file formalizes the current list of members.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

