### PR TITLE
Add compiler change for deprecation date

### DIFF
--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -327,7 +327,7 @@ def _handle_deprecation_warning(
                         f"Join source {source.joinSource.join.metaData.name} is going to be deprecated by {source.joinSource.join.metaData.deprecationDate}. Please ensure either to remove/migrate the dependency or set up correct deprecationDate for {obj.metaData.name}.",
                     )
 
-                    
+
 def _print_tables(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]]) -> None:
     tables = utils.get_modes_tables(obj)
     if obj_class is Join:

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -288,77 +288,31 @@ def _print_features(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, Group
         _print_features_names("Output GroupBy Features", get_group_by_output_columns(obj))
 
 
-def _print_deprecation_warning(
-    obj_name: Str,
-    deprecation_date: Str,
-    is_deprecation_entity: bool,
-    downstreams_without_deprecation_date: List[Str],
-    upstream_with_deprecation_date: Str,
-) -> None:
-    if is_deprecation_entity:
-        warning_message = f"Downstream entities {downstreams_without_deprecation_date}"
-        f" are missing deprecationDate or has a later deprecationDate than {obj_name}."
-        f" Please ensure either to remove/migrate the dependency or set up the correct deprecationDate."
-    else:
-        warning_message = f"Upstream entity {upstream_with_deprecation_date} is going to be deprecated by"
-        f" {deprecation_date}. Please ensure either to remove/migrate"
-        f" the dependency or set up correct deprecationDate for {obj_name}."
+def check_deprecation_date_setup_for_downstream(collection, entity_type, obj_name, obj_deprecation_date):
+    incorrect_deprecation_date = [
+        name
+        for name, item in collection.items()
+        if not item.metaData.deprecationDate or item.metaData.deprecationDate > obj_deprecation_date
+    ]
 
-    _print_error("Deprecation Warning:", warning_message)
-
-
-# For object with deprecation date set, check if downstream objects have correct deprecation date set.
-# The downstream can be groupBys or joins.
-def _handle_warning_for_deprecation_entity(
-    obj: Union[Join, GroupBy], downstream_group_bys: dict, downstream_joins: dict
-) -> None:
-    downstream_group_by_with_incorrect_deprecation_date = []
-    for gb_name, gb in downstream_group_bys.items():
-        if not gb.metaData.deprecationDate or gb.metaData.deprecationDate > obj.metaData.deprecationDate:
-            downstream_group_by_with_incorrect_deprecation_date.append(gb_name)
-    if downstream_group_by_with_incorrect_deprecation_date:
-        _print_deprecation_warning(
-            obj.metaData.name,
-            obj.metaData.deprecationDate,
-            True,
-            downstream_group_by_with_incorrect_deprecation_date,
-            None,
+    if incorrect_deprecation_date:
+        _print_error(
+            "Deprecation Warning:",
+            f"Downstream {entity_type} {incorrect_deprecation_date}"
+            f" are missing deprecationDate or has a later deprecationDate than upstream {obj_name}."
+            f" Please ensure either to remove/migrate the dependency or set up correct deprecationDate.",
         )
-    downstream_join_with_incorrect_deprecation_date = []
-    for join_name, join in downstream_joins.items():
-        if not join.metaData.deprecationDate or join.metaData.deprecationDate > obj.metaData.deprecationDate:
-            downstream_join_with_incorrect_deprecation_date.append(join_name)
-        if downstream_join_with_incorrect_deprecation_date:
-            _print_deprecation_warning(
-                obj.metaData.name,
-                obj.metaData.deprecationDate,
-                True,
-                downstream_join_with_incorrect_deprecation_date,
-                None,
+
+
+def check_deprecation_existence_in_upstream(collection, entity_type, obj_name):
+    for name, item in collection.items():
+        if item.metaData.deprecationDate:
+            _print_error(
+                "Deprecation Warning:",
+                f"{entity_type} {name} is going to be deprecated by"
+                f" {item.metaData.deprecationDate}. Please ensure either to remove/migrate"
+                f" the dependency or set up correct deprecationDate for {obj_name}.",
             )
-
-
-# For object without deprecation date, check if it is using any to-be-deprecated entity as upstream.
-# There are two possible upstream entities: groupBys or joins.
-# For active groupBys, check if it is using any deprecated join as joinSource.
-# For active joins, check if it is using any deprecated groupBy as joinPart.
-def _handle_warning_for_active_entity(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]]) -> None:
-    if obj_class is Join:
-        for jp in obj.joinParts:
-            if jp.groupBy.metaData.deprecationDate:
-                _print_deprecation_warning(
-                    obj.metaData.name, jp.groupBy.metaData.deprecationDate, False, None, jp.groupBy.metaData.name
-                )
-    else:
-        for source in obj.sources:
-            if source.joinSource and source.joinSource.join.metaData.deprecationDate:
-                _print_deprecation_warning(
-                    obj.metaData.name,
-                    source.joinSource.join.metaData.deprecationDate,
-                    False,
-                    None,
-                    source.joinSource.join.metaData.name,
-                )
 
 
 # For object with deprecation date set, check if downstream objects have correct deprecation date set.
@@ -368,9 +322,27 @@ def _handle_deprecation_warning(
     obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]], downstream_group_bys: dict, downstream_joins: dict
 ) -> None:
     if obj.metaData.deprecationDate:
-        _handle_warning_for_deprecation_entity(obj, downstream_group_bys, downstream_joins)
+        check_deprecation_date_setup_for_downstream(
+            downstream_group_bys, "group_bys", obj.metaData.name, obj.metaData.deprecationDate
+        )
+        check_deprecation_date_setup_for_downstream(
+            downstream_joins, "joins", obj.metaData.name, obj.metaData.deprecationDate
+        )
     else:
-        _handle_warning_for_active_entity(obj, obj_class)
+        if obj_class is Join:
+            check_deprecation_existence_in_upstream(
+                {jp.groupBy.metaData.name: jp.groupBy for jp in obj.joinParts}, "Join part", obj.metaData.name
+            )
+        else:
+            check_deprecation_existence_in_upstream(
+                {
+                    source.joinSource.join.metaData.name: source.joinSource.join
+                    for source in obj.sources
+                    if source.joinSource
+                },
+                "Join source",
+                obj.metaData.name,
+            )
 
 
 def _print_tables(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]]) -> None:

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -169,10 +169,9 @@ def extract_and_convert(chronon_root, input_path, output_root, debug, force_over
             extra_dependent_group_bys_to_materialize.update(new_group_bys)
             extra_dependent_joins_to_materialize.update(new_joins)
 
-    dependencies = {}
-    dependencies.update({**extra_dependent_group_bys_to_materialize, **extra_dependent_joins_to_materialize})
-
     if not force_overwrite:
+        dependencies = {}
+        dependencies.update({**extra_dependent_group_bys_to_materialize, **extra_dependent_joins_to_materialize})
         assert not dependencies, (
             "You must also materialize all dependent GroupBys or Joins."
             " You can do this by passing the --force-overwrite flag to the compile.py command."

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -300,7 +300,9 @@ def _handle_deprecation_warning(
         if downstream_group_by_with_incorrect_deprecation_date:
             _print_error(
                 "Deprecation Warning:",
-                f"Downstream group_bys {downstream_group_by_with_incorrect_deprecation_date} are missing deprecationDate or has a later deprecationDate than upstream {obj.metaData.name}. Please ensure either to remove/migrate the dependency or set up correct deprecationDate.",
+                f"Downstream group_bys {downstream_group_by_with_incorrect_deprecation_date}"
+                f" are missing deprecationDate or has a later deprecationDate than upstream {obj.metaData.name}."
+                f" Please ensure either to remove/migrate the dependency or set up correct deprecationDate.",
             )
         downstream_join_with_incorrect_deprecation_date = []
         for join_name, join in downstream_joins.items():
@@ -309,7 +311,10 @@ def _handle_deprecation_warning(
             if downstream_join_with_incorrect_deprecation_date:
                 _print_error(
                     "Deprecation Warning:",
-                    f"Downstream joins {downstream_join_with_incorrect_deprecation_date} are missing deprecationDate or has a later deprecationDate than upstream {obj.metaData.name}. Please ensure either to remove/migrate the dependency or set up correct deprecationDate.",
+                    f"Downstream joins {downstream_join_with_incorrect_deprecation_date}"
+                    f" are missing deprecationDate or has a later deprecationDate than upstream"
+                    f" {obj.metaData.name}. Please ensure either to remove/migrate the dependency"
+                    f" or set up correct deprecationDate.",
                 )
     else:
         if obj_class is Join:
@@ -317,14 +322,19 @@ def _handle_deprecation_warning(
                 if jp.groupBy.metaData.deprecationDate:
                     _print_error(
                         "Deprecation Warning:",
-                        f"Join part {jp.groupBy.metaData.name} is going to be deprecated by {jp.groupBy.metaData.deprecationDate}. Please ensure either to remove/migrate the dependency or set up correct deprecationDate for {obj.metaData.name}.",
+                        f"Join part {jp.groupBy.metaData.name} is going to be deprecated by"
+                        f" {jp.groupBy.metaData.deprecationDate}. Please ensure either to remove/migrate"
+                        f" the dependency or set up correct deprecationDate for {obj.metaData.name}.",
                     )
         else:
             for source in obj.sources:
                 if source.joinSource and source.joinSource.join.metaData.deprecationDate:
                     _print_error(
                         "Deprecation Warning:",
-                        f"Join source {source.joinSource.join.metaData.name} is going to be deprecated by {source.joinSource.join.metaData.deprecationDate}. Please ensure either to remove/migrate the dependency or set up correct deprecationDate for {obj.metaData.name}.",
+                        f"Join source {source.joinSource.join.metaData.name} is going to be"
+                        f" deprecated by {source.joinSource.join.metaData.deprecationDate}. Please"
+                        f" ensure either to remove/migrate the dependency or set up correct deprecationDate"
+                        f" for {obj.metaData.name}.",
                     )
 
 

--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -288,6 +288,9 @@ def _print_features(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, Group
         _print_features_names("Output GroupBy Features", get_group_by_output_columns(obj))
 
 
+# For object with deprecation date set, check if downstream objects have correct deprecation date set.
+# For object without deprecation date set, check if any upstream objects have deprecation date.
+# Print out warning message if any of the above conditions are met.
 def _handle_deprecation_warning(
     obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]], downstream_group_bys: dict, downstream_joins: dict
 ) -> None:

--- a/api/py/test/sample/joins/sample_team/sample_deprecation_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_deprecation_join.py
@@ -18,11 +18,6 @@ from sources import test_sources
 
 v1 = Join(
     left=test_sources.staging_entities,
-    right_parts=[JoinPart(group_by=sample_deprecation_group_by.v1, tags={"experimental": True})],
-    table_properties={"config_json": """{"sample_key": "sample_value"}"""},
+    right_parts=[JoinPart(group_by=sample_deprecation_group_by.v1)],
     output_namespace="sample_namespace",
-    tags={"business_relevance": "personalization"},
-    env={
-        "backfill": {"EXECUTOR_MEMORY": "9G"},
-    },
 )

--- a/api/py/test/sample/joins/sample_team/sample_deprecation_join.py
+++ b/api/py/test/sample/joins/sample_team/sample_deprecation_join.py
@@ -1,0 +1,28 @@
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from ai.chronon.join import Join, JoinPart
+from group_bys.sample_team import sample_deprecation_group_by
+from sources import test_sources
+
+v1 = Join(
+    left=test_sources.staging_entities,
+    right_parts=[JoinPart(group_by=sample_deprecation_group_by.v1, tags={"experimental": True})],
+    table_properties={"config_json": """{"sample_key": "sample_value"}"""},
+    output_namespace="sample_namespace",
+    tags={"business_relevance": "personalization"},
+    env={
+        "backfill": {"EXECUTOR_MEMORY": "9G"},
+    },
+)

--- a/api/py/test/sample/production/joins/sample_team/sample_deprecation_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_deprecation_join.v1
@@ -1,0 +1,122 @@
+{
+  "metaData": {
+    "name": "sample_team.sample_deprecation_join.v1",
+    "online": 0,
+    "production": 0,
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": {\"business_relevance\": \"personalization\"}, \"join_part_tags\": {\"sample_team.sample_deprecation_group_by.v1\": {\"experimental\": true}}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
+      "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
+      "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "config_json": "{\"sample_key\": \"sample_value\"}"
+    },
+    "outputNamespace": "sample_namespace",
+    "team": "sample_team",
+    "modeToEnvMap": {
+      "backfill": {
+        "EXECUTOR_MEMORY": "9G"
+      }
+    },
+    "samplePercent": 100.0,
+    "offlineSchedule": "@daily"
+  },
+  "left": {
+    "entities": {
+      "snapshotTable": "sample_namespace.sample_team_sample_staging_query_v1",
+      "query": {
+        "selects": {
+          "impressed_unique_count_1d": "impressed_unique_count_1d",
+          "viewed_unique_count_1d": "viewed_unique_count_1d",
+          "s2CellId": "s2CellId",
+          "place_id": "place_id"
+        },
+        "startPartition": "2021-03-01",
+        "setups": []
+      }
+    }
+  },
+  "joinParts": [
+    {
+      "groupBy": {
+        "metaData": {
+          "name": "sample_team.sample_deprecation_group_by.v1",
+          "online": 1,
+          "customJson": "{\"additional_argument\": \"To be placed in customJson\", \"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+          "dependencies": [
+            "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": \"2021-04-09\"}",
+            "{\"name\": \"wait_for_sample_namespace.another_sample_table_group_by_ds\", \"spec\": \"sample_namespace.another_sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
+          ],
+          "tableProperties": {
+            "source": "chronon"
+          },
+          "outputNamespace": "chronon_db",
+          "team": "sample_team",
+          "offlineSchedule": "@daily",
+          "deprecationDate": "2023-01-01"
+        },
+        "sources": [
+          {
+            "events": {
+              "table": "sample_namespace.sample_table_group_by",
+              "query": {
+                "selects": {
+                  "group_by_subject": "group_by_subject_expr_old_version",
+                  "event": "event_expr_old_version"
+                },
+                "startPartition": "2021-03-01",
+                "endPartition": "2021-04-09",
+                "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
+                "setups": []
+              }
+            }
+          },
+          {
+            "events": {
+              "table": "sample_namespace.another_sample_table_group_by",
+              "query": {
+                "selects": {
+                  "group_by_subject": "possibly_different_group_by_subject_expr",
+                  "event": "possibly_different_event_expr"
+                },
+                "startPartition": "2021-03-01",
+                "timeColumn": "__timestamp",
+                "setups": []
+              }
+            }
+          }
+        ],
+        "keyColumns": [
+          "group_by_subject"
+        ],
+        "aggregations": [
+          {
+            "inputColumn": "event",
+            "operation": 7,
+            "argMap": {}
+          },
+          {
+            "inputColumn": "event",
+            "operation": 12,
+            "argMap": {
+              "k": "128",
+              "percentiles": "[0.5]"
+            }
+          },
+          {
+            "inputColumn": "event",
+            "operation": 7,
+            "argMap": {},
+            "windows": [
+              {
+                "length": 7,
+                "timeUnit": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -79,11 +79,37 @@ def test_basic_compile():
         extract_and_convert, ["--chronon_root=test/sample", "--input_path=joins/sample_team/sample_join.py"]
     )
     assert result.exit_code == 0
+
+
+def test_compile_deprecation():
+    runner = CliRunner()
+    # Test deprecation warning when a to-be-deprecated group_by is used in an active join
     result = runner.invoke(
         extract_and_convert,
-        ["--chronon_root=test/sample", "--input_path=group_bys/sample_team/sample_deprecation_group_by.py"],
+        [
+            "--chronon_root=test/sample",
+            "--input_path=group_bys/sample_team/sample_deprecation_group_by.py",
+            "--force-overwrite",
+        ],
     )
     assert result.exit_code == 0
+    warning_message_title = "deprecation warning"
+    actual_message = str(result.output).strip().lower()
+    assert warning_message_title in actual_message, f"Deprecation warning message not seen in {actual_message}"
+
+    # Test deprecation warning when an active join is having a to-be-deprecated join part
+    result = runner.invoke(
+        extract_and_convert,
+        [
+            "--chronon_root=test/sample",
+            "--input_path=joins/sample_team/sample_deprecation_join.py",
+            "--force-overwrite",
+        ],
+    )
+    assert result.exit_code == 0
+    warning_message_title = "deprecation warning"
+    actual_message = str(result.output).strip().lower()
+    assert warning_message_title in actual_message, f"Deprecation warning message not seen in {actual_message}"
 
 
 def test_debug_compile():

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -81,9 +81,9 @@ def test_basic_compile():
     assert result.exit_code == 0
 
 
-def test_compile_deprecation():
+# Test deprecation warning when a to-be-deprecated group_by is used in an active join
+def test_compile_group_by_deprecation():
     runner = CliRunner()
-    # Test deprecation warning when a to-be-deprecated group_by is used in an active join
     result = runner.invoke(
         extract_and_convert,
         [
@@ -97,7 +97,10 @@ def test_compile_deprecation():
     actual_message = str(result.output).strip().lower()
     assert warning_message_title in actual_message, f"Deprecation warning message not seen in {actual_message}"
 
-    # Test deprecation warning when an active join is having a to-be-deprecated join part
+
+# Test deprecation warning when an active join is having a to-be-deprecated join part
+def test_compile_join_deprecation():
+    runner = CliRunner()
     result = runner.invoke(
         extract_and_convert,
         [


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Add change in compiler for deprecation date. 
1. Print out warning message when a group_by/join are flagged with deprecation date but there are downstream group_bys/joins with no deprecation date or later deprecation date. 
2. Print out warning message when a group_by/join are not flagged with deprecation date but there are upstream group_bys/joins with deprecation_date settings. 

The warning message will only be printed out for the configs user provided so there will be no duplicate message print out when we materializing downstream entities. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->

Integration tests: 
1. Test compile a join with to-be-deprecated groupBy
<img width="1678" alt="image" src="https://github.com/user-attachments/assets/fff568d8-d57e-4406-b63d-82689dcc07e3">
2. Test compile a groupBy with deprecation date while the downstream are not flagged deprecation_date
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/ff9b3aa8-87f2-4bf4-b993-c0c907a23c76">
3. Test compile a groupBy with a to-be-deprecated join source
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/c41c8830-f581-4181-b343-49bc9f64a8c5">
4. Test compile a to-be-deprecated join which is used as source in groupBy
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/5baca05b-97a1-4f24-86ca-e4ae06680ff6">



- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@rohitgirme @pengyu-hou @donghanz @pkundurthy 
