### PR TITLE
Update the online derivation validation behavior

### DIFF
--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -347,12 +347,8 @@ class ChrononRepoValidator(object):
         # Only validate the join derivation when the underlying groupBy is valid
         if join.derivations and group_by_correct:
             features = get_pre_derived_join_features(join)
-            # For online joins keys are not included in output schema
-            if join.metaData.online:
-                columns = features
-            else:
-                keys = get_pre_derived_source_keys(join.left)
-                columns = features + keys
+            keys = get_pre_derived_source_keys(join.left)
+            columns = features + keys
             errors.extend(self._validate_derivations(columns, join.derivations))
         return errors
 
@@ -390,11 +386,7 @@ class ChrononRepoValidator(object):
 
         # validate the derivations are defined correctly
         if group_by.derivations:
-            # For online group_by keys are not included in output schema
-            if group_by.metaData.online:
-                columns = get_pre_derived_group_by_features(group_by)
-            else:
-                columns = get_pre_derived_group_by_columns(group_by)
+            columns = get_pre_derived_group_by_columns(group_by)
             errors.extend(self._validate_derivations(columns, group_by.derivations))
 
         # validate the expected deprecation date is in the correct format it is defined

--- a/api/py/test/sample/group_bys/sample_team/sample_group_by_with_derivations.py
+++ b/api/py/test/sample/group_bys/sample_team/sample_group_by_with_derivations.py
@@ -12,15 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from ai.chronon.group_by import Aggregation, Derivation, GroupBy, Operation
 from sources import test_sources
-from ai.chronon.group_by import (
-    GroupBy,
-    Aggregation,
-    Operation,
-    Window,
-    TimeUnit,
-    Derivation
-)
 
 v1 = GroupBy(
     sources=test_sources.staging_entities,
@@ -30,15 +23,14 @@ v1 = GroupBy(
         Aggregation(input_column="viewed_unique_count", operation=Operation.SUM),
     ],
     production=False,
-    table_properties={
-        "sample_config_json": """{"sample_key": "sample_value"}""",
-        "description": "sample description"
-    },
+    table_properties={"sample_config_json": """{"sample_key": "sample_value"}""", "description": "sample description"},
     derivations=[
         Derivation(
-            name="impressed_unique_count_1d_new_name",
-            expression="impressed_unique_count_sum"
+            name=column_name,
+            expression=column_name,
         )
-    ],
+        for column_name in ["ds", "s2CellId", "place_id"]
+    ]
+    + [Derivation(name="impressed_unique_count_1d_new_name", expression="impressed_unique_count_sum")],
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_derivation.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_derivation.py
@@ -16,36 +16,31 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from sources import test_sources
+from ai.chronon.join import Derivation, Join, JoinPart
 from group_bys.sample_team import (
-    event_sample_group_by,
     entity_sample_group_by_from_module,
-    group_by_with_kwargs,
+    event_sample_group_by,
 )
-
-from ai.chronon.join import Join, JoinPart, Derivation
-
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.event_source,
     right_parts=[
         JoinPart(
             group_by=event_sample_group_by.v1,
-            key_mapping={'subject': 'group_by_subject'},
+            key_mapping={"subject": "group_by_subject"},
         ),
         JoinPart(
             group_by=entity_sample_group_by_from_module.v1,
-            key_mapping={'subject': 'group_by_subject'},
-        )
+            key_mapping={"subject": "group_by_subject"},
+        ),
     ],
     derivations=[
         Derivation(
             name="derived_field",
-            expression="sample_team_event_sample_group_by_v1_event_sum_7d / sample_team_entity_sample_group_by_from_module_v1_entity_last"
+            expression="sample_team_event_sample_group_by_v1_event_sum_7d / sample_team_entity_sample_group_by_from_module_v1_entity_last",
         ),
-        Derivation(
-            name="*",
-            expression="*"
-        )
-    ]
+        Derivation(name="group_by_subject", expression="group_by_subject"),
+        Derivation(name="ds", expression="ds"),
+    ],
 )

--- a/api/py/test/sample/production/joins/sample_team/sample_join_derivation.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_derivation.v1
@@ -167,8 +167,12 @@
       "expression": "sample_team_event_sample_group_by_v1_event_sum_7d / sample_team_entity_sample_group_by_from_module_v1_entity_last"
     },
     {
-      "name": "*",
-      "expression": "*"
+      "name": "group_by_subject",
+      "expression": "group_by_subject"
+    },
+    {
+      "name": "ds",
+      "expression": "ds"
     }
   ]
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We used to exclude the keys columns for online joins/group_bys because keys are not included in the online fetching result. But there are some use cases where the user firstly add keys in offline group_bys derivations, then mark the offline group_by to be online. The validator failed in this case because we are not allowed online derivation on keys. We don't want users to change their offline derivation behavior just to pass the validator and recompute everything. 

This PR is to update the validator behavior to enable online derivations on keys. Although online derivation on keys are not gonna make any difference in fetching result, it won't break the re-compiling on existing offline entity. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @donghanz 
