### PR TITLE
[Utils] Fix get_related_table_names to include backfill join bootstrap table

### DIFF
--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -443,7 +443,7 @@ def get_modes_tables(conf: ChrononJobTypes) -> Dict[str, List[str]]:
         if join.labelPart is not None:
             tables[Modes.label_join] = [f"{table_name}_labels", f"{table_name}_labeled", f"{table_name}_labeled_latest"]
 
-        if conf.bootstrapParts:
+        if conf.bootstrapParts or get_offline_schedule(conf) is not None:
             tables[SubStage.bootstrap] = [f"{table_name}_bootstrap"]
 
         if conf.joinParts:

--- a/api/py/test/test_utils.py
+++ b/api/py/test/test_utils.py
@@ -196,13 +196,13 @@ def test_get_related_table_names_for_simple_joins():
         # Joins will have the stats-summary & log (because of default sample = 100%)
         assert any(table.endswith("_daily_stats") for table in tables)
         assert any(table.endswith("_logged") for table in tables)
+        assert any(table.endswith("_bootstrap") for table in tables)  # always generated in backfill mode
 
         assert not any(table.endswith("_upload") for table in tables)
         assert not any(table.endswith("_consistency") for table in tables)
         assert not any(table.endswith("_labels") for table in tables)
         assert not any(table.endswith("_labeled") for table in tables)
         assert not any(table.endswith("_labeled_latest") for table in tables)
-        assert not any(table.endswith("_bootstrap") for table in tables)
 
 
 def test_get_related_table_names_for_label_joins():
@@ -214,6 +214,8 @@ def test_get_related_table_names_for_label_joins():
         # Joins will have the stats-summary & log (because of default sample = 100%)
         assert any(table.endswith("_daily_stats") for table in tables)
         assert any(table.endswith("_logged") for table in tables)
+        assert any(table.endswith("_bootstrap") for table in tables)  # always generated in backfill mode
+
         # label tables should be available
         assert any(table.endswith("_labels") for table in tables)
         assert any(table.endswith("_labeled") for table in tables)
@@ -221,7 +223,6 @@ def test_get_related_table_names_for_label_joins():
 
         assert not any(table.endswith("_upload") for table in tables)
         assert not any(table.endswith("_consistency") for table in tables)
-        assert not any(table.endswith("_bootstrap") for table in tables)
 
 
 def test_get_related_table_names_for_consistency_joins():
@@ -233,6 +234,7 @@ def test_get_related_table_names_for_consistency_joins():
         # Joins will have the stats-summary & log (because of default sample = 100%)
         assert any(table.endswith("_daily_stats") for table in tables)
         assert any(table.endswith("_logged") for table in tables)
+        assert any(table.endswith("_bootstrap") for table in tables)  # always generated in backfill mode
         # consistency tables should be available
         assert any(table.endswith("_consistency") for table in tables)
 
@@ -240,7 +242,6 @@ def test_get_related_table_names_for_consistency_joins():
         assert not any(table.endswith("_labeled") for table in tables)
         assert not any(table.endswith("_labeled_latest") for table in tables)
         assert not any(table.endswith("_upload") for table in tables)
-        assert not any(table.endswith("_bootstrap") for table in tables)
 
 
 def test_get_related_table_names_for_bootstrap_joins():


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Minor fix to ensure that related tables will display bootstrap table for join-backfills.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- This is more accurate than the current logic

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [X] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@donghanz 