### PR TITLE
Additional capabilities to compile.py

### DIFF
--- a/airflow/helpers.py
+++ b/airflow/helpers.py
@@ -116,9 +116,9 @@ def should_schedule(conf, mode, conf_type):
             # online + (realtime or has topic)
             online = conf["metaData"].get("online", 0) == 1
             streaming = requires_streaming_task(conf, conf_type)
-            return conf["metaData"].get("online", 0) == 1 and (
+            return online and (
                 conf["metaData"].get("accuracy", 1) == 0 or
-                requires_streaming_task(conf, conf_type)
+                streaming
             )
     if conf_type == "joins":
         if mode == "metadata-upload":

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -80,9 +80,7 @@ class Operation:
     LAST_K = collector(ttypes.Operation.LAST_K)
     TOP_K = collector(ttypes.Operation.TOP_K)
     BOTTOM_K = collector(ttypes.Operation.BOTTOM_K)
-    APPROX_PERCENTILE = generic_collector(
-        ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=128
-    )
+    APPROX_PERCENTILE = generic_collector(ttypes.Operation.APPROX_PERCENTILE, ["percentiles"], k=128)
 
 
 def Aggregations(**agg_dict):
@@ -105,13 +103,8 @@ def DefaultAggregation(keys, sources, operation=Operation.LAST, tags=None):
             "ds",
             query.timeColumn,
         ]
-        aggregate_columns += [
-            column for column in columns if column not in non_aggregate_columns
-        ]
-    return [
-        Aggregation(operation=operation, input_column=column, tags=tags)
-        for column in aggregate_columns
-    ]
+        aggregate_columns += [column for column in columns if column not in non_aggregate_columns]
+    return [Aggregation(operation=operation, input_column=column, tags=tags) for column in aggregate_columns]
 
 
 class TimeUnit:
@@ -201,8 +194,7 @@ def validate_group_by(group_by: ttypes.GroupBy):
     first_source_columns = set(utils.get_columns(sources[0]))
     # TODO undo this check after ml_models CI passes
     assert "ts" not in first_source_columns, (
-        "'ts' is a reserved key word for Chronon,"
-        " please specify the expression in timeColumn"
+        "'ts' is a reserved key word for Chronon," " please specify the expression in timeColumn"
     )
     for src in sources:
         query = utils.get_query(src)
@@ -212,19 +204,15 @@ def validate_group_by(group_by: ttypes.GroupBy):
                 "event source as it should be the same with timeColumn"
             )
             assert query.reversalColumn is None, (
-                "reversalColumn should not be specified for event source "
-                "as it won't have mutations"
+                "reversalColumn should not be specified for event source " "as it won't have mutations"
             )
             if group_by.accuracy != Accuracy.SNAPSHOT:
                 assert query.timeColumn is not None, (
-                    "please specify query.timeColumn for non-snapshot accurate "
-                    "group by with event source"
+                    "please specify query.timeColumn for non-snapshot accurate " "group by with event source"
                 )
         else:
             if contains_windowed_aggregation(aggregations):
-                assert (
-                    query.timeColumn
-                ), "Please specify timeColumn for entity source with windowed aggregations"
+                assert query.timeColumn, "Please specify timeColumn for entity source with windowed aggregations"
 
     column_set = None
     # all sources should select the same columns
@@ -247,10 +235,7 @@ Keys {unselected_keys}, are unselected in source
         has_mutations = (
             any(
                 [
-                    (
-                        s.entities.mutationTable is not None
-                        or s.entities.mutationTopic is not None
-                    )
+                    (s.entities.mutationTable is not None or s.entities.mutationTopic is not None)
                     for s in sources
                     if s.entities is not None
                 ]
@@ -277,9 +262,7 @@ Keys {unselected_keys}, are unselected in source
                     try:
                         percentile_array = json.loads(agg.argMap["percentiles"])
                         assert isinstance(percentile_array, list)
-                        assert all(
-                            [float(p) >= 0 and float(p) <= 1 for p in percentile_array]
-                        )
+                        assert all([float(p) >= 0 and float(p) <= 1 for p in percentile_array])
                     except Exception as e:
                         LOGGER.exception(e)
                         raise ValueError(
@@ -295,10 +278,7 @@ Keys {unselected_keys}, are unselected in source
             if agg.windows:
                 assert not (
                     # Snapshot accuracy.
-                    (
-                        (group_by.accuracy and group_by.accuracy == Accuracy.SNAPSHOT)
-                        or group_by.backfillStartDate
-                    )
+                    ((group_by.accuracy and group_by.accuracy == Accuracy.SNAPSHOT) or group_by.backfillStartDate)
                     and
                     # Hourly aggregation.
                     any([window.timeUnit == TimeUnit.HOURS for window in agg.windows])
@@ -310,9 +290,7 @@ Keys {unselected_keys}, are unselected in source
                 )
 
 
-_ANY_SOURCE_TYPE = Union[
-    ttypes.Source, ttypes.EventSource, ttypes.EntitySource, ttypes.JoinSource
-]
+_ANY_SOURCE_TYPE = Union[ttypes.Source, ttypes.EventSource, ttypes.EntitySource, ttypes.JoinSource]
 
 
 def _get_op_suffix(operation, argmap):
@@ -421,8 +399,8 @@ def GroupBy(
         system yourself.
     :type production: bool
     :param backfill_start_date:
-        Start date from which GroupBy data should be computed. This will determine how far back in time that Chronon would
-        go to compute the resultant table and its aggregations.
+        Start date from which GroupBy data should be computed. This will determine how far back in time
+        that Chronon would go to compute the resultant table and its aggregations.
     :type backfill_start_date: str
     :param dependencies:
         This goes into MetaData.dependencies - which is a list of strings representing the table partitions to wait for.
@@ -502,11 +480,7 @@ def GroupBy(
         query = (
             source.entities.query
             if source.entities is not None
-            else (
-                source.events.query
-                if source.events is not None
-                else source.joinSource.query
-            )
+            else (source.events.query if source.events is not None else source.joinSource.query)
         )
 
         if query.selects is None:
@@ -543,11 +517,7 @@ def GroupBy(
         sources = [sources]
     sources = [_sanitize_columns(_normalize_source(source)) for source in sources]
 
-    deps = [
-        dep
-        for src in sources
-        for dep in utils.get_dependencies(src, dependencies, lag=lag)
-    ]
+    deps = [dep for src in sources for dep in utils.get_dependencies(src, dependencies, lag=lag)]
 
     kwargs.update({"lag": lag})
     # get caller's filename to assign team

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -20,17 +20,24 @@
 import logging
 import os
 
-import click
-
 import ai.chronon.api.ttypes as api
 import ai.chronon.repo.extract_objects as eo
 import ai.chronon.utils as utils
+import click
 from ai.chronon.api.ttypes import GroupBy, Join, StagingQuery
-from ai.chronon.repo import JOIN_FOLDER_NAME, \
-    GROUP_BY_FOLDER_NAME, STAGING_QUERY_FOLDER_NAME, TEAMS_FILE_PATH
-from ai.chronon.repo import teams
+from ai.chronon.repo import (
+    GROUP_BY_FOLDER_NAME,
+    JOIN_FOLDER_NAME,
+    STAGING_QUERY_FOLDER_NAME,
+    TEAMS_FILE_PATH,
+    teams,
+)
 from ai.chronon.repo.serializer import thrift_simple_json_protected
-from ai.chronon.repo.validator import ChrononRepoValidator, get_join_output_columns, get_group_by_output_columns
+from ai.chronon.repo.validator import (
+    ChrononRepoValidator,
+    get_group_by_output_columns,
+    get_join_output_columns,
+)
 
 # This is set in the main function -
 # from command line or from env variable during invocation
@@ -48,31 +55,22 @@ def get_folder_name_from_class_name(class_name):
 
 
 @click.command()
+@click.option("--chronon_root", envvar="CHRONON_ROOT", help="Path to the root chronon folder", default=os.getcwd())
 @click.option(
-    '--chronon_root',
-    envvar='CHRONON_ROOT',
-    help='Path to the root chronon folder',
-    default=os.getcwd())
+    "--input_path",
+    "--conf",
+    "input_path",
+    help="Relative Path to the root chronon folder, which contains the objects to be serialized",
+    required=True,
+)
 @click.option(
-    '--input_path', '--conf', 'input_path',
-    help='Relative Path to the root chronon folder, which contains the objects to be serialized',
-    required=True)
-@click.option(
-    '--output_root',
-    help='Relative Path to the root chronon folder, to where the serialized output should be written',
-    default="production")
-@click.option(
-    '--debug',
-    help='debug mode',
-    is_flag=True)
-@click.option(
-    '--force-overwrite',
-    help='Force overwriting existing materialized conf.',
-    is_flag=True)
-@click.option(
-    '--feature-display',
-    help='Print out the features list created by the conf.',
-    is_flag=True)
+    "--output_root",
+    help="Relative Path to the root chronon folder, to where the serialized output should be written",
+    default="production",
+)
+@click.option("--debug", help="debug mode", is_flag=True)
+@click.option("--force-overwrite", help="Force overwriting existing materialized conf.", is_flag=True)
+@click.option("--feature-display", help="Print out the features list created by the conf.", is_flag=True)
 def extract_and_convert(chronon_root, input_path, output_root, debug, force_overwrite, feature_display):
     """
     CLI tool to convert Python chronon GroupBy's, Joins and Staging queries into their thrift representation.
@@ -85,7 +83,7 @@ def extract_and_convert(chronon_root, input_path, output_root, debug, force_over
     _print_highlighted("Using chronon root path", chronon_root)
     chronon_root_path = os.path.expanduser(chronon_root)
     utils.chronon_root_path = chronon_root_path
-    path_split = input_path.split('/')
+    path_split = input_path.split("/")
     obj_folder_name = path_split[0]
     obj_class = FOLDER_NAME_TO_CLASS[obj_folder_name]
     full_input_path = os.path.join(chronon_root_path, input_path)
@@ -99,7 +97,7 @@ def extract_and_convert(chronon_root, input_path, output_root, debug, force_over
     else:
         raise Exception(f"Input Path: {full_input_path}, isn't a file or a folder")
     validator = ChrononRepoValidator(chronon_root_path, output_root, log_level=log_level)
-    extra_online_bsd_group_bys = {}
+    extra_online_or_gb_backfill_enabled_group_bys = {}
     num_written_objs = 0
     full_output_root = os.path.join(chronon_root_path, output_root)
     teams_path = os.path.join(chronon_root_path, TEAMS_FILE_PATH)
@@ -115,34 +113,42 @@ def extract_and_convert(chronon_root, input_path, output_root, debug, force_over
 
             # In case of join, we need to materialize the following underlying group_bys
             # 1. group_bys whose online param is set
-            # 2. group_bys whose backfill_start_date (BSD) param is set.
+            # 2. group_bys whose backfill_start_date param is set.
             if obj_class is Join:
                 online_group_bys = {}
-                bsd_group_bys = {}
+                offline_backfill_enabled_group_bys = {}
                 offline_gbs = []  # gather list to report errors
                 for jp in obj.joinParts:
                     if jp.groupBy.metaData.online:
                         online_group_bys[jp.groupBy.metaData.name] = jp.groupBy
                     elif jp.groupBy.backfillStartDate:
-                        bsd_group_bys[jp.groupBy.metaData.name] = jp.groupBy
+                        offline_backfill_enabled_group_bys[jp.groupBy.metaData.name] = jp.groupBy
                     else:
                         offline_gbs.append(jp.groupBy.metaData.name)
-                logging.debug(f"Online GroupBys: {online_group_bys.keys()}, BSD GroupBys: {bsd_group_bys.keys()}, offline GroupBys: {offline_gbs}")
-                extra_online_bsd_group_bys.update({**online_group_bys, **bsd_group_bys})
+                logging.debug(
+                    f"Online GroupBys: {online_group_bys.keys()}, "
+                    f"Offline GroupBys with backfill enabled: {offline_backfill_enabled_group_bys.keys()}, "
+                    f"Offline GroupBys: {offline_gbs}"
+                )
+                extra_online_or_gb_backfill_enabled_group_bys.update(
+                    {**online_group_bys, **offline_backfill_enabled_group_bys}
+                )
                 if obj.metaData.online:
-                    group_bys_not_online = offline_gbs + list(bsd_group_bys.keys())
-                    assert not group_bys_not_online, \
-                        "You must make all dependent GroupBys `online` if you want to make your join [{}] `online`." \
-                        " You can do this by passing the `online=True` argument to the GroupBy constructor." \
+                    group_bys_not_online = offline_gbs + list(offline_backfill_enabled_group_bys.keys())
+                    assert not group_bys_not_online, (
+                        "You must make all dependent GroupBys `online` if you want to make your join [{}] `online`."
+                        " You can do this by passing the `online=True` argument to the GroupBy constructor."
                         " Fix the following: {}".format(obj.metaData.name, group_bys_not_online)
-    if extra_online_bsd_group_bys:
+                    )
+    if extra_online_or_gb_backfill_enabled_group_bys:
         _handle_extra_group_bys(
-            group_bys=extra_online_bsd_group_bys,
+            group_bys=extra_online_or_gb_backfill_enabled_group_bys,
             force_overwrite=force_overwrite,
             full_output_root=full_output_root,
             log_level=log_level,
             teams_path=teams_path,
-            validator=validator)
+            validator=validator,
+        )
     if num_written_objs > 0:
         print(f"Successfully wrote {num_written_objs} {(obj_class).__name__} objects to {full_output_root}")
 
@@ -154,19 +160,27 @@ def _print_features(obj, obj_class):
         _print_features_names("Output GroupBy Features", get_group_by_output_columns(obj))
 
 
-def _handle_extra_group_bys(group_bys, force_overwrite, full_output_root, log_level, teams_path,
-                            validator):
+def _handle_extra_group_bys(group_bys, force_overwrite, full_output_root, log_level, teams_path, validator):
     num_written_group_bys = 0
     # load materialized joins to validate the additional group_bys against.
     validator.load_objs()
     for name, obj in group_bys.items():
         team_name = name.split(".")[0]
         _set_team_level_metadata(obj, teams_path, team_name)
-        if _write_obj(full_output_root, validator, name, obj, log_level,
-                      # online and BSD GBs referenced in join compiled here
-                      force_compile=True, force_overwrite=force_overwrite):
+        if _write_obj(
+            full_output_root,
+            validator,
+            name,
+            obj,
+            log_level,
+            # online and offline GBs with backfill enabled referenced in join compiled here
+            force_compile=True,
+            force_overwrite=force_overwrite,
+        ):
             num_written_group_bys += 1
-    print(f"Successfully wrote {num_written_group_bys} online GroupBy objects to {full_output_root}")
+    print(
+        f"Successfully wrote {num_written_group_bys} online or backfill enabled GroupBy objects to {full_output_root}"
+    )
 
 
 def _set_team_level_metadata(obj: object, teams_path: str, team_name: str):
@@ -185,8 +199,8 @@ def _set_team_level_metadata(obj: object, teams_path: str, team_name: str):
 
 def __fill_template(table, obj, namespace):
     if table:
-        table = table.replace('{{ logged_table }}', utils.log_table_name(obj, full_name=True))
-        table = table.replace('{{ db }}', namespace)
+        table = table.replace("{{ logged_table }}", utils.log_table_name(obj, full_name=True))
+        table = table.replace("{{ db }}", namespace)
     return table
 
 
@@ -198,25 +212,28 @@ def _set_templated_values(obj, cls, teams_path, team_name):
         if obj.metaData.dependencies:
             obj.metaData.dependencies = [__fill_template(dep, obj, namespace) for dep in obj.metaData.dependencies]
     if cls == api.Join and obj.labelPart:
-        obj.labelPart.metaData.dependencies = [label_dep.replace('{{ join_backfill_table }}',
-                                                                 utils.output_table_name(obj, full_name=True))
-                                               for label_dep in obj.labelPart.metaData.dependencies]
+        obj.labelPart.metaData.dependencies = [
+            label_dep.replace("{{ join_backfill_table }}", utils.output_table_name(obj, full_name=True))
+            for label_dep in obj.labelPart.metaData.dependencies
+        ]
 
 
-def _write_obj(full_output_root: str,
-               validator: ChrononRepoValidator,
-               name: str,
-               obj: object,
-               log_level: int,
-               force_compile: bool = False,
-               force_overwrite: bool = False) -> bool:
+def _write_obj(
+    full_output_root: str,
+    validator: ChrononRepoValidator,
+    name: str,
+    obj: object,
+    log_level: int,
+    force_compile: bool = False,
+    force_overwrite: bool = False,
+) -> bool:
     """
     Returns True if the object is successfully written.
     """
     team_name = name.split(".")[0]
     obj_class = type(obj)
     class_name = obj_class.__name__
-    name = name.split('.', 1)[1]
+    name = name.split(".", 1)[1]
     _print_highlighted(f"{class_name} Team", team_name)
     _print_highlighted(f"{class_name} Name", name)
     obj_folder_name = get_folder_name_from_class_name(class_name)
@@ -224,15 +241,14 @@ def _write_obj(full_output_root: str,
     output_file = os.path.join(output_path, name)
     skip_reasons = validator.can_skip_materialize(obj)
     if not force_compile and skip_reasons:
-        reasons = ', '.join(skip_reasons)
+        reasons = ", ".join(skip_reasons)
         _print_warning(f"Skipping {class_name} {name}: {reasons}")
         if os.path.exists(output_file):
             _print_warning(f"old file exists for skipped config: {output_file}")
         return False
     validation_errors = validator.validate_obj(obj)
     if validation_errors:
-        _print_error(f"Could not write {class_name} {name}",
-                     ', '.join(validation_errors))
+        _print_error(f"Could not write {class_name} {name}", ", ".join(validation_errors))
         return False
     if force_overwrite:
         _print_warning(f"Force overwrite {class_name} {name}")
@@ -249,8 +265,9 @@ def _write_obj_as_json(name: str, obj: object, output_file: str, obj_class: type
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
     assert os.path.isdir(output_folder), f"{output_folder} isn't a folder."
-    assert (hasattr(obj, "name") or hasattr(obj, "metaData")), \
-        f"Can't serialize objects without the name attribute for object {name}"
+    assert hasattr(obj, "name") or hasattr(
+        obj, "metaData"
+    ), f"Can't serialize objects without the name attribute for object {name}"
     with open(output_file, "w") as f:
         _print_highlighted(f"Writing {class_name} to", output_file)
         f.write(thrift_simple_json_protected(obj, obj_class))
@@ -276,5 +293,5 @@ def _print_warning(string):
     print(f"\u001b[33m{string}\u001b[0m")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     extract_and_convert()

--- a/api/py/ai/chronon/repo/explore.py
+++ b/api/py/ai/chronon/repo/explore.py
@@ -79,7 +79,7 @@ HIGHLIGHT = BOLD + ITALIC + RED
 
 # walks the json nodes recursively collecting all values that match the path
 # a trailing `[]` in a field in the path indicates that there is an array of
-# object in the correspoding node value.
+# object in the corresponding node value.
 def extract_json(json_path, conf_json):
     if json_path is None:
         return conf_json

--- a/api/py/test/sample/group_bys/unit_test/entity_sample_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/entity_sample_group_by.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation
-)
-
 
 v1 = GroupBy(
     sources=test_sources.staging_entities,
@@ -35,5 +29,5 @@ require_backfill = GroupBy(
     aggregations=[
         Aggregation(input_column="impressed_unique_count_1d", operation=Operation.SUM),
     ],
-    backfill_start_date="2023-01-01"
+    backfill_start_date="2023-01-01",
 )

--- a/api/py/test/sample/group_bys/unit_test/event_sample_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/event_sample_group_by.py
@@ -1,0 +1,34 @@
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from sources import test_sources
+from ai.chronon.group_by import (
+    GroupBy,
+    Aggregation,
+    Operation,
+)
+
+
+v1 = GroupBy(
+    sources=test_sources.event_source,
+    keys=["group_by_subject"],
+    aggregations=[
+        Aggregation(
+            input_column="event",
+            operation=Operation.SUM
+        ),
+    ],
+    online=True,
+)

--- a/api/py/test/sample/group_bys/unit_test/sample_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/sample_group_by.py
@@ -1,0 +1,39 @@
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from sources import test_sources
+from ai.chronon.group_by import (
+    GroupBy,
+    Aggregation,
+    Operation
+)
+
+
+v1 = GroupBy(
+    sources=test_sources.staging_entities,
+    keys=["s2CellId", "place_id"],
+    aggregations=[
+        Aggregation(input_column="viewed_unique_count_1d", operation=Operation.SUM),
+    ],
+)
+
+require_backfill = GroupBy(
+    sources=test_sources.staging_entities,
+    keys=["s2CellId", "place_id"],
+    aggregations=[
+        Aggregation(input_column="impressed_unique_count_1d", operation=Operation.SUM),
+    ],
+    backfill_start_date="2023-01-01"
+)

--- a/api/py/test/sample/joins/unit_test/sample_join.py
+++ b/api/py/test/sample/joins/unit_test/sample_join.py
@@ -16,24 +16,19 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.unit_test import (
-    event_sample_group_by,
-    sample_group_by
-)
-
 from ai.chronon.join import Join, JoinPart
-
+from group_bys.unit_test import entity_sample_group_by, event_sample_group_by
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
-            group_by=sample_group_by.require_backfill,
+            group_by=entity_sample_group_by.require_backfill,
         ),
     ],
 )

--- a/api/py/test/sample/joins/unit_test/sample_join.py
+++ b/api/py/test/sample/joins/unit_test/sample_join.py
@@ -1,0 +1,39 @@
+"""
+Sample Join
+"""
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from sources import test_sources
+from group_bys.unit_test import (
+    event_sample_group_by,
+    sample_group_by
+)
+
+from ai.chronon.join import Join, JoinPart
+
+
+v1 = Join(
+    left=test_sources.event_source,
+    right_parts=[
+        JoinPart(
+            group_by=event_sample_group_by.v1,
+            key_mapping={'subject': 'group_by_subject'},
+        ),
+        JoinPart(
+            group_by=sample_group_by.require_backfill,
+        ),
+    ],
+)

--- a/api/py/test/sample/joins/unit_test/sample_online_join.py
+++ b/api/py/test/sample/joins/unit_test/sample_online_join.py
@@ -1,0 +1,36 @@
+"""
+Sample Join
+"""
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from sources import test_sources
+from group_bys.unit_test import (
+    event_sample_group_by
+)
+
+from ai.chronon.join import Join, JoinPart
+
+
+v1 = Join(
+    left=test_sources.event_source,
+    right_parts=[
+        JoinPart(
+            group_by=event_sample_group_by.v1,
+            key_mapping={'subject': 'group_by_subject'},
+        ),
+    ],
+    online=True,
+)

--- a/api/py/test/sample/joins/unit_test/sample_online_join_with_gb_not_online.py
+++ b/api/py/test/sample/joins/unit_test/sample_online_join_with_gb_not_online.py
@@ -1,0 +1,35 @@
+"""
+Sample Join with GBs that are online and requires backfill
+"""
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from sources import test_sources
+from group_bys.unit_test import (
+    sample_group_by,
+)
+
+from ai.chronon.join import Join, JoinPart
+
+
+v1 = Join(
+    left=test_sources.event_source,
+    right_parts=[
+        JoinPart(
+            group_by=sample_group_by.v1
+        ),
+    ],
+    online=True,
+)

--- a/api/py/test/sample/joins/unit_test/sample_online_join_with_gb_not_online.py
+++ b/api/py/test/sample/joins/unit_test/sample_online_join_with_gb_not_online.py
@@ -16,20 +16,14 @@ Sample Join with GBs that are online and requires backfill
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
-from group_bys.unit_test import (
-    sample_group_by,
-)
-
 from ai.chronon.join import Join, JoinPart
-
+from group_bys.unit_test import entity_sample_group_by
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
-        JoinPart(
-            group_by=sample_group_by.v1
-        ),
+        JoinPart(group_by=entity_sample_group_by.v1),
     ],
     online=True,
 )

--- a/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
@@ -1,0 +1,48 @@
+{
+  "metaData": {
+    "name": "sample_team.sample_group_by_group_by.v1",
+    "production": 0,
+    "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "sample_config_json": "{\"sample_key\": \"sample_value\"}",
+      "description": "sample description"
+    },
+    "outputNamespace": "sample_namespace",
+    "team": "sample_team",
+    "offlineSchedule": "@daily"
+  },
+  "sources": [
+    {
+      "events": {
+        "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
+        "query": {
+          "selects": {
+            "event": "event_expr",
+            "group_by_subject": "group_by_expr",
+            "s2CellId": "s2CellId",
+            "place_id": "place_id",
+            "impressed_unique_count_1d_sum": "impressed_unique_count_1d_sum"
+          },
+          "startPartition": "2021-04-09",
+          "timeColumn": "ts",
+          "setups": []
+        }
+      }
+    }
+  ],
+  "keyColumns": [
+    "s2CellId",
+    "place_id"
+  ],
+  "aggregations": [
+    {
+      "inputColumn": "impressed_unique_count_1d_sum",
+      "operation": 3,
+      "argMap": {}
+    }
+  ],
+  "backfillStartDate": "2022-01-01"
+}

--- a/api/py/test/sample/teams.json
+++ b/api/py/test/sample/teams.json
@@ -51,11 +51,15 @@
         }
     },
     "kaggle": {
-        "description": "Workspace for kaggle compeitions",
+        "description": "Workspace for kaggle competitions",
         "namespace": "default"
     },
     "quickstart": {
         "description": "Used for the quickstart example",
+        "namespace": "default"
+    },
+      "unit_test": {
+        "description": "Used for the unit test cases",
         "namespace": "default"
     }
 }

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -16,9 +16,48 @@ Run the flow for materialize.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+import os
+import pytest
+import shutil
+
 from ai.chronon.repo.compile import extract_and_convert
 from click.testing import CliRunner
 
+CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Utility functions
+def _get_full_file_path(relative_path):
+    """Utility function to get the full file path based on a relative path."""
+    return os.path.join(CURRENT_FILE_DIR, relative_path)
+
+def _invoke_cli_with_params(runner, input_path):
+    """Invoke the CLI command with consistent options and specified input_path."""
+    result = runner.invoke(extract_and_convert, [
+        '--chronon_root=test/sample',
+        f'--input_path={input_path}',
+        '--debug',
+    ])
+    return result
+
+def _assert_file_exists(full_file_path, message):
+    """Assert that a file exists at the specified path."""
+    assert os.path.isfile(full_file_path), message
+
+@pytest.fixture
+def specific_setup():
+    # This setup code will only run for tests that request this fixture
+    yield # This is where the testing happens
+    # Teardown phase: Cleanup after tests
+    current_file_dir = os.path.dirname(os.path.abspath(__file__))
+    directories_to_clean = [
+        'sample/production/joins/unit_test/',
+        'sample/production/group_bys/unit_test/'
+    ]
+
+    for relative_path in directories_to_clean:
+        full_path = os.path.join(current_file_dir, relative_path)
+        if os.path.exists(full_path):
+            shutil.rmtree(full_path)
 
 def test_basic_compile():
     runner = CliRunner()
@@ -43,7 +82,6 @@ def test_basic_compile():
     ])
     assert result.exit_code == 0
 
-
 def test_debug_compile():
     runner = CliRunner()
     result = runner.invoke(extract_and_convert, [
@@ -52,7 +90,6 @@ def test_debug_compile():
         '--debug'
     ])
     assert result.exit_code == 0
-
 
 def test_failed_compile():
     """
@@ -64,6 +101,44 @@ def test_failed_compile():
     ])
     assert result.exit_code != 0
 
+def test_failed_compile_online_join_not_online_gb(specific_setup):
+    """
+    Raises an error when compiling an online join that references a group_by that is not online.
+    """
+    runner = CliRunner()
+    result = _invoke_cli_with_params(runner, 'joins/unit_test/sample_online_join_with_gb_not_online.py')
+
+    error_message_expected = "Fix the following: ['unit_test.sample_group_by.v1']"
+    assert result.exit_code != 0, "Command unexpectedly succeeded, but an error was expected."
+    assert error_message_expected in str(result.exception), "Got a different message than expected."
+    assert isinstance(result.exception, AssertionError), "Expected an AssertionError, but got a different exception or no exception."
+
+def test_compiling_online_join_compiles_all_online_gb(specific_setup):
+    """
+    Test that compiling an online join correctly materializes all online group_bys.
+    """
+    runner = CliRunner()
+    result = _invoke_cli_with_params(runner, 'joins/unit_test/sample_online_join.py')
+    assert result.exit_code == 0
+
+    full_file_path = _get_full_file_path('sample/production/group_bys/unit_test/event_sample_group_by.v1')
+    _assert_file_exists(full_file_path, "Expected the group_by to be materialized, but it was not.")
+
+def test_compiling_join_compiles_online_bsd_gb(specific_setup):
+    """
+    Test that compiling a join correctly materializes online group_bys and those with backfillStartDate set.
+    """
+    runner = CliRunner()
+    result = _invoke_cli_with_params(runner, 'joins/unit_test/sample_join.py')
+    assert result.exit_code == 0
+
+    paths_to_check = [
+        'sample/production/group_bys/unit_test/event_sample_group_by.v1',
+        'sample/production/group_bys/unit_test/sample_group_by.require_backfill'
+    ]
+    for path in paths_to_check:
+        full_file_path = _get_full_file_path(path)
+        _assert_file_exists(full_file_path, f"Expected {os.path.basename(path)} to be materialized, but it was not.")
 
 def test_failed_compile_missing_input_column():
     """

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -17,137 +17,149 @@ Run the flow for materialize.
 #     limitations under the License.
 
 import os
-import pytest
 import shutil
 
+import pytest
 from ai.chronon.repo.compile import extract_and_convert
 from click.testing import CliRunner
 
 CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 # Utility functions
 def _get_full_file_path(relative_path):
     """Utility function to get the full file path based on a relative path."""
     return os.path.join(CURRENT_FILE_DIR, relative_path)
 
+
 def _invoke_cli_with_params(runner, input_path):
     """Invoke the CLI command with consistent options and specified input_path."""
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        f'--input_path={input_path}',
-        '--debug',
-    ])
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            f"--input_path={input_path}",
+            "--debug",
+        ],
+    )
     return result
+
 
 def _assert_file_exists(full_file_path, message):
     """Assert that a file exists at the specified path."""
     assert os.path.isfile(full_file_path), message
 
+
 @pytest.fixture
 def specific_setup():
     # This setup code will only run for tests that request this fixture
-    yield # This is where the testing happens
+    yield  # This is where the testing happens
     # Teardown phase: Cleanup after tests
     current_file_dir = os.path.dirname(os.path.abspath(__file__))
-    directories_to_clean = [
-        'sample/production/joins/unit_test/',
-        'sample/production/group_bys/unit_test/'
-    ]
+    directories_to_clean = ["sample/production/joins/unit_test/", "sample/production/group_bys/unit_test/"]
 
     for relative_path in directories_to_clean:
         full_path = os.path.join(current_file_dir, relative_path)
         if os.path.exists(full_path):
             shutil.rmtree(full_path)
 
+
 def test_basic_compile():
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team/'
-    ])
+    result = runner.invoke(extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/"])
     assert result.exit_code == 0
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team'
-    ])
+    result = runner.invoke(extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team"])
     assert result.exit_code == 0
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team/sample_join.py'
-    ])
+    result = runner.invoke(
+        extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/sample_join.py"]
+    )
     assert result.exit_code == 0
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=group_bys/sample_team/sample_deprecation_group_by.py'
-    ])
+    result = runner.invoke(
+        extract_and_convert,
+        ["--chronon_root=test/sample", "--input_path=group_bys/sample_team/sample_deprecation_group_by.py"],
+    )
     assert result.exit_code == 0
+
 
 def test_debug_compile():
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=joins/sample_team/',
-        '--debug'
-    ])
+    result = runner.invoke(
+        extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/", "--debug"]
+    )
     assert result.exit_code == 0
+
 
 def test_failed_compile():
     """
     Should fail as it fails to find teams.
     """
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--input_path=joins/sample_team/',
-    ])
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--input_path=joins/sample_team/",
+        ],
+    )
     assert result.exit_code != 0
+
 
 def test_failed_compile_online_join_not_online_gb(specific_setup):
     """
     Raises an error when compiling an online join that references a group_by that is not online.
     """
     runner = CliRunner()
-    result = _invoke_cli_with_params(runner, 'joins/unit_test/sample_online_join_with_gb_not_online.py')
+    result = _invoke_cli_with_params(runner, "joins/unit_test/sample_online_join_with_gb_not_online.py")
 
-    error_message_expected = "Fix the following: ['unit_test.sample_group_by.v1']"
+    error_message_expected = "Fix the following: ['unit_test.entity_sample_group_by.v1']"
     assert result.exit_code != 0, "Command unexpectedly succeeded, but an error was expected."
-    assert error_message_expected in str(result.exception), "Got a different message than expected."
-    assert isinstance(result.exception, AssertionError), "Expected an AssertionError, but got a different exception or no exception."
+    assert error_message_expected in str(
+        result.exception
+    ), f"Got a different message than expected.: {result.exception}"
+    assert isinstance(
+        result.exception, AssertionError
+    ), "Expected an AssertionError, but got a different exception or no exception."
+
 
 def test_compiling_online_join_compiles_all_online_gb(specific_setup):
     """
     Test that compiling an online join correctly materializes all online group_bys.
     """
     runner = CliRunner()
-    result = _invoke_cli_with_params(runner, 'joins/unit_test/sample_online_join.py')
+    result = _invoke_cli_with_params(runner, "joins/unit_test/sample_online_join.py")
     assert result.exit_code == 0
 
-    full_file_path = _get_full_file_path('sample/production/group_bys/unit_test/event_sample_group_by.v1')
+    full_file_path = _get_full_file_path("sample/production/group_bys/unit_test/event_sample_group_by.v1")
     _assert_file_exists(full_file_path, "Expected the group_by to be materialized, but it was not.")
+
 
 def test_compiling_join_compiles_online_bsd_gb(specific_setup):
     """
     Test that compiling a join correctly materializes online group_bys and those with backfillStartDate set.
     """
     runner = CliRunner()
-    result = _invoke_cli_with_params(runner, 'joins/unit_test/sample_join.py')
+    result = _invoke_cli_with_params(runner, "joins/unit_test/sample_join.py")
     assert result.exit_code == 0
 
     paths_to_check = [
-        'sample/production/group_bys/unit_test/event_sample_group_by.v1',
-        'sample/production/group_bys/unit_test/sample_group_by.require_backfill'
+        "sample/production/group_bys/unit_test/event_sample_group_by.v1",
+        "sample/production/group_bys/unit_test/entity_sample_group_by.require_backfill",
     ]
     for path in paths_to_check:
         full_file_path = _get_full_file_path(path)
         _assert_file_exists(full_file_path, f"Expected {os.path.basename(path)} to be materialized, but it was not.")
+
 
 def test_failed_compile_missing_input_column():
     """
     Should raise errors as we are trying to create aggregations without input column.
     """
     runner = CliRunner()
-    result = runner.invoke(extract_and_convert, [
-        '--chronon_root=test/sample',
-        '--input_path=group_bys/sample_team/sample_group_by_missing_input_column.py',
-        '--debug'
-    ])
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=group_bys/sample_team/sample_group_by_missing_input_column.py",
+            "--debug",
+        ],
+    )
     assert result.exit_code != 0


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Additional capabilities to compile.py
1. If a join (not online) references a group_by that has a backfill_start_date set, group_by will be materialized
2. If a join (not online) references a group_by that is online, group_by will be materialized

PR contains other minor doc and code fixes

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Above capabilities help keep the python configurations the JSON materialized files in sync

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @hzding621 @donghanz @yuli-han @pkundurthy 
