### PR TITLE
fix: fix tox when running specific tests

### DIFF
--- a/api/py/tox.ini
+++ b/api/py/tox.ini
@@ -14,11 +14,10 @@ commands_pre =
     --chronon_root=test/sample \
     --input_path=joins/sample_team/
 commands =
-  pytest test/ \
+  pytest {posargs:test/} \
     --cov=ai/ \
     --cov-report term \
-    --cov-report html \
-    {posargs}
+    --cov-report html
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

fix the postargs setup in tox.ini



## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
in old code, tox setup is broken when running specific tests. 

in old code, when running a cmd like `tox -- test/test_compile.py`, `test_compile.py` will be run twice, and the tests are not set up properly to run twice, so they lead to false errors. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

run in several modes:
- `tox`
- `tox -- test/*`
- `tox -- test/test_compile.py` 

## Checklist
- [ ] Documentation update

## Reviewers

@rohitgirme @pkundurthy @donghanz 

