### PR TITLE
fix: fix backfill end ds when endPartition is defined

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -111,7 +111,7 @@ object JoinUtils {
     lazy val defaultLeftStart = Option(leftSource.query.startPartition)
       .getOrElse(tableUtils.firstAvailablePartition(leftSource.table, leftSource.subPartitionFilters).get)
     val leftStart = overrideStart.getOrElse(defaultLeftStart)
-    val leftEnd = Option(leftSource.query.endPartition).getOrElse(endPartition)
+    val leftEnd = Seq(Option(leftSource.query.endPartition), Some(endPartition)).flatten.min
     PartitionRange(leftStart, leftEnd)(tableUtils)
   }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
If `leftSource.query.endPartition` is later than `endPartition`, then `endPartition` will be ignored. This results in the backfill range is larger than expected.

To resolve this, we select the earlier date as the backfill end date.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Reviewers
