### PR TITLE
Analyzer - Adding skipTimestampCheck as an input option to the Analyzer

### DIFF
--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -54,6 +54,8 @@ Optional parameters:
 
 `--enable-hitter`: enable skewed data analysis - include the heavy hitter analysis in output, only output schema if not specified
 
+`--skip-timestamp-check`: skip sampling and timestamp checks - setting to true will result in timestamp checks being skipped
+
 `--start-date` : Finds heavy hitters & time-distributions for a specified start date. Default 3 days prior to "today"
 
 `--count` : Finds the specified number of heavy hitters approximately. The larger this number is the more accurate the analysis will be. Default 128

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -68,7 +68,9 @@ class Analyzer(tableUtils: TableUtils,
                count: Int = 64,
                sample: Double = 0.1,
                enableHitter: Boolean = false,
-               silenceMode: Boolean = false) {
+               silenceMode: Boolean = false,
+               skipTimestampCheck: Boolean = false
+              ) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   // include ts into heavy hitter analysis - useful to surface timestamps that have wrong units
   // include total approx row count - so it is easy to understand the percentage of skewed data
@@ -186,14 +188,18 @@ class Analyzer(tableUtils: TableUtils,
   def analyzeGroupBy(groupByConf: api.GroupBy,
                      prefix: String = "",
                      includeOutputTableName: Boolean = false,
-                     enableHitter: Boolean = false): (Array[AggregationMetadata], Map[String, DataType]) = {
+                     enableHitter: Boolean = false,
+                     skipTimestampCheck: Boolean = false,
+                    ): (Array[AggregationMetadata], Map[String, DataType]) = {
     groupByConf.setups.foreach(tableUtils.sql)
     val groupBy = GroupBy.from(groupByConf, range, tableUtils, computeDependency = enableHitter, finalize = true)
     val name = "group_by/" + prefix + groupByConf.metaData.name
     logger.info(s"""|Running GroupBy analysis for $name ...""".stripMargin)
 
-    val timestampChecks = runTimestampChecks(groupBy.inputDf)
-    validateTimestampChecks(timestampChecks, "GroupBy", name)
+    if (!skipTimestampCheck) {
+      val timestampChecks = runTimestampChecks(groupBy.inputDf)
+      validateTimestampChecks(timestampChecks, "GroupBy", name)
+    }
 
     val analysis =
       if (enableHitter)
@@ -257,7 +263,9 @@ class Analyzer(tableUtils: TableUtils,
   def analyzeJoin(joinConf: api.Join,
                   enableHitter: Boolean = false,
                   validateTablePermission: Boolean = true,
-                  validationAssert: Boolean = false): (Map[String, DataType], ListBuffer[AggregationMetadata]) = {
+                  validationAssert: Boolean = false,
+                  skipTimestampCheck: Boolean = false
+                 ): (Map[String, DataType], ListBuffer[AggregationMetadata]) = {
     val name = "joins/" + joinConf.metaData.name
     logger.info(s"""|Running join analysis for $name ...""".stripMargin)
     // run SQL environment setups such as UDFs and JARs
@@ -276,8 +284,10 @@ class Analyzer(tableUtils: TableUtils,
       (analysis, leftDf)
     }
 
-    val timestampChecks = runTimestampChecks(leftDf)
-    validateTimestampChecks(timestampChecks, "Join", name)
+    if (!skipTimestampCheck) {
+      val timestampChecks = runTimestampChecks(leftDf)
+      validateTimestampChecks(timestampChecks, "Join", name)
+    }
 
     val leftSchema = leftDf.schema.fields
       .map(field => (field.name, SparkConversions.toChrononType(field.name, field.dataType)))
@@ -298,7 +308,7 @@ class Analyzer(tableUtils: TableUtils,
 
     joinConf.joinParts.toScala.foreach { part =>
       val (aggMetadata, gbKeySchema) =
-        analyzeGroupBy(part.groupBy, part.fullPrefix, includeOutputTableName = true, enableHitter = enableHitter)
+        analyzeGroupBy(part.groupBy, part.fullPrefix, includeOutputTableName = true, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
       aggregationsMetadata ++= aggMetadata.map { aggMeta =>
         AggregationMetadata(part.fullPrefix + "_" + aggMeta.name,
                             aggMeta.columnType,
@@ -499,12 +509,12 @@ class Analyzer(tableUtils: TableUtils,
 
   // For groupBys validate if the timestamp provided produces some values
   // if all values are null this should be flagged as an error
-  def runTimestampChecks(df: DataFrame, sampleNumber: Int = 1000): Map[String, String] = {
+  def runTimestampChecks(df: DataFrame, sampleNumber: Int = 100): Map[String, String] = {
 
     val hasTimestamp = df.schema.fieldNames.contains(Constants.TimeColumn)
     val mapTimestampChecks = if (hasTimestamp) {
       // set max sample to 1000 rows if larger input is provided
-      val sampleN = if (sampleNumber > 1000) { 1000 }
+      val sampleN = if (sampleNumber > 100) { 100 }
       else { sampleNumber }
       dataFrameToMap(
         df.limit(sampleN)
@@ -588,12 +598,12 @@ class Analyzer(tableUtils: TableUtils,
       case confPath: String =>
         if (confPath.contains("/joins/")) {
           val joinConf = parseConf[api.Join](confPath)
-          analyzeJoin(joinConf, enableHitter = enableHitter)
+          analyzeJoin(joinConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
         } else if (confPath.contains("/group_bys/")) {
           val groupByConf = parseConf[api.GroupBy](confPath)
-          analyzeGroupBy(groupByConf, enableHitter = enableHitter)
+          analyzeGroupBy(groupByConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
         }
-      case groupByConf: api.GroupBy => analyzeGroupBy(groupByConf, enableHitter = enableHitter)
-      case joinConf: api.Join       => analyzeJoin(joinConf, enableHitter = enableHitter)
+      case groupByConf: api.GroupBy => analyzeGroupBy(groupByConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
+      case joinConf: api.Join       => analyzeJoin(joinConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
     }
 }

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -514,7 +514,7 @@ class Analyzer(tableUtils: TableUtils,
 
     val hasTimestamp = df.schema.fieldNames.contains(Constants.TimeColumn)
     val mapTimestampChecks = if (hasTimestamp) {
-      // set max sample to 1000 rows if larger input is provided
+      // set max sample to 100 rows if larger input is provided
       val sampleN = if (sampleNumber > 100) { 100 }
       else { sampleNumber }
       dataFrameToMap(

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -69,8 +69,7 @@ class Analyzer(tableUtils: TableUtils,
                sample: Double = 0.1,
                enableHitter: Boolean = false,
                silenceMode: Boolean = false,
-               skipTimestampCheck: Boolean = false
-              ) {
+               skipTimestampCheck: Boolean = false) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   // include ts into heavy hitter analysis - useful to surface timestamps that have wrong units
   // include total approx row count - so it is easy to understand the percentage of skewed data
@@ -189,8 +188,7 @@ class Analyzer(tableUtils: TableUtils,
                      prefix: String = "",
                      includeOutputTableName: Boolean = false,
                      enableHitter: Boolean = false,
-                     skipTimestampCheck: Boolean = false,
-                    ): (Array[AggregationMetadata], Map[String, DataType]) = {
+                     skipTimestampCheck: Boolean = false): (Array[AggregationMetadata], Map[String, DataType]) = {
     groupByConf.setups.foreach(tableUtils.sql)
     val groupBy = GroupBy.from(groupByConf, range, tableUtils, computeDependency = enableHitter, finalize = true)
     val name = "group_by/" + prefix + groupByConf.metaData.name
@@ -264,8 +262,7 @@ class Analyzer(tableUtils: TableUtils,
                   enableHitter: Boolean = false,
                   validateTablePermission: Boolean = true,
                   validationAssert: Boolean = false,
-                  skipTimestampCheck: Boolean = false
-                 ): (Map[String, DataType], ListBuffer[AggregationMetadata]) = {
+                  skipTimestampCheck: Boolean = false): (Map[String, DataType], ListBuffer[AggregationMetadata]) = {
     val name = "joins/" + joinConf.metaData.name
     logger.info(s"""|Running join analysis for $name ...""".stripMargin)
     // run SQL environment setups such as UDFs and JARs
@@ -308,7 +305,11 @@ class Analyzer(tableUtils: TableUtils,
 
     joinConf.joinParts.toScala.foreach { part =>
       val (aggMetadata, gbKeySchema) =
-        analyzeGroupBy(part.groupBy, part.fullPrefix, includeOutputTableName = true, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
+        analyzeGroupBy(part.groupBy,
+                       part.fullPrefix,
+                       includeOutputTableName = true,
+                       enableHitter = enableHitter,
+                       skipTimestampCheck = skipTimestampCheck)
       aggregationsMetadata ++= aggMetadata.map { aggMeta =>
         AggregationMetadata(part.fullPrefix + "_" + aggMeta.name,
                             aggMeta.columnType,
@@ -603,7 +604,9 @@ class Analyzer(tableUtils: TableUtils,
           val groupByConf = parseConf[api.GroupBy](confPath)
           analyzeGroupBy(groupByConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
         }
-      case groupByConf: api.GroupBy => analyzeGroupBy(groupByConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
-      case joinConf: api.Join       => analyzeJoin(joinConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
+      case groupByConf: api.GroupBy =>
+        analyzeGroupBy(groupByConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
+      case joinConf: api.Join =>
+        analyzeJoin(joinConf, enableHitter = enableHitter, skipTimestampCheck = skipTimestampCheck)
     }
 }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -425,6 +425,12 @@ object Driver {
             "enable skewed data analysis - whether to include the heavy hitter analysis, will only output schema if disabled",
           default = Some(false)
         )
+      val skipTimestampCheck: ScallopOption[Boolean] =
+        opt[Boolean](
+          required = false,
+          descr = "skip sampling and timestamp checks - setting to true will result in timestamp checks being skipped",
+          default = Some(false)
+        )
 
       override def subcommandName() = "analyzer_util"
     }
@@ -437,7 +443,8 @@ object Driver {
                    args.endDate(),
                    args.count(),
                    args.sample(),
-                   args.enableHitter()).run
+                   args.enableHitter(),
+                   args.skipTimestampCheck()).run
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.0.79-SNAPSHOT"
+version := "0.0.79"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
 - We add a flag `skipTimestampCheck` to the Analyzer
 - We enable the Driver to be able to parse a --skip-timestamp-check boolean flag 
 - We reduce the default sample-size from 1000 ==> 100 for timestamp checks

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
 - We want to reduce the overhead introduced by timestamp checks
 - We want to provide an option to skip timestamp checks in the analyzer

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [x] Documentation update

## Reviewers

