### PR TITLE
fix: improve table archive in jp parallel mode 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -415,7 +415,8 @@ abstract class JoinBase(joinConf: api.Join,
       logger.info(s"No semantic change detected, leaving output table in place.")
     } else {
       logger.info(s"Semantic changes detected, archiving output table.")
-      performArchive(tablesChanged, autoArchive, outputTable)
+      // Only archive the output table when semantic_hash change is detected
+      performArchive(Seq(outputTable), autoArchive, outputTable)
     }
 
     val (rangeToFill, unfilledRanges) = getUnfilledRange(overrideStartPartition, outputTable)
@@ -482,12 +483,20 @@ abstract class JoinBase(joinConf: api.Join,
 
     // Run command to archive ALL tables that have changed semantically since the last run
     // TODO: We should not archive the output table or other JP's intermediate tables in the case of selected join parts mode
+    // TODO: maintain JP semantic_hash at tblproperties of each JP table
     val (tablesChanged, autoArchive) = tablesToRecompute(joinConf, outputTable, tableUtils, unsetSemanticHash)
     if (tablesChanged.isEmpty) {
       logger.info(s"No semantic change detected, leaving output table in place.")
     } else {
       logger.info(s"Semantic changes detected, archiving output table.")
-      performArchive(tablesChanged, autoArchive, outputTable)
+      // We should NOT archive the bootstrap_table because at this point it is already run and updated, but the
+      // semantic_hash of the output table may be out of date, and this may cause bootstrap_table to be archived table.
+      val tablesToArchive = if (selectedJoinParts.isDefined) {
+        tablesChanged.filterNot(_ == joinConf.metaData.bootstrapTable)
+      } else {
+        tablesChanged
+      }
+      performArchive(tablesToArchive, autoArchive, outputTable)
     }
 
     // Overwriting Join Left with bootstrap table to simplify later computation
@@ -510,7 +519,11 @@ abstract class JoinBase(joinConf: api.Join,
     def finalResult: DataFrame = tableUtils.sql(rangeToFill.genScanQuery(null, outputTable))
     if (unfilledRanges.isEmpty) {
       logger.info(s"\nThere is no data to compute based on end partition of ${rangeToFill.end}.\n\n Exiting..")
-      return Some(finalResult)
+      if (selectedJoinParts.isDefined) {
+        return None
+      } else {
+        return Some(finalResult)
+      }
     }
 
     stepDays.foreach(metrics.gauge("step_days", _))


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

In JP parallel mode, in some edge case there is a bug that will cause unwanted archives. 

When the left hash changes:
- the `left` task will handle archive of the bootstrap table
- the `right` and `final` task should not do the archive again! But because `right` and `final` tasks are using semantic_hash stored on the final table (which is not updated), it will do the archive again. This will cause the bootstrap_table to be archived again after it's already re-computed by the `left` task, and this will result in data loss. 

Besides the fix, this PR also adds more debugging logs. 
## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Tables are being incorrectedly archived right now. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@donghanz 
