### PR TITLE
Add deprecation date in metadata 

### DIFF
--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -367,6 +367,7 @@ def GroupBy(
     name: str = None,
     tags: Dict[str, str] = None,
     derivations: List[ttypes.Derivation] = None,
+    deprecationDate: str = None,
     **kwargs,
 ) -> ttypes.GroupBy:
     """
@@ -478,6 +479,9 @@ def GroupBy(
         Derivation allows arbitrary SQL select clauses to be computed using columns from the output of group by backfill
         output schema. It is supported for offline computations for now.
     :type derivations: List[ai.chronon.api.ttypes.Drivation]
+    :param deprecationDate:
+        Expected deprecation date of the group by. This is useful to track the deprecation status of the group by.
+    :type deprecationDate: str
     :param kwargs:
         Additional properties that would be passed to run.py if specified under additional_args property.
         And provides an option to pass custom values to the processing logic.
@@ -568,6 +572,7 @@ def GroupBy(
         tableProperties=table_properties,
         team=team,
         offlineSchedule=offline_schedule,
+        deprecationDate=deprecationDate,
     )
 
     group_by = ttypes.GroupBy(

--- a/api/py/ai/chronon/join.py
+++ b/api/py/ai/chronon/join.py
@@ -405,6 +405,7 @@ def Join(
     bootstrap_from_log: bool = False,
     label_part: api.LabelPart = None,
     derivations: List[api.Derivation] = None,
+    deprecationDate: str = None,
     tags: Dict[str, str] = None,
     **kwargs,
 ) -> api.Join:
@@ -502,6 +503,9 @@ def Join(
         Flag to indicate whether join backfill should backfill previous holes.
         Setting to false will only backfill latest single partition
     :type historical_backfill: bool
+    :param deprecationDate:
+        Expected deprecation date of the group by. This is useful to track the deprecation status of the group by.
+    :type deprecationDate: str
     :return:
         A join object that can be used to backfill or serve data. For ML use-cases this should map 1:1 to model.
     """
@@ -631,6 +635,7 @@ def Join(
         offlineSchedule=offline_schedule,
         consistencySamplePercent=consistency_sample_percent,
         historicalBackfill=historical_backfill,
+        deprecationDate=deprecationDate,
     )
 
     return api.Join(

--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -335,6 +335,10 @@ class ChrononRepoValidator(object):
                 errors.append("join {} is online but includes the following offline group_bys: {}".format(
                     join.metaData.name, ', '.join(offline_included_group_bys)))
         # Only validate the join derivation when the underlying groupBy is valid
+        # validate the expected deprecation date is in the correct format it is defined
+        if join.metaData.deprecationDate:
+            if not re.match(r"\d{4}-\d{2}-\d{2}", join.metaData.deprecationDate):
+                errors.append("Deprecation date is not in the correct format for join {}".format(join.metaData.name))
         group_by_correct = all(not errors for errors in group_by_errors)
         if join.derivations and group_by_correct:
             features = get_pre_derived_join_features(join)

--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -388,6 +388,11 @@ class ChrononRepoValidator(object):
                 columns = get_pre_derived_group_by_columns(group_by)
             errors.extend(self._validate_derivations(columns, group_by.derivations))
 
+        # validate the expected deprecation date is in the correct format it is defined
+        if group_by.metaData.deprecationDate:
+            if not re.match(r"\d{4}-\d{2}-\d{2}", group_by.metaData.deprecationDate):
+                errors.append("Deprecation date is not in the correct format for group_by {}".format(group_by.metaData.name))
+
         for source in group_by.sources:
             src: Source = source
             if src.events and src.events.isCumulative and (src.events.query.timeColumn is None):

--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -334,12 +334,12 @@ class ChrononRepoValidator(object):
             if offline_included_group_bys:
                 errors.append("join {} is online but includes the following offline group_bys: {}".format(
                     join.metaData.name, ', '.join(offline_included_group_bys)))
-        # Only validate the join derivation when the underlying groupBy is valid
         # validate the expected deprecation date is in the correct format it is defined
         if join.metaData.deprecationDate:
             if not re.match(r"\d{4}-\d{2}-\d{2}", join.metaData.deprecationDate):
                 errors.append("Deprecation date is not in the correct format for join {}".format(join.metaData.name))
         group_by_correct = all(not errors for errors in group_by_errors)
+        # Only validate the join derivation when the underlying groupBy is valid
         if join.derivations and group_by_correct:
             features = get_pre_derived_join_features(join)
             # For online joins keys are not included in output schema

--- a/api/py/test/sample/group_bys/sample_team/sample_deprecation_group_by.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_deprecation_group_by.py
@@ -1,0 +1,59 @@
+"""
+Sample group by
+"""
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from sources import test_sources
+from ai.chronon.group_by import (
+    GroupBy,
+    Aggregation,
+    Operation,
+    Window,
+    TimeUnit,
+)
+
+
+v1 = GroupBy(
+    sources=[
+        test_sources.events_until_20210409,
+        test_sources.events_after_20210409,
+    ],
+    keys=["group_by_subject"],
+    aggregations=[
+        Aggregation(input_column="event", operation=Operation.SUM),
+        Aggregation(input_column="event", operation=Operation.APPROX_PERCENTILE([0.5])),
+        Aggregation(input_column="event", operation=Operation.SUM, windows=[Window(7, TimeUnit.DAYS)]),
+    ],
+    additional_argument="To be placed in customJson",
+    online=True,
+    deprecationDate="2023-01-01",
+)
+
+v1_incorrect_deprecation_format = GroupBy(
+    sources=[
+        test_sources.events_until_20210409,
+        test_sources.events_after_20210409,
+    ],
+    keys=["group_by_subject"],
+    aggregations=[
+        Aggregation(input_column="event", operation=Operation.SUM),
+        Aggregation(input_column="event", operation=Operation.APPROX_PERCENTILE([0.5])),
+        Aggregation(input_column="event", operation=Operation.SUM, windows=[Window(7, TimeUnit.DAYS)]),
+    ],
+    additional_argument="To be placed in customJson",
+    online=True,
+    deprecationDate="2023-1-1",
+)

--- a/api/py/test/sample/production/group_bys/sample_team/sample_deprecation_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_deprecation_group_by.v1
@@ -1,0 +1,78 @@
+{
+  "metaData": {
+    "name": "sample_team.sample_deprecation_group_by.v1",
+    "online": 1,
+    "customJson": "{\"additional_argument\": \"To be placed in customJson\", \"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
+      "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "chronon_db",
+    "team": "sample_team",
+    "offlineSchedule": "@daily",
+    "deprecationDate": "2023-01-01"
+  },
+  "sources": [
+    {
+      "events": {
+        "table": "sample_namespace.sample_table_group_by",
+        "query": {
+          "selects": {
+            "group_by_subject": "group_by_subject_expr_old_version",
+            "event": "event_expr_old_version"
+          },
+          "startPartition": "2021-03-01",
+          "endPartition": "2021-04-09",
+          "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
+          "setups": []
+        }
+      }
+    },
+    {
+      "events": {
+        "table": "sample_namespace.another_sample_table_group_by",
+        "query": {
+          "selects": {
+            "group_by_subject": "possibly_different_group_by_subject_expr",
+            "event": "possibly_different_event_expr"
+          },
+          "startPartition": "2021-03-01",
+          "timeColumn": "__timestamp",
+          "setups": []
+        }
+      }
+    }
+  ],
+  "keyColumns": [
+    "group_by_subject"
+  ],
+  "aggregations": [
+    {
+      "inputColumn": "event",
+      "operation": 7,
+      "argMap": {}
+    },
+    {
+      "inputColumn": "event",
+      "operation": 12,
+      "argMap": {
+        "k": "128",
+        "percentiles": "[0.5]"
+      }
+    },
+    {
+      "inputColumn": "event",
+      "operation": 7,
+      "argMap": {},
+      "windows": [
+        {
+          "length": 7,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ]
+}

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -37,6 +37,11 @@ def test_basic_compile():
         '--input_path=joins/sample_team/sample_join.py'
     ])
     assert result.exit_code == 0
+    result = runner.invoke(extract_and_convert, [
+        '--chronon_root=test/sample',
+        '--input_path=group_bys/sample_team/sample_deprecation_group_by.py'
+    ])
+    assert result.exit_code == 0
 
 
 def test_debug_compile():

--- a/api/py/test/test_validator.py
+++ b/api/py/test/test_validator.py
@@ -135,3 +135,11 @@ def test_validate_join_with_derivations_on_external_parts(zvalidator):
     from sample.joins.sample_team.sample_join_with_derivations_on_external_parts import v1
     errors = zvalidator._validate_join(v1)
     assert(len(errors) == 0)
+
+
+def test_validate_group_by_deprecation_date(zvalidator):
+    from sample.group_bys.sample_team.sample_deprecation_group_by import v1, v1_incorrect_deprecation_format
+    errors = zvalidator._validate_group_by(v1)
+    assert(len(errors) == 0)
+    errors = zvalidator._validate_group_by(v1_incorrect_deprecation_format)
+    assert(len(errors) == 1)

--- a/api/src/main/scala/ai/chronon/api/Builders.scala
+++ b/api/src/main/scala/ai/chronon/api/Builders.scala
@@ -267,7 +267,8 @@ object Builders {
         samplePercent: Double = 100,
         consistencySamplePercent: Double = 5,
         tableProperties: Map[String, String] = Map.empty,
-        historicalBackill: Boolean = true
+        historicalBackill: Boolean = true,
+        deprecationDate: String = null
     ): MetaData = {
       val result = new MetaData()
       result.setName(name)
@@ -285,6 +286,8 @@ object Builders {
         result.setConsistencySamplePercent(consistencySamplePercent)
       if (tableProperties.nonEmpty)
         result.setTableProperties(tableProperties.toJava)
+      if (deprecationDate.nonEmpty)
+        result.setDeprecationDate(deprecationDate)
       result
     }
   }

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -257,6 +257,8 @@ struct MetaData {
     // Flag to indicate whether join backfill should backfill previous holes.
     // Setting to false will only backfill latest single partition
     14: optional bool historicalBackfill
+    // Optional expected deprecation date
+    15: optional string deprecationDate
 }
 
 // Equivalent to a FeatureSet in chronon terms
@@ -274,7 +276,7 @@ struct GroupBy {
     5: optional Accuracy accuracy
     // Optional start date for a group by backfill, if it's unset then no historical partitions will be generate
     6: optional string backfillStartDate
-    // support for offline only for now
+    // Optional derivation list
     7: optional list<Derivation> derivations
 }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Add an optional string field deprecationDate in metadata. Users can set up the deprecationDate in their python config and the data will be saved in metadata in json config. 

The optiona string filed has to be in format like YYYY-mm-DD, add validation code in validator to make sure the format is correct. 


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @pengyu-hou 
