### PR TITLE
Adding `--table-display` option to compile to list related tables and the associated modes and sub_stages in compile.py

### DIFF
--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -287,7 +287,7 @@ def _print_features(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, Group
 
 
 def _print_tables(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]]) -> None:
-    _, tables = utils.get_modes_tables(obj)
+    tables = utils.get_modes_tables(obj)
     if obj_class is Join:
         _print_modes_tables("Output Join Tables", tables)
     if obj_class is GroupBy:

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -17,8 +17,10 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+import json
 import logging
 import os
+import textwrap
 from typing import Optional, Tuple, Type, Union
 
 import ai.chronon.api.ttypes as api
@@ -73,7 +75,12 @@ def get_folder_name_from_class_name(class_name):
 @click.option("--debug", help="debug mode", is_flag=True)
 @click.option("--force-overwrite", help="Force overwriting existing materialized conf.", is_flag=True)
 @click.option("--feature-display", help="Print out the features list created by the conf.", is_flag=True)
-def extract_and_convert(chronon_root, input_path, output_root, debug, force_overwrite, feature_display):
+@click.option(
+    "--table-display",
+    help="Print out the list of tables that are materialized per job modes in this conf.",
+    is_flag=True,
+)
+def extract_and_convert(chronon_root, input_path, output_root, debug, force_overwrite, feature_display, table_display):
     """
     CLI tool to convert Python chronon GroupBy's, Joins and Staging queries into their thrift representation.
     The materialized objects are what will be submitted to spark jobs - driven by airflow, or by manual user testing.
@@ -118,6 +125,9 @@ def extract_and_convert(chronon_root, input_path, output_root, debug, force_over
 
             if feature_display:
                 _print_features(obj, obj_class)
+
+            if table_display:
+                _print_tables(obj, obj_class)
 
             # In case of join, we need to materialize the following underlying group_bys
             # 1. group_bys whose online param is set
@@ -276,6 +286,14 @@ def _print_features(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, Group
         _print_features_names("Output GroupBy Features", get_group_by_output_columns(obj))
 
 
+def _print_tables(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]]) -> None:
+    _, tables = utils.get_modes_tables(obj)
+    if obj_class is Join:
+        _print_modes_tables("Output Join Tables", tables)
+    if obj_class is GroupBy:
+        _print_modes_tables("Output GroupBy Tables", tables)
+
+
 def _handle_extra_conf_objects_to_materialize(
     conf_objs,
     force_overwrite: bool,
@@ -409,6 +427,11 @@ def _print_highlighted(left, right):
 def _print_features_names(left, right):
     # Print in green and separate lines.
     print(f"{left:>25} - \u001b[32m{right}\u001b[0m")
+
+
+def _print_modes_tables(left, right):
+    text = textwrap.indent(json.dumps(right, indent=2), " " * 27)
+    print(f"{left:>25} - \u001b[32m\n{text}\u001b[0m")
 
 
 def _print_error(left, right):

--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -22,7 +22,7 @@ import subprocess
 import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass, fields
-from typing import List, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast
 
 import ai.chronon.api.ttypes as api
 import ai.chronon.repo.extract_objects as eo
@@ -402,7 +402,7 @@ def requires_log_flattening_task(conf: ChrononJobTypes) -> bool:
     return (conf.metaData.samplePercent or 0) > 0
 
 
-def get_modes_tables(conf: ChrononJobTypes) -> List[str]:
+def get_modes_tables(conf: ChrononJobTypes) -> Dict[str, List[str]]:
     """Based on a conf get all the applicable modes and tables"""
 
     if conf.metaData.name:

--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import tempfile
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import List, Optional, Union, cast
 
 import ai.chronon.api.ttypes as api
@@ -30,6 +31,24 @@ from ai.chronon.repo import TEAMS_FILE_PATH, teams
 ChrononJobTypes = Union[api.GroupBy, api.Join, api.StagingQuery]
 
 chronon_root_path = ""  # passed from compile.py
+
+
+@dataclass
+class Modes:
+    backfill = "backfill"
+    upload = "upload"
+    streaming = "streaming"
+    stats_summary = "stats-summary"
+    label_join = "label-join"
+    log_flattener = "log-flattener"
+    consistency_metrics_compute = "consistency-metrics-compute"
+
+
+@dataclass
+class SubStage:
+    bootstrap = "bootstrap"
+    join_parts = "join_parts"
+    backfill_left = "backfill-left"
 
 
 def edit_distance(str1, str2):
@@ -384,67 +403,86 @@ def requires_log_flattening_task(conf: ChrononJobTypes) -> bool:
     return (conf.metaData.samplePercent or 0) > 0
 
 
-def get_applicable_modes(conf: ChrononJobTypes) -> List[str]:
-    """Based on a conf and mode determine if a conf should define a task."""
-    modes = []  # type: List[str]
+def get_modes_tables(conf: ChrononJobTypes) -> List[str]:
+    """Based on a conf get all the applicable modes and tables"""
 
+    if conf.metaData.name:
+        table_name = output_table_name(conf, full_name=True)
+    else:
+        table_name = output_table_name(conf, full_name=False)
+
+    modes = []
+    tables = {}
+
+    # from GroupBy
     if isinstance(conf, api.GroupBy):
         group_by = cast(api.GroupBy, conf)
         if group_by.backfillStartDate is not None:
-            modes.append("backfill")
+            modes.append(Modes.backfill)
+            tables[Modes.backfill] = [f"{table_name}"]
 
         online = group_by.metaData.online or False
-
         if online:
-            modes.append("upload")
+            modes.append(Modes.upload)
+            tables[Modes.upload] = [f"{table_name}_upload"]
 
             temporal_accuracy = group_by.accuracy or False
             streaming = has_topic(group_by)
             if temporal_accuracy or streaming:
-                modes.append("streaming")
+                modes.append(Modes.streaming)
+    # from Join
     elif isinstance(conf, api.Join):
         join = cast(api.Join, conf)
         if get_offline_schedule(conf) is not None:
-            modes.append("backfill")
-            modes.append("stats-summary")
+            modes.append(Modes.backfill)
+            modes.append(Modes.stats_summary)
+            tables[Modes.backfill] = [f"{table_name}"]
+            tables[Modes.stats_summary] = [f"{table_name}_daily_stats"]
         if (
             join.metaData.customJson is not None
             and json.loads(join.metaData.customJson).get("check_consistency") is True
         ):
-            modes.append("consistency-metrics-compute")
+            modes.append(Modes.consistency_metrics_compute)
+            tables[Modes.consistency_metrics_compute] = [f"{table_name}_consistency"]
         if requires_log_flattening_task(join):
-            modes.append("log-flattener")
+            modes.append(Modes.log_flattener)
+            tables[Modes.log_flattener] = [f"{table_name}_logged"]
         if join.labelPart is not None:
-            modes.append("label-join")
+            modes.append(Modes.label_join)
+            tables[Modes.label_join] = [f"{table_name}_labels", f"{table_name}_labeled", f"{table_name}_labeled_latest"]
+
+        if conf.bootstrapParts:
+            tables[SubStage.bootstrap] = [f"{table_name}_bootstrap"]
+
+        if conf.joinParts:
+            tables[SubStage.join_parts] = [join_part_output_table_name(conf, jp) for jp in conf.joinParts]
+    # from StagingQuery
     elif isinstance(conf, api.StagingQuery):
-        modes.append("backfill")
+        modes.append(Modes.backfill)
+        tables[Modes.backfill] = [f"{table_name}"]
     else:
         raise ValueError(f"Unsupported job type {type(conf).__name__}")
 
+    return modes, tables
+
+
+def get_applicable_modes(conf: ChrononJobTypes) -> List[str]:
+    """Based on a conf and mode determine if a conf should define a task."""
+    modes, _ = get_modes_tables(conf)  # type: List[str]
     return modes
 
 
-def get_related_table_names(conf: ChrononJobTypes) -> List[str]:
-    table_name = output_table_name(conf, full_name=True)
+def get_related_table_names(conf: ChrononJobTypes, skip_join_parts=True) -> List[str]:
+    """Based on a conf get all the related tables"""
 
-    applicable_modes = set(get_applicable_modes(conf))
+    _, tables = get_modes_tables(conf)
     related_tables = []  # type: List[str]
 
-    if "upload" in applicable_modes:
-        related_tables.append(f"{table_name}_upload")
-    if "stats-summary" in applicable_modes:
-        related_tables.append(f"{table_name}_daily_stats")
-    if "label-join" in applicable_modes:
-        related_tables.append(f"{table_name}_labels")
-        related_tables.append(f"{table_name}_labeled")
-        related_tables.append(f"{table_name}_labeled_latest")
-    if "log-flattener" in applicable_modes:
-        related_tables.append(f"{table_name}_logged")
-    if "consistency-metrics-compute" in applicable_modes:
-        related_tables.append(f"{table_name}_consistency")
+    for m in tables:
+        if skip_join_parts and m == SubStage.join_parts:
+            continue
 
-    if isinstance(conf, api.Join) and conf.bootstrapParts:
-        related_tables.append(f"{table_name}_bootstrap")
+        related_tables.extend(tables[m])
 
     return related_tables
 

--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -48,7 +48,6 @@ class Modes:
 class SubStage:
     bootstrap = "bootstrap"
     join_parts = "join_parts"
-    backfill_left = "backfill-left"
 
 
 def edit_distance(str1, str2):

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -272,3 +272,41 @@ def test_detected_dependent_nested_joins():
     expected_message = "Successfully wrote 1 Join objects to test/sample/production".strip().lower()
     actual_message = str(result.output).strip().lower()
     assert expected_message in actual_message, f"Got a different message than expected {actual_message}"
+
+
+def test_compile_table_display():
+    """
+    Test that compiling an online join correctly materializes all online group_bys.
+    """
+    runner = CliRunner()
+    input_path = f"joins/sample_team/sample_join_with_derivations_on_external_parts.py"
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            f"--input_path={input_path}",
+            "--table-display",
+        ],
+    )
+
+    assert "Output Join Tables" in result.output
+    assert result.exit_code == 0
+
+
+def test_compile_feature_display():
+    """
+    Test that compiling an online join correctly materializes all online group_bys.
+    """
+    runner = CliRunner()
+    input_path = f"joins/sample_team/sample_join_with_derivations_on_external_parts.py"
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            f"--input_path={input_path}",
+            "--feature-display",
+        ],
+    )
+
+    assert "Output Join Features" in result.output
+    assert result.exit_code == 0

--- a/api/py/test/test_utils.py
+++ b/api/py/test/test_utils.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +13,11 @@
 #     limitations under the License.
 
 import os
-import json
-from ai.chronon.repo.serializer import json2thrift, file2thrift
-from ai.chronon import utils
+
 import ai.chronon.api.ttypes as api
 import pytest
+from ai.chronon import utils
+from ai.chronon.repo.serializer import file2thrift, json2thrift
 
 
 @pytest.fixture
@@ -28,6 +27,7 @@ def event_group_by():
     This is an event source, not streaming
     """
     from sample.group_bys.sample_team.sample_group_by_from_module import v1
+
     return v1
 
 
@@ -43,57 +43,65 @@ def event_source(event_group_by):
 @pytest.fixture
 def group_by_requiring_backfill():
     from sample.group_bys.sample_team.sample_group_by import require_backfill
-    #utils.__set_name(group_by_requiring_backfill, api.GroupBy, "group")
+
+    # utils.__set_name(group_by_requiring_backfill, api.GroupBy, "group")
     return require_backfill
 
 
 @pytest.fixture
 def online_group_by_requiring_streaming():
     from sample.group_bys.sample_team.entity_sample_group_by_from_module import v1
+
     return v1
 
 
 @pytest.fixture
 def basic_staging_query():
     from sample.staging_queries.sample_team.sample_staging_query import v1
+
     return v1
 
 
 @pytest.fixture
 def basic_join():
     from sample.joins.sample_team.sample_join import v1
+
     return v1
 
 
 @pytest.fixture
 def never_scheduled_join():
     from sample.joins.sample_team.sample_join import never
+
     return never
 
 
 @pytest.fixture
 def consistency_check_join():
     from sample.joins.sample_team.sample_join import consistency_check
+
     return consistency_check
 
 
 @pytest.fixture
 def no_log_flattener_join():
     from sample.joins.sample_team.sample_join import no_log_flattener
+
     return no_log_flattener
 
 
 @pytest.fixture
 def label_part_join():
     from sample.joins.sample_team.sample_label_join import v1
+
     return v1
 
 
 def test_edit_distance():
-    assert utils.edit_distance('test', 'test') == 0
-    assert utils.edit_distance('test', 'testy') > 0
+    assert utils.edit_distance("test", "test") == 0
+    assert utils.edit_distance("test", "testy") > 0
     assert utils.edit_distance("test", "testing") <= (
-            utils.edit_distance("test", "tester") + utils.edit_distance("tester", "testing")
+        utils.edit_distance("test", "tester") + utils.edit_distance("tester", "testing")
     )
 
 
@@ -112,10 +120,7 @@ def test_dedupe_in_order():
     assert utils.dedupe_in_order([2, 1, 3, 1, 3, 2]) == [2, 1, 3]
 
 
-def test_get_applicable_mode_for_group_bys(
-        group_by_requiring_backfill,
-        online_group_by_requiring_streaming
-):
+def test_get_applicable_mode_for_group_bys(group_by_requiring_backfill, online_group_by_requiring_streaming):
     modes = utils.get_applicable_modes(group_by_requiring_backfill)
     assert "backfill" in modes
     assert "upload" not in modes
@@ -132,11 +137,7 @@ def test_get_applicable_mode_for_staging_query(basic_staging_query):
 
 
 def test_get_applicable_mode_for_joins(
-        basic_join,
-        never_scheduled_join,
-        consistency_check_join,
-        no_log_flattener_join,
-        label_part_join
+    basic_join, never_scheduled_join, consistency_check_join, no_log_flattener_join, label_part_join
 ):
     modes = utils.get_applicable_modes(basic_join)
     assert "backfill" in modes
@@ -162,11 +163,8 @@ def test_get_applicable_mode_for_joins(
     assert "label-join" in modes
 
 
-def test_get_related_table_names_for_group_bys(
-        group_by_requiring_backfill,
-        online_group_by_requiring_streaming
-):
-    with open('test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1') as conf_file:
+def test_get_related_table_names_for_group_bys(group_by_requiring_backfill, online_group_by_requiring_streaming):
+    with open("test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1") as conf_file:
         json = conf_file.read()
         group_by = json2thrift(json, api.GroupBy)
         tables = utils.get_related_table_names(group_by)
@@ -174,7 +172,7 @@ def test_get_related_table_names_for_group_bys(
 
 
 def test_get_related_table_names_for_group_bys():
-    with open('test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1') as conf_file:
+    with open("test/sample/production/group_bys/sample_team/entity_sample_group_by_from_module.v1") as conf_file:
         json = conf_file.read()
         group_by = json2thrift(json, api.GroupBy)
         tables = utils.get_related_table_names(group_by)
@@ -190,7 +188,7 @@ def test_get_related_table_names_for_group_bys():
 
 
 def test_get_related_table_names_for_simple_joins():
-    with open('test/sample/production/joins/sample_team/sample_join.v1') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_join.v1") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -208,7 +206,7 @@ def test_get_related_table_names_for_simple_joins():
 
 
 def test_get_related_table_names_for_label_joins():
-    with open('test/sample/production/joins/sample_team/sample_label_join.v1') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_label_join.v1") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -227,7 +225,7 @@ def test_get_related_table_names_for_label_joins():
 
 
 def test_get_related_table_names_for_consistency_joins():
-    with open('test/sample/production/joins/sample_team/sample_join.consistency_check') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_join.consistency_check") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -246,7 +244,7 @@ def test_get_related_table_names_for_consistency_joins():
 
 
 def test_get_related_table_names_for_bootstrap_joins():
-    with open('test/sample/production/joins/sample_team/sample_join_bootstrap.v1') as conf_file:
+    with open("test/sample/production/joins/sample_team/sample_join_bootstrap.v1") as conf_file:
         json = conf_file.read()
         join = json2thrift(json, api.Join)
         tables = utils.get_related_table_names(join)
@@ -264,8 +262,32 @@ def test_get_related_table_names_for_bootstrap_joins():
         assert not any(table.endswith("_consistency") for table in tables)
 
 
+def test_tables_with_without_skip_join_parts():
+    with open("test/sample/production/joins/sample_team/sample_join_bootstrap.v1") as conf_file:
+        json = conf_file.read()
+        join = json2thrift(json, api.Join)
+        tables_without = utils.get_related_table_names(join)
+        tables_with = utils.get_related_table_names(join, skip_join_parts=False)
+
+        expected_tables = [
+            "chronon_db.sample_team_sample_join_bootstrap_v1",
+            "chronon_db.sample_team_sample_join_bootstrap_v1_daily_stats",
+            "chronon_db.sample_team_sample_join_bootstrap_v1_logged",
+            "chronon_db.sample_team_sample_join_bootstrap_v1_bootstrap",
+        ]
+
+        expected_join_parts = [
+            "sample_team_sample_join_bootstrap_v1_sample_team_event_sample_group_by_v1",
+            "sample_team_sample_join_bootstrap_v1_sample_team_entity_sample_group_by_from_module_v1",
+        ]
+
+        assert set(tables_without) == set(expected_tables)
+        assert set(tables_with) == set(expected_tables + expected_join_parts)
+
+
 @pytest.mark.parametrize(
-    "materialized_group_by,table_name", [
+    "materialized_group_by,table_name",
+    [
         ("entity_sample_group_by_from_module.v1", "chronon_db.sample_team_entity_sample_group_by_from_module_v1"),
         ("event_sample_group_by.v1", "sample_namespace.sample_team_event_sample_group_by_v1"),
         ("group_by_with_kwargs.v1", "chronon_db.sample_team_group_by_with_kwargs_v1"),
@@ -278,9 +300,12 @@ def test_group_by_table_names(repo, materialized_group_by, table_name):
 
 
 @pytest.mark.parametrize(
-    "materialized_join,table_name", [
-        ("sample_chaining_join.v1",
-         "chronon_db.sample_team_sample_chaining_join_v1_sample_team_sample_chaining_group_by"),
+    "materialized_join,table_name",
+    [
+        (
+            "sample_chaining_join.v1",
+            "chronon_db.sample_team_sample_chaining_join_v1_sample_team_sample_chaining_group_by",
+        ),
         ("sample_join.v1", "sample_namespace.sample_team_sample_join_v1_sample_team_sample_group_by_v1"),
     ],
 )

--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -22,7 +22,9 @@ compile.py --conf=path/to/your/chronon_file.py
 
 The path that you pass should either commence with `group_by/`, `join/`, or `staging_query/`
 
-This will produce one 
+This will produce JSON configs for each config in the given paths under the `production/` folder.
+
+There are also options to display generated features `--feature-display` or the `--table-display` to show related modes and tables that might be generated.
 
 ## Analyze
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
-  Modifying some utils that help tally tables generated by a config 
- utils function `get_modes_tables` as the central function to process configs to get modes, sub-stages and tables.
- applicable modes and substages are mapped to tables generated
- Update `compile.py` to output the related tables, modes and sub-stages
- Linting `compile.py`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- Having a list of applicable modes can make it easy to debug and understand particular tasks being created
- Having a list of related tables can help debug issues with data generation, and can also allow us to add features like WALL checks (airbnb-internal) and new partition sensors. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

example (e.g.)
```
command]$ materialize --input_path=joins/zipline_test/test_wall_checks_join.py --table-display

  Using chronon root path - /Users/praveen_kundurthy/airlab/repos/ml_models/zipline
         Input joins from - /Users/praveen_kundurthy/airlab/repos/ml_models/zipline/joins/zipline_test/test_wall_checks_join.py
                Join Team - zipline_test
                Join Name - test_wall_checks_join.v1
          Writing Join to - /Users/praveen_kundurthy/airlab/repos/ml_models/zipline/production/joins/zipline_test/test_wall_checks_join.v1
            Output Tables - 
                           {
                             "backfill": [
                               "zipline_test.zipline_test_test_wall_checks_join_v1"
                             ],
                             "stats-summary": [
                               "zipline_test.zipline_test_test_wall_checks_join_v1_daily_stats"
                             ],
                             "log-flattener": [
                               "zipline_test.zipline_test_test_wall_checks_join_v1_logged"
                             ],
                             "join_parts": [
                               "zipline_test_test_wall_checks_join_v1_zipline_test_test_online_groupby_wall_test_product_cases_aggregate",
                               "zipline_test_test_wall_checks_join_v1_zipline_test_test_online_groupby_wall_test_bookings_agg"
                             ]
                           }
             GroupBy Team - zipline_test
             GroupBy Name - test_online_groupby_wall_test.product_cases_aggregate
       Writing GroupBy to - /Users/praveen_kundurthy/airlab/repos/ml_models/zipline/production/group_bys/zipline_test/test_online_groupby_wall_test.product_cases_aggregate
             GroupBy Team - zipline_test
             GroupBy Name - test_online_groupby_wall_test.bookings_agg
       Writing GroupBy to - /Users/praveen_kundurthy/airlab/repos/ml_models/zipline/production/group_bys/zipline_test/test_online_groupby_wall_test.bookings_agg
Successfully wrote 2 online GroupBy objects to /Users/praveen_kundurthy/airlab/repos/ml_models/zipline/production
Successfully wrote 1 Join objects to /Users/praveen_kundurthy/airlab/repos/ml_models/zipline/production
```

## Checklist
- [x] Documentation update

## Reviewers
@hzding621 
