### PR TITLE
fix: join keys filtering

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory
 import java.util
 import scala.collection.{Seq, mutable}
 import scala.util.ScalaJavaConversions.{JListOps, ListOps, MapOps}
-import scala.util.Try
 
 class GroupBy(val aggregations: Seq[api.Aggregation],
               val keyColumns: Seq[String],

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -340,11 +340,18 @@ class Join(joinConf: api.Join,
                     s"Macro ${Constants.ChrononRunDs} is only supported for single day join, current range is ${leftRange}")
                 }
 
-                val (runSmallMode: Boolean, bloomFilterOpt: Option[util.Map[String, BloomFilter]], filteredJoinPart: api.JoinPart) =
+                val (runSmallMode: Boolean,
+                     bloomFilterOpt: Option[util.Map[String, BloomFilter]],
+                     filteredJoinPart: api.JoinPart) =
                   genKeyFilter(joinPart, unfilledLeftDf)
 
                 val df =
-                  computeRightTable(unfilledLeftDf, filteredJoinPart, leftRange, leftTimeRangeOpt, bloomFilterOpt, runSmallMode)
+                  computeRightTable(unfilledLeftDf,
+                                    filteredJoinPart,
+                                    leftRange,
+                                    leftTimeRangeOpt,
+                                    bloomFilterOpt,
+                                    runSmallMode)
                     .map(df => filteredJoinPart -> df)
                 Thread.currentThread().setName(s"done-$threadName")
                 df

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -237,7 +237,10 @@ class Join(joinConf: api.Join,
     df.save(outputTable, tableProps, autoExpand = true)
   }
 
-  override def computeRange(leftDf: DataFrame, leftRange: PartitionRange, bootstrapInfo: BootstrapInfo, usingBootstrappedLeft: Boolean = false): Option[DataFrame] = {
+  override def computeRange(leftDf: DataFrame,
+                            leftRange: PartitionRange,
+                            bootstrapInfo: BootstrapInfo,
+                            usingBootstrappedLeft: Boolean = false): Option[DataFrame] = {
 
     val leftTaggedDf = leftDf.addTimebasedColIfExists()
 
@@ -324,7 +327,9 @@ class Join(joinConf: api.Join,
                     None
                   } else {
                     val leftBlooms = joinConf.leftKeyCols.iterator.map { key =>
-                      key -> unfilledLeftDf.map(_.df.generateBloomFilter(key, leftRowCount, joinConf.left.table, leftRange)).getOrElse(null)
+                      key -> unfilledLeftDf
+                        .map(_.df.generateBloomFilter(key, leftRowCount, joinConf.left.table, leftRange))
+                        .getOrElse(null)
                     }.toJMap
                     Some(leftBlooms)
                   }

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -291,6 +291,8 @@ class Join(joinConf: api.Join,
           } else {
             if (leftRowCount <= tableUtils.bloomFilterThreshold) {
               logger.info(s"Counted $leftRowCount rows, running join in bloom filter mode.")
+              // Generate a Bloom filter for 'joinPart' when the row count to be backfilled falls below a specified threshold.
+              // This method anticipates that there will likely be a substantial number of rows on the right side that need to be filtered out.
               val leftBlooms = joinConf.leftKeyCols.iterator.map { key =>
                 key -> unfilledLeftDf
                   .map(_.df.generateBloomFilter(key, leftRowCount, joinConf.left.table, leftRange))

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -283,7 +283,7 @@ class Join(joinConf: api.Join,
 
         def genKeyFilter(joinPart: JoinPart, unfilledLeftDf: Option[DfWithStats]) = {
           val leftRowCount: Int = unfilledLeftDf.map(_.count.toInt).getOrElse(0)
-          if (tableUtils.smallModelEnabled && leftRowCount <= tableUtils.smallModeNumRowsCutoff) {
+          if (tableUtils.smallModelEnabled && leftRowCount > 0 && leftRowCount <= tableUtils.smallModeNumRowsCutoff) {
             logger.info(s"Counted $leftRowCount rows, running join in small mode.")
             // If left DF is small, hardcode the key filter into the joinPart's GroupBy's where clause.
             injectKeyFilter(unfilledLeftDf.map(_.df).get, joinPart)

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -297,11 +297,13 @@ class Join(joinConf: api.Join,
                   .getOrElse(null)
               }.toJMap
 
-              val rightBlooms = joinPart.rightToLeft.iterator.map { case (rightCol, leftCol) =>
+              val rightBlooms = joinPart.rightToLeft.iterator.map {
+                case (rightCol, leftCol) =>
                   rightCol -> leftBlooms.get(leftCol)
               }.toJMap
 
-              val bloomSizes = rightBlooms.asScala.map { case (rightCol, bloom) =>
+              val bloomSizes = rightBlooms.asScala.map {
+                case (rightCol, bloom) =>
                   s"$rightCol -> ${bloom.bitSize()}"
               }
               logger.info(s"Bloom sizes: ${bloomSizes.mkString(", ")}")
@@ -336,7 +338,8 @@ class Join(joinConf: api.Join,
                     s"Macro ${Constants.ChrononRunDs} is only supported for single day join, current range is ${leftRange}")
                 }
 
-                val (runSmallMode: Boolean, bloomFilterOpt: Option[util.Map[String, BloomFilter]]) = genKeyFilter(joinPart, unfilledLeftDf)
+                val (runSmallMode: Boolean, bloomFilterOpt: Option[util.Map[String, BloomFilter]]) =
+                  genKeyFilter(joinPart, unfilledLeftDf)
 
                 val df =
                   computeRightTable(unfilledLeftDf, joinPart, leftRange, leftTimeRangeOpt, bloomFilterOpt, runSmallMode)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -192,9 +192,7 @@ abstract class JoinBase(joinConf: api.Join,
             // Cache join part data into intermediate table
             if (filledDf.isDefined) {
               logger.info(s"Writing to join part table: $partTable for partition range $unfilledRange")
-              filledDf.get.save(partTable,
-                                tableProps,
-                                sortByCols = joinPart.groupBy.keyColumns.toScala)
+              filledDf.get.save(partTable, tableProps, sortByCols = joinPart.groupBy.keyColumns.toScala)
             } else {
               logger.info(s"Skipping $partTable because no data in computed joinPart.")
             }
@@ -325,7 +323,10 @@ abstract class JoinBase(joinConf: api.Join,
     Some(rightDfWithDerivations)
   }
 
-  def computeRange(leftDf: DataFrame, leftRange: PartitionRange, bootstrapInfo: BootstrapInfo, usingBootstrappedLeft: Boolean = false): Option[DataFrame]
+  def computeRange(leftDf: DataFrame,
+                   leftRange: PartitionRange,
+                   bootstrapInfo: BootstrapInfo,
+                   usingBootstrappedLeft: Boolean = false): Option[DataFrame]
 
   def computeBootstrapTable(leftDf: DataFrame, range: PartitionRange, bootstrapInfo: BootstrapInfo): DataFrame
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -297,34 +297,7 @@ object JoinUtils {
       unfilledRange: PartitionRange,
       bloomMapOpt: Option[util.Map[String, BloomFilter]]): Option[util.Map[String, BloomFilter]] = {
 
-    val rightBlooms = bloomMapOpt.map { joinBlooms =>
-      joinPart.rightToLeft.iterator.map {
-        case (rightCol, leftCol) =>
-          rightCol -> joinBlooms.get(leftCol)
-      }.toJMap
-    }
 
-    // print bloom sizes
-    val bloomSizes = rightBlooms.map { blooms =>
-      val sizes = blooms.asScala
-        .map {
-          case (rightCol, bloom) =>
-            s"$rightCol -> ${bloom.bitSize()}"
-        }
-      logger.info(s"Bloom sizes: ${sizes.mkString(", ")}")
-    }
-
-    logger.info(s"""
-           Generating bloom filter for joinPart:
-         |  part name : ${joinPart.groupBy.metaData.name},
-         |  left type : ${joinConf.left.dataModel},
-         |  right type: ${joinPart.groupBy.dataModel},
-         |  accuracy  : ${joinPart.groupBy.inferredAccuracy},
-         |  part unfilled range: $unfilledRange,
-         |  left row count: $leftRowCount
-         |  bloom sizes: $bloomSizes
-         |  groupBy: ${joinPart.groupBy.toString}
-         |""".stripMargin)
     rightBlooms
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -295,9 +295,9 @@ object JoinUtils {
       joinConf: ai.chronon.api.Join,
       leftRowCount: Long,
       unfilledRange: PartitionRange,
-      joinLevelBloomMapOpt: Option[util.Map[String, BloomFilter]]): Option[util.Map[String, BloomFilter]] = {
+      bloomMapOpt: Option[util.Map[String, BloomFilter]]): Option[util.Map[String, BloomFilter]] = {
 
-    val rightBlooms = joinLevelBloomMapOpt.map { joinBlooms =>
+    val rightBlooms = bloomMapOpt.map { joinBlooms =>
       joinPart.rightToLeft.iterator.map {
         case (rightCol, leftCol) =>
           rightCol -> joinBlooms.get(leftCol)

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -297,7 +297,6 @@ object JoinUtils {
       unfilledRange: PartitionRange,
       bloomMapOpt: Option[util.Map[String, BloomFilter]]): Option[util.Map[String, BloomFilter]] = {
 
-
     rightBlooms
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -282,7 +282,9 @@ object JoinUtils {
     labelMap.groupBy(_._2).map { case (v, kvs) => (v, tableUtils.chunk(kvs.keySet.toSet)) }
   }
 
-  def injectKeyFilter(leftDf: DataFrame, joinPart: api.JoinPart): Unit = {
+  def injectKeyFilter(leftDf: DataFrame, originalJoinPart: api.JoinPart): api.JoinPart = {
+    // make a copy of the original joinPart to avoid accumulating the key filters into the same object
+    val joinPart = originalJoinPart.deepCopy()
     // Modifies the joinPart to inject the key filter into the where Clause of GroupBys by hardcoding the keyset
     val groupByKeyNames = joinPart.groupBy.getKeyColumns.asScala
 
@@ -329,6 +331,7 @@ object JoinUtils {
           }
         }
     }
+    joinPart
   }
 
   def filterColumns(df: DataFrame, filter: Seq[String]): DataFrame = {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -24,7 +24,6 @@ import ai.chronon.spark.Extensions._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{coalesce, col, udf}
-import org.apache.spark.util.sketch.BloomFilter
 import org.slf4j.LoggerFactory
 
 import java.util
@@ -281,23 +280,6 @@ object JoinUtils {
     })
 
     labelMap.groupBy(_._2).map { case (v, kvs) => (v, tableUtils.chunk(kvs.keySet.toSet)) }
-  }
-
-  /**
-    * Generate a Bloom filter for 'joinPart' when the row count to be backfilled falls below a specified threshold.
-    * This method anticipates that there will likely be a substantial number of rows on the right side that need to be filtered out.
-    *
-    * @return bloomfilter map option for right part
-    */
-
-  def genBloomFilterIfNeeded(
-      joinPart: ai.chronon.api.JoinPart,
-      joinConf: ai.chronon.api.Join,
-      leftRowCount: Long,
-      unfilledRange: PartitionRange,
-      bloomMapOpt: Option[util.Map[String, BloomFilter]]): Option[util.Map[String, BloomFilter]] = {
-
-    rightBlooms
   }
 
   def injectKeyFilter(leftDf: DataFrame, joinPart: api.JoinPart): Unit = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
There are a few issues on the join keys filtering:
1. Bloom Filter
- We only have a unified join level bloom filter. However, now we compute Join Part tasks separately, so it makes more sense to generate the bloom filter per JP.
- bootstrap is always enabled once `useCachedLeft` is true, even though there is no actual bootstrap tables defined. Hence, we still need to generate the bloom filter, even though there is `matched_hashes` column.
2. SQL injection in the small mode
- whether the job should run in the small mode or not depends on the actual row count that needs to be backfilled. Especially in the case of bootstrap, the actual row count may far less than the left table row count. Hence, we move the small mode logic to the post-bootstrap step.


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested: Tested with internal datasets

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @pengyu-hou @yuli-han 
