### PR TITLE
fix: join derivations on structs

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/SparkExpressionEvalFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/SparkExpressionEvalFn.scala
@@ -94,7 +94,7 @@ class SparkExpressionEvalFn[T](encoder: Encoder[T], groupBy: GroupBy) extends Ri
       val serFinish = System.currentTimeMillis()
       rowSerTimeHistogram.update(serFinish - start)
 
-      val maybeRow = catalystUtil.performSql(row)
+      val maybeRow = catalystUtil.sqlTransformRowToMap(row)
       exprEvalTimeHistogram.update(System.currentTimeMillis() - serFinish)
       maybeRow.foreach(out.collect)
       exprEvalSuccessCounter.inc()

--- a/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
@@ -109,11 +109,12 @@ class PooledCatalystUtil(expressions: collection.Seq[(String, String)], inputSch
     }
     arr
   }
-  def performSql(values: Map[String, Any]): Option[Map[String, Any]] =
+
+  // In fetching join derivations, Structs are Array-encoded in inputs but Map-encoded in outputs.
+  // TODO: Generalize this beyond fetching join derivations.
+  def applyDerivations(values: Map[String, Any]): Option[Map[String, Any]] =
     poolMap.performWithValue(poolKey, cuPool) { util =>
       {
-        // In fetching join derivations, Structs are Array-encoded in inputs and Map-encoded in outputs.
-        // TODO: Generalize this beyond fetching join derivations.
         val valuesArr = mapToArr(values)
         util.internalRowToMap(util.toInternalRow(valuesArr))
       }

--- a/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
@@ -116,7 +116,7 @@ class PooledCatalystUtil(expressions: collection.Seq[(String, String)], inputSch
     poolMap.performWithValue(poolKey, cuPool) { util =>
       {
         val valuesArr = mapToArr(values)
-        util.internalRowToMap(util.toInternalRow(valuesArr))
+        util.sqlTransformRowToMap(util.toInternalRow(valuesArr))
       }
     }
   def outputChrononSchema: Array[(String, DataType)] =
@@ -146,15 +146,15 @@ class CatalystUtil(expressions: collection.Seq[(String, String)],
 
   def toInternalRow(values: Array[Any]): InternalRow = inputArrEncoder(values).asInstanceOf[InternalRow]
   private def toInternalRow(values: Map[String, Any]): InternalRow = inputEncoder(values).asInstanceOf[InternalRow]
-  def performSql(values: Array[Any]): Option[Array[Any]] = internalRowToArray(toInternalRow(values))
-  def performSql(values: Map[String, Any]): Option[Map[String, Any]] = internalRowToMap(toInternalRow(values))
+  def sqlTransform(values: Array[Any]): Option[Array[Any]] = sqlTransformInternalRowToArray(toInternalRow(values))
+  def sqlTransform(values: Map[String, Any]): Option[Map[String, Any]] = sqlTransformRowToMap(toInternalRow(values))
 
-  def internalRowToMap(row: InternalRow): Option[Map[String, Any]] = {
+  def sqlTransformRowToMap(row: InternalRow): Option[Map[String, Any]] = {
     val resultRowMaybe = transformFunc(row)
     val outputVal = resultRowMaybe.map(resultRow => outputDecoder(resultRow))
     outputVal.map(_.asInstanceOf[Map[String, Any]])
   }
-  def internalRowToArray(row: InternalRow): Option[Array[Any]] = {
+  private def sqlTransformInternalRowToArray(row: InternalRow): Option[Array[Any]] = {
     val resultRowMaybe = transformFunc(row)
     val outputVal = resultRowMaybe.map(resultRow => outputArrDecoder(resultRow))
     outputVal.map(_.asInstanceOf[Array[Any]])

--- a/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
@@ -136,11 +136,11 @@ class CatalystUtil(expressions: collection.Seq[(String, String)],
     }
 
   private val (transformFunc: (InternalRow => Option[InternalRow]), outputSparkSchema: types.StructType) = initialize()
-  @transient lazy val outputChrononSchema = SparkConversions.toChrononSchema(outputSparkSchema)
-  private val outputDecoder = SparkInternalRowConversions.from(outputSparkSchema)
   @transient lazy val inputSparkSchema = SparkConversions.fromChrononSchema(inputSchema)
   private val inputEncoder = SparkInternalRowConversions.to(inputSparkSchema, true)
   private val inputArrEncoder = SparkInternalRowConversions.to(inputSparkSchema, false)
+  @transient lazy val outputChrononSchema = SparkConversions.toChrononSchema(outputSparkSchema)
+  private val outputDecoder = SparkInternalRowConversions.from(outputSparkSchema)
   private lazy val outputArrDecoder = SparkInternalRowConversions.from(outputSparkSchema, false)
 
   def toInternalRow(values: Array[Any]): InternalRow = inputArrEncoder(values).asInstanceOf[InternalRow]

--- a/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/OnlineDerivationUtil.scala
@@ -40,7 +40,7 @@ object OnlineDerivationUtil {
   ): DerivationFunc = {
     {
       case (keys: Map[String, Any], values: Map[String, Any]) =>
-        reintroduceExceptions(catalystUtil.performSql(keys ++ values).orNull, values)
+        reintroduceExceptions(catalystUtil.applyDerivations(keys ++ values).orNull, values)
     }
   }
 

--- a/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
@@ -116,7 +116,7 @@ object SparkInternalRowConversions {
   // The purpose of this class is to be used on fetcher output in a fetching context
   // we take a data type and build a function that operates on actual value
   // we want to build functions where we only branch at construction time, but not at function execution time.
-  def to(dataType: types.DataType, structToMap: Boolean = true): Any => Any = {
+  def to(dataType: types.DataType, structToMap: Boolean): Any => Any = {
     val unguardedFunc: Any => Any = dataType match {
       case types.MapType(keyType, valueType, _) =>
         val keyConverter = to(keyType, structToMap)

--- a/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
@@ -179,7 +179,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "bytes_x" -> "bytes_x"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("bool_x"), true)
     assertEquals(res.get("int32_x"), Int.MaxValue)
@@ -199,7 +199,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "e" -> "1 / 2 + 1"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 5)
     assertEquals(res.get("a"), 162)
     assertEquals(res.get("b"), 1073741824.0)
@@ -224,7 +224,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "k" -> "COALESCE(NULL, NULL, int32_x, NULL)"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 11)
     assertEquals(res.get("a"), 2147483645L)
     assertEquals(res.get("b"), "U3BhcmsgU1FM")
@@ -250,7 +250,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "e" -> "DAYOFWEEK('2009-07-30')"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 5)
     assertEquals(res.get("a"), "2038-01-19 03:14:07")
     assertTrue(res.get("b").isInstanceOf[java.lang.Long])
@@ -276,7 +276,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "bytes_x" -> "bytes_udf(bytes_x)"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("bool_x"), false)
     assertEquals(res.get("int32_x"), Int.MaxValue - 1)
@@ -300,7 +300,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "recursive_udf" -> "recursive_udf(8)"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 3)
     assertEquals(res.get("two_param_udf"), Long.MaxValue - Int.MaxValue)
     assertEquals(res.get("add_two_udf"), 3)
@@ -313,7 +313,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("FALSE AND int64_x > `int32_x`")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertTrue(res.isEmpty)
   }
 
@@ -322,7 +322,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("FALSE OR int64_x > `int32_x`")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 1)
     assertEquals(res.get("a"), Int.MaxValue)
   }
@@ -332,7 +332,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("FALSE OR int64_x < `int32_x`")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertTrue(res.isEmpty)
   }
 
@@ -341,7 +341,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("int64_x > `int32_x`", "FALSE OR int64_x > `int32_x`")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 1)
     assertEquals(res.get("a"), Int.MaxValue)
   }
@@ -351,7 +351,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("int64_x > `int32_x`", "FALSE OR int64_x < `int32_x`")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertTrue(res.isEmpty)
   }
 
@@ -360,7 +360,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq()
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 1)
     assertEquals(res.get("a"), Int.MaxValue)
   }
@@ -371,7 +371,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("COALESCE(NULL, NULL, int32_x, int64_x, NULL) = `int32_x`")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 1)
     assertEquals(res.get("a"), Int.MaxValue)
   }
@@ -382,7 +382,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     val selects = Seq("a" -> "int32_x")
     val wheres = Seq("int32_x - 1 = SUB_ONE(int32_x)")
     val cu = new CatalystUtil(selects, CommonScalarsStruct, wheres)
-    val res = cu.performSql(CommonScalarsRow)
+    val res = cu.sqlTransform(CommonScalarsRow)
     assertEquals(res.get.size, 1)
     assertEquals(res.get("a"), Int.MaxValue)
   }
@@ -398,7 +398,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "bytes_x" -> "bytes_x"
     )
     val cu = new CatalystUtil(selects, CommonScalarsStruct)
-    val res = cu.performSql(CommonScalarsNullRow)
+    val res = cu.sqlTransform(CommonScalarsNullRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("bool_x"), null)
     assertEquals(res.get("int32_x"), null)
@@ -419,7 +419,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "inner_opt_int32_opt" -> "inner_opt.int32_opt"
     )
     val cu = new CatalystUtil(selects, NestedOuterStruct)
-    val res = cu.performSql(NestedRow)
+    val res = cu.sqlTransform(NestedRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("inner_req"), Map("int32_req" -> 12, "int32_opt" -> 34))
     assertEquals(res.get("inner_opt"), Map("int32_req" -> 56, "int32_opt" -> 78))
@@ -438,7 +438,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "inner_req_int32_opt" -> "inner_req.int32_opt"
     )
     val cu = new CatalystUtil(selects, NestedOuterStruct)
-    val res = cu.performSql(NestedNullRow)
+    val res = cu.sqlTransform(NestedNullRow)
     assertEquals(res.get.size, 4)
     assertEquals(res.get("inner_req"), Map("int32_req" -> 12, "int32_opt" -> null))
     assertEquals(res.get("inner_opt"), null)
@@ -457,7 +457,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "bytess" -> "bytess"
     )
     val cu = new CatalystUtil(selects, ListContainersStruct)
-    val res = cu.performSql(ListContainersRow)
+    val res = cu.sqlTransform(ListContainersRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("bools"), makeArrayList(false, true, false))
     assertEquals(res.get("int32s"), makeArrayList(1, 2, 3))
@@ -485,7 +485,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "bytess" -> "bytess"
     )
     val cu = new CatalystUtil(selects, ListContainersStruct)
-    val res = cu.performSql(ArrayContainersRow)
+    val res = cu.sqlTransform(ArrayContainersRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("bools"), makeArrayList(false, true, false))
     assertEquals(res.get("int32s"), makeArrayList(1, 2, 3))
@@ -504,7 +504,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "a" -> "int64s[1] + int32s[2]"
     )
     val cu = new CatalystUtil(selects, ListContainersStruct)
-    val res = cu.performSql(ListContainersRow)
+    val res = cu.sqlTransform(ListContainersRow)
     assertEquals(res.get.size, 1)
     assertEquals(res.get("a"), 8L)
   }
@@ -519,7 +519,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "e" -> "CARDINALITY(int32s)"
     )
     val cu = new CatalystUtil(selects, ListContainersStruct)
-    val res = cu.performSql(ListContainersRow)
+    val res = cu.sqlTransform(ListContainersRow)
     assertEquals(res.get.size, 5)
     assertEquals(res.get("a"), makeArrayList(2, 4, 6))
     assertEquals(res.get("b"), makeArrayList("123", "123"))
@@ -539,7 +539,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "bytess" -> "bytess"
     )
     val cu = new CatalystUtil(selects, MapContainersStruct)
-    val res = cu.performSql(MapContainersRow)
+    val res = cu.sqlTransform(MapContainersRow)
     assertEquals(res.get.size, 6)
     assertEquals(res.get("bools"), makeHashMap(1 -> false, 2 -> true, 3 -> false))
     assertEquals(res.get("int32s"), makeHashMap(1 -> 1, 2 -> 2, 3 -> 3))
@@ -559,7 +559,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "b" -> "strings['a']"
     )
     val cu = new CatalystUtil(selects, MapContainersStruct)
-    val res = cu.performSql(MapContainersRow)
+    val res = cu.sqlTransform(MapContainersRow)
     assertEquals(res.get.size, 2)
     assertEquals(res.get("a"), 2)
     assertEquals(res.get("b"), "hello")
@@ -573,7 +573,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
       "c" -> "MAP_VALUES(strings)"
     )
     val cu = new CatalystUtil(selects, MapContainersStruct)
-    val res = cu.performSql(MapContainersRow)
+    val res = cu.sqlTransform(MapContainersRow)
     assertEquals(res.get.size, 3)
     assertEquals(res.get("a"), makeHashMap(1 -> "2", 3 -> "4"))
     assertEquals(res.get("b").asInstanceOf[util.ArrayList[Any]].size, 3)
@@ -609,7 +609,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     ).toSeq
     val wheres = Seq("tag = 'inexistent'")
     val cu = new CatalystUtil(selects, inputEventStruct, wheres)
-    val res = cu.performSql(inputEventRow)
+    val res = cu.sqlTransform(inputEventRow)
     assertTrue(res.isEmpty)
   }
 
@@ -621,7 +621,7 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     ).toSeq
     val wheres = Seq("tag = 'v1.0'")
     val cu = new CatalystUtil(selects, inputEventStruct, wheres)
-    val res = cu.performSql(inputEventRow)
+    val res = cu.sqlTransform(inputEventRow)
     assertTrue(res.get.size == 3)
     assertTrue(res.get("id") == "unique_key")
     assertTrue(res.get("created") == 1000L)

--- a/online/src/test/scala/ai/chronon/online/test/ThriftDecodingTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/ThriftDecodingTest.scala
@@ -74,7 +74,7 @@ class ThriftDecodingTest {
 
     // apply sql on this
     val cu = new CatalystUtil(collection.Seq(der_name -> der_expr), schema.asInstanceOf[StructType])
-    val result = cu.performSql(decoder.apply(dks).asInstanceOf[Array[Any]]).orNull
+    val result = cu.sqlTransform(decoder.apply(dks).asInstanceOf[Array[Any]]).orNull
     val resultJson = gson.toJson(result)
     assertEquals(resultJson, "[24.0]")
   }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Fix catalyst util handling struct inputs. Currently all structs are in Array format after converting from Avro format from KVStore: https://github.com/airbnb/chronon/blob/main/api/src/main/scala/ai/chronon/api/Row.scala#L56-L68

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Fix derivations with struct inputs 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@yuli-han 

