### PR TITLE
fix: bucketized aggregation bug fix

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/BucketedColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/BucketedColumnAggregator.scala
@@ -19,8 +19,6 @@ package ai.chronon.aggregator.row
 import ai.chronon.aggregator.base.BaseAggregator
 import ai.chronon.api.Row
 
-import scala.collection.mutable
-
 class BucketedColumnAggregator[Input, IR, Output](agg: BaseAggregator[Input, IR, Output],
                                                   columnIndices: ColumnIndices,
                                                   bucketIndex: Int,
@@ -75,8 +73,9 @@ class BucketedColumnAggregator[Input, IR, Output](agg: BaseAggregator[Input, IR,
     lazy val prepared = rowUpdater.inversePrepare(inputRow)
     if (previousMap == null) { // map is absent
       if (prepared != null) {
-        val map = mutable.HashMap[String, IR](bucket -> prepared.asInstanceOf[IR])
-        ir.update(columnIndices.output, map)
+        val newMap = new IrMap()
+        newMap.put(bucket, prepared.asInstanceOf[IR])
+        ir.update(columnIndices.output, newMap)
       }
       return
     }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

fix a bug in `BucketedColumnAggregator` in the `delete` function. the current code uses `mutable.HashMap` (scala map) but should be using `IrMap` (java map). 

the `update` function is correct, and after the fix the code in `update` and `delete` are consistent. 

this bug will only surface when reversal mutations are the first to appear in the streaming rows. 


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

bug fix. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@donghanz @yuli-han @pengyu-hou 
