### PR TITLE
Introduce new flag enableTimestampCheck in analyzer

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -68,7 +68,8 @@ class Analyzer(tableUtils: TableUtils,
                count: Int = 64,
                sample: Double = 0.1,
                enableHitter: Boolean = false,
-               silenceMode: Boolean = false) {
+               silenceMode: Boolean = false,
+               analyzeForMetadata: Boolean = false) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   // include ts into heavy hitter analysis - useful to surface timestamps that have wrong units
   // include total approx row count - so it is easy to understand the percentage of skewed data
@@ -192,8 +193,10 @@ class Analyzer(tableUtils: TableUtils,
     val name = "group_by/" + prefix + groupByConf.metaData.name
     logger.info(s"""|Running GroupBy analysis for $name ...""".stripMargin)
 
-    val timestampChecks = runTimestampChecks(groupBy.inputDf)
-    validateTimestampChecks(timestampChecks, "GroupBy", name)
+    if (!analyzeForMetadata) {
+      val timestampChecks = runTimestampChecks(groupBy.inputDf)
+      validateTimestampChecks(timestampChecks, "GroupBy", name)
+    }
 
     val analysis =
       if (enableHitter)
@@ -276,8 +279,10 @@ class Analyzer(tableUtils: TableUtils,
       (analysis, leftDf)
     }
 
-    val timestampChecks = runTimestampChecks(leftDf)
-    validateTimestampChecks(timestampChecks, "Join", name)
+    if (!analyzeForMetadata) {
+      val timestampChecks = runTimestampChecks(leftDf)
+      validateTimestampChecks(timestampChecks, "Join", name)
+    }
 
     val leftSchema = leftDf.schema.fields
       .map(field => (field.name, SparkConversions.toChrononType(field.name, field.dataType)))

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -50,7 +50,7 @@ object MetadataExporter {
 
   def enrichMetadata(path: String): String = {
     val configData = mapper.readValue(new File(path), classOf[Map[String, Any]])
-    val analyzer = new Analyzer(tableUtils, path, yesterday, today, silenceMode = true)
+    val analyzer = new Analyzer(tableUtils, path, yesterday, today, silenceMode = true, analyzeForMetadata = true)
     val enrichedData: Map[String, Any] =
       try {
         if (path.contains(GROUPBY_PATH_SUFFIX)) {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We don't want to include real data access check in metadata export mode when running analyzer. This PR is to introduce a new flag enableTimestampCheck and set it to false in metadata-export. 


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pkundurthy @hzding621 @pengyu-hou 
