### PR TITLE
[Backfill] Adding Archive Flag to TBLPROPERTIES

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -64,4 +64,5 @@ object Constants {
   val LabelViewPropertyFeatureTable: String = "feature_table"
   val LabelViewPropertyKeyLabelTable: String = "label_table"
   val ChrononRunDs: String = "CHRONON_RUN_DS"
+  val chrononArchiveFlag: String = "chronon_archived"
 }

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -377,6 +377,8 @@ abstract class JoinBase(joinConf: api.Join,
       // we keep everything in sync.
       if (tableUtils.tableExists(bootstrapTable)) {
         tableUtils.alterTableProperties(bootstrapTable, tableProps)
+        // remove any properties set if table was previously archived
+        tableUtils.unsetTableProperties(bootstrapTable, Seq(tableUtils.chrononArchiveFlag))
       }
     } else {
       logger.info(s"Detected semantic change in left side of join, archiving bootstrap table for recomputation.")

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -378,7 +378,7 @@ abstract class JoinBase(joinConf: api.Join,
       if (tableUtils.tableExists(bootstrapTable)) {
         tableUtils.alterTableProperties(bootstrapTable, tableProps)
         // remove any properties set if table was previously archived
-        tableUtils.unsetTableProperties(bootstrapTable, Seq(tableUtils.chrononArchiveFlag))
+        tableUtils.unsetTableProperties(bootstrapTable, Seq(Constants.chrononArchiveFlag))
       }
     } else {
       logger.info(s"Detected semantic change in left side of join, archiving bootstrap table for recomputation.")

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -376,9 +376,7 @@ abstract class JoinBase(joinConf: api.Join,
       // It is possible that while bootstrap_table's semantic_hash is unchanged, the rest has changed, so
       // we keep everything in sync.
       if (tableUtils.tableExists(bootstrapTable)) {
-        tableUtils.alterTableProperties(bootstrapTable, tableProps)
-        // remove any properties set if table was previously archived
-        tableUtils.unsetTableProperties(bootstrapTable, Seq(Constants.chrononArchiveFlag))
+        tableUtils.alterTableProperties(bootstrapTable, tableProps, unsetProperties = Seq(Constants.chrononArchiveFlag))
       }
     } else {
       logger.info(s"Detected semantic change in left side of join, archiving bootstrap table for recomputation.")

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -671,6 +671,9 @@ case class TableUtils(sparkSession: SparkSession) {
       val command = s"ALTER TABLE $tableName RENAME TO $finalArchiveTableName"
       logger.info(s"Archiving table with command: $command")
       sql(command)
+      val commandProp = s"ALTER TABLE $finalArchiveTableName SET TBLPROPERTIES ('chronon_archived' = 'true')"
+      logger.info(s"Update table properties to indicate archived table: $commandProp")
+      sql(commandProp)
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -82,7 +82,6 @@ case class TableUtils(sparkSession: SparkSession) {
   val joinPartParallelism: Int = sparkSession.conf.get("spark.chronon.join.part.parallelism", "1").toInt
   val aggregationParallelism: Int = sparkSession.conf.get("spark.chronon.group_by.parallelism", "1000").toInt
   val maxWait: Int = sparkSession.conf.get("spark.chronon.wait.hours", "48").toInt
-  val chrononArchiveFlag: String = "chronon_archived"
 
   sparkSession.sparkContext.setLogLevel("ERROR")
   // converts String-s like "a=b/c=d" to Map("a" -> "b", "c" -> "d")
@@ -320,7 +319,7 @@ case class TableUtils(sparkSession: SparkSession) {
     if (tableProperties != null && tableProperties.nonEmpty) {
       alterTableProperties(tableName, tableProperties)
       // remove any properties set if table was previously archived
-      unsetTableProperties(tableName, Seq(chrononArchiveFlag))
+      unsetTableProperties(tableName, Seq(Constants.chrononArchiveFlag))
     }
 
     if (autoExpand) {
@@ -386,7 +385,7 @@ case class TableUtils(sparkSession: SparkSession) {
       if (tableProperties != null && tableProperties.nonEmpty) {
         alterTableProperties(tableName, tableProperties)
         // remove any properties set if table was previously archived
-        unsetTableProperties(tableName, Seq(chrononArchiveFlag))
+        unsetTableProperties(tableName, Seq(Constants.chrononArchiveFlag))
       }
     }
 
@@ -683,7 +682,7 @@ case class TableUtils(sparkSession: SparkSession) {
       logger.info(s"Archiving table with command: $command")
       sql(command)
       logger.info(s"Setting table property chronon_archived -> true")
-      alterTableProperties(finalArchiveTableName, Map(chrononArchiveFlag -> "true"))
+      alterTableProperties(finalArchiveTableName, Map(Constants.chrononArchiveFlag -> "true"))
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -47,7 +47,7 @@ case class TableUtils(sparkSession: SparkSession) {
   private val ARCHIVE_TIMESTAMP_FORMAT = "yyyyMMddHHmmss"
   @transient private lazy val archiveTimestampFormatter = DateTimeFormatter
     .ofPattern(ARCHIVE_TIMESTAMP_FORMAT)
-    .withZone(ZoneId.systemDefault())
+    .withZone(ZoneId.of("UTC"))
   val partitionColumn: String =
     sparkSession.conf.get("spark.chronon.partition.column", "ds")
   private val partitionFormat: String =

--- a/spark/src/test/scala/ai/chronon/spark/test/LocalDataLoaderTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/LocalDataLoaderTest.scala
@@ -43,9 +43,24 @@ object LocalDataLoaderTest {
 
 class LocalDataLoaderTest {
 
+  val srcPath = "src/test/resources/local_data_csv/"
+
+  def matchPath(srcPath: String, fileName: Option[String] = None): File = (new File (srcPath).exists (), fileName.isDefined) match {
+      // if src/ path exists and a filename is provided
+      case (true, true) => new File (srcPath + fileName.get)
+      // if src/ path exists and no filename is provided
+      case (true, false) => new File (srcPath)
+      // if src/ path does not exist and a filename is provided try spark/src/
+      case (false, true) => new File ("spark/" + srcPath + fileName.get)
+      // if src/ path does not exist and no filename is provided try spark/src/
+      case (false, false) => new File ("spark/" + srcPath)
+    }
+
   @Test
   def loadDataFileAsTableShouldBeCorrect(): Unit = {
-    val file = new File("spark/src/test/resources/local_data_csv/test_table_1_data.csv")
+
+    val fileName = "test_table_1_data.csv"
+    val file = matchPath(srcPath, Some(fileName))
     val nameSpaceAndTable = "test.table"
     LocalDataLoader.loadDataFileAsTable(file, spark, nameSpaceAndTable)
 
@@ -58,7 +73,7 @@ class LocalDataLoaderTest {
 
   @Test
   def loadDataRecursivelyShouldBeCorrect(): Unit = {
-    val path = new File("spark/src/test/resources/local_data_csv")
+    val path = matchPath(srcPath)
     LocalDataLoader.loadDataRecursively(path, spark)
 
     val loadedDataDf = spark.sql(s"SELECT * FROM local_data_csv.test_table_1_data")

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
@@ -453,7 +453,7 @@ class TableUtilsTest {
 
     // test after a un-archive we can remove chronon_archived property
     tableUtils.sql(s"ALTER TABLE db.$archiveTableName RENAME TO $tableName")
-    tableUtils.unsetTableProperties(tableName, Seq("chronon_archived","other_doesnt_exist"))
+    tableUtils.alterTableProperties(tableName, properties = Map("chronon_archived" -> "true"), unsetProperties = Seq("chronon_archived"))
     val tblPropsAfter = tableUtils.sql(s"SHOW TBLPROPERTIES $tableName").collect()
     val mapValAfter = readTblPropertiesMap(tblPropsAfter)
     assert(mapValAfter.getOrElse("chronon_archived","false") == "false")

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsTest.scala
@@ -457,7 +457,5 @@ class TableUtilsTest {
     val tblPropsAfter = tableUtils.sql(s"SHOW TBLPROPERTIES $tableName").collect()
     val mapValAfter = readTblPropertiesMap(tblPropsAfter)
     assert(mapValAfter.getOrElse("chronon_archived","false") == "false")
-
   }
-
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- When a table is archived in spark, we add a new table property called `chronon_archived = true` 
- Explicitly setting the archive timestamp to UTC
- Add an option in the `alterTableProperties` to unset properties

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- This allows us to flag all tables which are currently archived by Chronon
- Within airbnb, we can apply our own custom archiving rules based on this flag

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@donghanz @pengyu-hou 
