### PR TITLE
Materialize dependent GBs and Joins when materializing a python configuration

### DIFF
--- a/api/py/test/sample/group_bys/unit_test/sample_chaining_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/sample_chaining_group_by.py
@@ -1,0 +1,44 @@
+"""
+Sample Chaining Group By with join as a source
+"""
+
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from ai.chronon.api import ttypes
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
+from ai.chronon.query import Query, select
+from joins.unit_test import sample_parent_join
+
+chaining_group_by_v1 = GroupBy(
+    sources=ttypes.Source(
+        joinSource=ttypes.JoinSource(
+            join=sample_parent_join.parent_join,
+            query=Query(
+                selects=select(
+                    event="event_expr",
+                    group_by_subject="group_by_expr",
+                ),
+                start_partition="2023-04-15",
+                time_column="ts",
+            ),
+        )
+    ),
+    keys=["user_id"],
+    aggregations=[
+        Aggregation(input_column="event", operation=Operation.LAST),
+    ],
+    online=True,
+    production=True,
+)

--- a/api/py/test/sample/group_bys/unit_test/sample_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/sample_group_by.py
@@ -1,0 +1,28 @@
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
+from sources import test_sources
+
+v1 = GroupBy(
+    sources=test_sources.event_source,
+    keys=["group_by_subject"],
+    aggregations=[
+        Aggregation(
+            input_column="event",
+            operation=Operation.SUM,
+        ),
+    ],
+    online=True,
+)

--- a/api/py/test/sample/group_bys/unit_test/user/sample_nested_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/user/sample_nested_group_by.py
@@ -1,0 +1,33 @@
+from ai.chronon.api import ttypes
+from ai.chronon.api.ttypes import Aggregation, Operation, TimeUnit, Window
+from ai.chronon.group_by import Aggregations, GroupBy
+from ai.chronon.query import Query, select
+
+source = ttypes.Source(
+    events=ttypes.EventSource(
+        table="random_table_name",
+        query=Query(
+            selects=select(
+                user="id_item",
+                play="if(transaction_type='A', 1, 0)",
+                pause="if(transaction_type='B', 1, 0)",
+            ),
+            start_partition="2023-03-01",
+            time_column="UNIX_TIMESTAMP(ts) * 1000",
+        ),
+    )
+)
+
+windows = [
+    Window(length=30, timeUnit=TimeUnit.DAYS),
+]
+
+v1 = GroupBy(
+    keys=["user"],
+    sources=source,
+    aggregations=Aggregations(
+        play_count=Aggregation(operation=Operation.SUM, inputColumn="play", windows=windows),
+        pause_count=Aggregation(operation=Operation.SUM, inputColumn="pause", windows=windows),
+    ),
+    online=True,
+)

--- a/api/py/test/sample/joins/unit_test/sample_parent_join.py
+++ b/api/py/test/sample/joins/unit_test/sample_parent_join.py
@@ -1,0 +1,28 @@
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from ai.chronon.join import Join, JoinPart
+from group_bys.unit_test import sample_group_by
+from sources import test_sources
+
+parent_join = Join(
+    left=test_sources.event_source,
+    right_parts=[
+        JoinPart(
+            group_by=sample_group_by.v1,
+            key_mapping={"subject": "group_by_subject"},
+        ),
+    ],
+    online=True,
+)

--- a/api/py/test/sample/joins/unit_test/user/sample_transactions.py
+++ b/api/py/test/sample/joins/unit_test/user/sample_transactions.py
@@ -1,0 +1,23 @@
+# from airbnb.data_sources_2 import HiveEventSource
+from ai.chronon.api import ttypes
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, select
+from group_bys.unit_test.user.sample_nested_group_by import v1 as nested_v1
+
+source = ttypes.Source(
+    events=ttypes.EventSource(
+        table="item_snapshot",
+        query=Query(
+            selects=select(user="id_requester"),
+            wheres=["dim_requester_user_role = 'user'"],
+            start_partition="2023-03-01",
+            time_column="UNIX_TIMESTAMP(ts_created_at_utc) * 1000",
+        ),
+    )
+)
+
+v1 = Join(
+    left=source,
+    right_parts=[JoinPart(group_by=nested_v1)],
+    online=True,
+)

--- a/api/py/test/sample/production/group_bys/unit_test/sample_chaining_group_by.chaining_group_by_v1
+++ b/api/py/test/sample/production/group_bys/unit_test/sample_chaining_group_by.chaining_group_by_v1
@@ -1,0 +1,125 @@
+{
+  "metaData": {
+    "name": "unit_test.sample_chaining_group_by.chaining_group_by_v1",
+    "online": 1,
+    "production": 1,
+    "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_default.unit_test_sample_parent_join_parent_join_ds\", \"spec\": \"default.unit_test_sample_parent_join_parent_join/ds={{ ds }}\", \"start\": \"2023-04-15\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "offlineSchedule": "@daily"
+  },
+  "sources": [
+    {
+      "joinSource": {
+        "join": {
+          "metaData": {
+            "name": "unit_test.sample_parent_join.parent_join",
+            "online": 1,
+            "production": 0,
+            "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
+            "dependencies": [
+              "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+            ],
+            "tableProperties": {
+              "source": "chronon"
+            },
+            "outputNamespace": "default",
+            "team": "unit_test",
+            "samplePercent": 100.0,
+            "offlineSchedule": "@daily"
+          },
+          "left": {
+            "events": {
+              "table": "sample_namespace.sample_table_group_by",
+              "query": {
+                "selects": {
+                  "event": "event_expr",
+                  "group_by_subject": "group_by_expr",
+                  "ts": "ts"
+                },
+                "startPartition": "2021-04-09",
+                "timeColumn": "ts",
+                "setups": []
+              }
+            }
+          },
+          "joinParts": [
+            {
+              "groupBy": {
+                "metaData": {
+                  "name": "unit_test.sample_group_by.v1",
+                  "online": 1,
+                  "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+                  "dependencies": [
+                    "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+                  ],
+                  "tableProperties": {
+                    "source": "chronon"
+                  },
+                  "outputNamespace": "default",
+                  "team": "unit_test",
+                  "offlineSchedule": "@daily"
+                },
+                "sources": [
+                  {
+                    "events": {
+                      "table": "sample_namespace.sample_table_group_by",
+                      "query": {
+                        "selects": {
+                          "event": "event_expr",
+                          "group_by_subject": "group_by_expr"
+                        },
+                        "startPartition": "2021-04-09",
+                        "timeColumn": "ts",
+                        "setups": []
+                      }
+                    }
+                  }
+                ],
+                "keyColumns": [
+                  "group_by_subject"
+                ],
+                "aggregations": [
+                  {
+                    "inputColumn": "event",
+                    "operation": 7,
+                    "argMap": {}
+                  }
+                ]
+              },
+              "keyMapping": {
+                "subject": "group_by_subject"
+              }
+            }
+          ]
+        },
+        "query": {
+          "selects": {
+            "event": "event_expr",
+            "group_by_subject": "group_by_expr",
+            "user_id": "user_id"
+          },
+          "startPartition": "2023-04-15",
+          "timeColumn": "ts",
+          "setups": []
+        }
+      }
+    }
+  ],
+  "keyColumns": [
+    "user_id"
+  ],
+  "aggregations": [
+    {
+      "inputColumn": "event",
+      "operation": 3,
+      "argMap": {}
+    }
+  ]
+}

--- a/api/py/test/sample/production/group_bys/unit_test/sample_group_by.v1
+++ b/api/py/test/sample/production/group_bys/unit_test/sample_group_by.v1
@@ -1,0 +1,42 @@
+{
+  "metaData": {
+    "name": "unit_test.sample_group_by.v1",
+    "online": 1,
+    "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "offlineSchedule": "@daily"
+  },
+  "sources": [
+    {
+      "events": {
+        "table": "sample_namespace.sample_table_group_by",
+        "query": {
+          "selects": {
+            "event": "event_expr",
+            "group_by_subject": "group_by_expr"
+          },
+          "startPartition": "2021-04-09",
+          "timeColumn": "ts",
+          "setups": []
+        }
+      }
+    }
+  ],
+  "keyColumns": [
+    "group_by_subject"
+  ],
+  "aggregations": [
+    {
+      "inputColumn": "event",
+      "operation": 7,
+      "argMap": {}
+    }
+  ]
+}

--- a/api/py/test/sample/production/group_bys/unit_test/user.sample_nested_group_by.v1
+++ b/api/py/test/sample/production/group_bys/unit_test/user.sample_nested_group_by.v1
@@ -1,0 +1,58 @@
+{
+  "metaData": {
+    "name": "unit_test.user.sample_nested_group_by.v1",
+    "online": 1,
+    "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_random_table_name_ds\", \"spec\": \"random_table_name/ds={{ ds }}\", \"start\": \"2023-03-01\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "offlineSchedule": "@daily"
+  },
+  "sources": [
+    {
+      "events": {
+        "table": "random_table_name",
+        "query": {
+          "selects": {
+            "user": "id_item",
+            "play": "if(transaction_type='A', 1, 0)",
+            "pause": "if(transaction_type='B', 1, 0)"
+          },
+          "startPartition": "2023-03-01",
+          "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
+          "setups": []
+        }
+      }
+    }
+  ],
+  "keyColumns": [
+    "user"
+  ],
+  "aggregations": [
+    {
+      "inputColumn": "play",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    },
+    {
+      "inputColumn": "pause",
+      "operation": 7,
+      "windows": [
+        {
+          "length": 30,
+          "timeUnit": 1
+        }
+      ]
+    }
+  ]
+}

--- a/api/py/test/sample/production/joins/unit_test/sample_parent_join.parent_join
+++ b/api/py/test/sample/production/joins/unit_test/sample_parent_join.parent_join
@@ -1,0 +1,78 @@
+{
+  "metaData": {
+    "name": "unit_test.sample_parent_join.parent_join",
+    "online": 1,
+    "production": 0,
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "samplePercent": 100.0,
+    "offlineSchedule": "@daily"
+  },
+  "left": {
+    "events": {
+      "table": "sample_namespace.sample_table_group_by",
+      "query": {
+        "selects": {
+          "event": "event_expr",
+          "group_by_subject": "group_by_expr",
+          "ts": "ts"
+        },
+        "startPartition": "2021-04-09",
+        "timeColumn": "ts",
+        "setups": []
+      }
+    }
+  },
+  "joinParts": [
+    {
+      "groupBy": {
+        "metaData": {
+          "name": "unit_test.sample_group_by.v1",
+          "online": 1,
+          "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+          "dependencies": [
+            "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+          ],
+          "team": "unit_test",
+          "offlineSchedule": "@daily"
+        },
+        "sources": [
+          {
+            "events": {
+              "table": "sample_namespace.sample_table_group_by",
+              "query": {
+                "selects": {
+                  "event": "event_expr",
+                  "group_by_subject": "group_by_expr"
+                },
+                "startPartition": "2021-04-09",
+                "timeColumn": "ts",
+                "setups": []
+              }
+            }
+          }
+        ],
+        "keyColumns": [
+          "group_by_subject"
+        ],
+        "aggregations": [
+          {
+            "inputColumn": "event",
+            "operation": 7,
+            "argMap": {}
+          }
+        ]
+      },
+      "keyMapping": {
+        "subject": "group_by_subject"
+      }
+    }
+  ]
+}

--- a/api/py/test/sample/production/joins/unit_test/user.sample_transactions.v1
+++ b/api/py/test/sample/production/joins/unit_test/user.sample_transactions.v1
@@ -1,0 +1,98 @@
+{
+  "metaData": {
+    "name": "unit_test.user.sample_transactions.v1",
+    "online": 1,
+    "production": 0,
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_item_snapshot_ds\", \"spec\": \"item_snapshot/ds={{ ds }}\", \"start\": \"2023-03-01\", \"end\": null}",
+      "{\"name\": \"wait_for_random_table_name_ds\", \"spec\": \"random_table_name/ds={{ ds }}\", \"start\": \"2023-03-01\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "samplePercent": 100.0,
+    "offlineSchedule": "@daily"
+  },
+  "left": {
+    "events": {
+      "table": "item_snapshot",
+      "query": {
+        "selects": {
+          "user": "id_requester",
+          "ts": "UNIX_TIMESTAMP(ts_created_at_utc) * 1000"
+        },
+        "wheres": [
+          "dim_requester_user_role = 'user'"
+        ],
+        "startPartition": "2023-03-01",
+        "timeColumn": "UNIX_TIMESTAMP(ts_created_at_utc) * 1000",
+        "setups": []
+      }
+    }
+  },
+  "joinParts": [
+    {
+      "groupBy": {
+        "metaData": {
+          "name": "unit_test.user.sample_nested_group_by.v1",
+          "online": 1,
+          "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+          "dependencies": [
+            "{\"name\": \"wait_for_random_table_name_ds\", \"spec\": \"random_table_name/ds={{ ds }}\", \"start\": \"2023-03-01\", \"end\": null}"
+          ],
+          "tableProperties": {
+            "source": "chronon"
+          },
+          "outputNamespace": "default",
+          "team": "unit_test",
+          "offlineSchedule": "@daily"
+        },
+        "sources": [
+          {
+            "events": {
+              "table": "random_table_name",
+              "query": {
+                "selects": {
+                  "user": "id_item",
+                  "play": "if(transaction_type='A', 1, 0)",
+                  "pause": "if(transaction_type='B', 1, 0)"
+                },
+                "startPartition": "2023-03-01",
+                "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
+                "setups": []
+              }
+            }
+          }
+        ],
+        "keyColumns": [
+          "user"
+        ],
+        "aggregations": [
+          {
+            "inputColumn": "play",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          },
+          {
+            "inputColumn": "pause",
+            "operation": 7,
+            "windows": [
+              {
+                "length": 30,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/api/py/test/sample/teams.json
+++ b/api/py/test/sample/teams.json
@@ -61,5 +61,9 @@
       "unit_test": {
         "description": "Used for the unit test cases",
         "namespace": "default"
+    },
+  "cs_ds": {
+        "description": "Used for unit testing purposes",
+        "namespace": "default"
     }
 }

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -163,3 +163,106 @@ def test_failed_compile_missing_input_column():
         ],
     )
     assert result.exit_code != 0
+
+
+def test_failed_compile_when_dependent_join_detected():
+    """
+    Should raise errors as we are trying to create aggregations without input column.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        extract_and_convert,
+        ["--chronon_root=test/sample", "--input_path=group_bys/sample_team/event_sample_group_by.py"],
+    )
+    assert result.exit_code != 0
+    error_message_expected = "Detected dependencies are as follows: ['sample_team.sample_chaining_join.parent_join', 'sample_team.sample_join_bootstrap.v1', 'sample_team.sample_join_bootstrap.v2', 'sample_team.sample_join_derivation.v1', 'sample_team.sample_join_with_derivations_on_external_parts.v1', 'sample_team.sample_label_join.v1', 'sample_team.sample_label_join_with_agg.v1', 'sample_team.sample_online_join.v1']"
+    actual_exception_message = str(result.exception).strip().lower()
+    error_message_expected = error_message_expected.strip().lower()
+    assert (
+        error_message_expected in actual_exception_message
+    ), f"Got a different message than expected {actual_exception_message}"
+    assert isinstance(
+        result.exception, AssertionError
+    ), "Expected an AssertionError, but got a different exception or no exception."
+
+
+def test_detected_dependent_joins_materialized():
+    """
+    Should raise errors as we are trying to create aggregations without input column.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=group_bys/sample_team/event_sample_group_by.py",
+            "--force-overwrite",
+        ],
+    )
+    assert result.exit_code == 0
+    expected_message = "Successfully wrote 8 Join objects to test/sample/production".strip().lower()
+    actual_message = str(result.output).strip().lower()
+    assert expected_message in actual_message, f"Got a different message than expected {actual_message}"
+
+
+def test_failed_compile_when_dependent_groupby_detected():
+    """
+    Should raise errors as we are trying to create aggregations without input column.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=joins/unit_test/sample_parent_join.py",
+        ],
+    )
+    assert result.exit_code != 0
+    error_message_expected = (
+        "Detected dependencies are as follows: ['unit_test.sample_chaining_group_by.chaining_group_by_v1']"
+    )
+    actual_exception_message = str(result.exception).strip().lower()
+    error_message_expected = error_message_expected.strip().lower()
+    assert (
+        error_message_expected in actual_exception_message
+    ), f"Got a different message than expected {actual_exception_message}"
+    assert isinstance(
+        result.exception, AssertionError
+    ), "Expected an AssertionError, but got a different exception or no exception."
+
+
+def test_detected_dependent_group_bys_materialized():
+    """
+    Should raise errors as we are trying to create aggregations without input column.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=joins/unit_test/sample_parent_join.py",
+            "--force-overwrite",
+        ],
+    )
+    assert result.exit_code == 0
+    expected_message = "Successfully wrote 2 GroupBy objects to test/sample/production".strip().lower()
+    actual_message = str(result.output).strip().lower()
+    assert expected_message in actual_message, f"Got a different message than expected {actual_message}"
+
+
+def test_detected_dependent_inline_group_bys():
+    """
+    Should raise errors as we are trying to create aggregations without input column.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=joins/sample_team/sample_chaining_join.py",
+        ],
+    )
+    assert result.exit_code == 0
+    # expected_message = "Successfully wrote 2 GroupBy objects to test/sample/production".strip().lower()
+    # actual_message = str(result.output).strip().lower()
+    # assert expected_message in actual_message, f"Got a different message than expected {actual_message}"

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -17,7 +17,6 @@ Run the flow for materialize.
 #     limitations under the License.
 
 import os
-import shutil
 
 import pytest
 from ai.chronon.repo.compile import extract_and_convert
@@ -56,12 +55,18 @@ def specific_setup():
     yield  # This is where the testing happens
     # Teardown phase: Cleanup after tests
     current_file_dir = os.path.dirname(os.path.abspath(__file__))
-    directories_to_clean = ["sample/production/joins/unit_test/", "sample/production/group_bys/unit_test/"]
+    files_to_clean = [
+        "sample/production/group_bys/unit_test/event_sample_group_by.v1",
+        "sample/production/group_bys/unit_test/entity_sample_group_by.require_backfill",
+        "sample/production/joins/unit_test/sample_online_join.v1",
+        "sample/production/joins/unit_test/sample_join.v1",
+        "sample/production/joins/unit_test/sample_online_join_with_gb_not_online.v1",
+    ]
 
-    for relative_path in directories_to_clean:
+    for relative_path in files_to_clean:
         full_path = os.path.join(current_file_dir, relative_path)
         if os.path.exists(full_path):
-            shutil.rmtree(full_path)
+            os.remove(full_path)
 
 
 def test_basic_compile():

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -250,7 +250,7 @@ def test_detected_dependent_group_bys_materialized():
     assert expected_message in actual_message, f"Got a different message than expected {actual_message}"
 
 
-def test_detected_dependent_inline_group_bys():
+def test_detected_dependent_nested_joins():
     """
     Should raise errors as we are trying to create aggregations without input column.
     """
@@ -259,10 +259,11 @@ def test_detected_dependent_inline_group_bys():
         extract_and_convert,
         [
             "--chronon_root=test/sample",
-            "--input_path=joins/sample_team/sample_chaining_join.py",
+            "--input_path=group_bys/unit_test/user/sample_nested_group_by.py",
+            "--force-overwrite",
         ],
     )
     assert result.exit_code == 0
-    # expected_message = "Successfully wrote 2 GroupBy objects to test/sample/production".strip().lower()
-    # actual_message = str(result.output).strip().lower()
-    # assert expected_message in actual_message, f"Got a different message than expected {actual_message}"
+    expected_message = "Successfully wrote 1 Join objects to test/sample/production".strip().lower()
+    actual_message = str(result.output).strip().lower()
+    assert expected_message in actual_message, f"Got a different message than expected {actual_message}"

--- a/api/py/tox.ini
+++ b/api/py/tox.ini
@@ -9,10 +9,12 @@ allowlist_externals = rm
 setenv = PYTHONPATH = {toxinidir}:{toxinidir}/test/sample
 # Run a compile test run.
 commands_pre =
-  rm -rf test/sample/production
+  rm -rf test/sample/production/joins/sample_team
+  rm -rf test/sample/production/group_bys/sample_team
   python ai/chronon/repo/compile.py \
     --chronon_root=test/sample \
-    --input_path=joins/sample_team/
+    --input_path=joins/sample_team/ \
+    --force-overwrite
 commands =
   pytest {posargs:test/} \
     --cov=ai/ \

--- a/api/py/tox.ini
+++ b/api/py/tox.ini
@@ -11,6 +11,7 @@ setenv = PYTHONPATH = {toxinidir}:{toxinidir}/test/sample
 commands_pre =
   rm -rf test/sample/production/joins/sample_team
   rm -rf test/sample/production/group_bys/sample_team
+  # Materialized files are verified in release script - python-api-build.sh
   python ai/chronon/repo/compile.py \
     --chronon_root=test/sample \
     --input_path=joins/sample_team/ \


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Materialize dependent GBs and Joins when materializing a python configuration.
Scenario A
GB_1 is used by 5 other Joins. When running compile.py on GB_1, the 5 other Joins should also be materialized to include changes made to GB_1.

Scenario B
GB_2 uses Join_2 via JoinSource. When running compile.py on Join_2, GB_2 should also be materialized to include changes made to GB_2.

In above scenarios, if dependencies are detected, compile.py will error out. User will have to add the --force-overwrite flag to materialize the input conf file and all detected dependencies

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
To ensure the python configurations and materialized JSON files stay in sync

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

