### PR TITLE
Float -> Double Type mismatch for sum operation 

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
@@ -278,7 +278,7 @@ object ColumnAggregator {
           case ShortType   => simple(new Sum[Long](LongType), toLong[Short])
           case BooleanType => simple(new Sum[Long](LongType), boolToLong)
           case DoubleType  => simple(new Sum[Double](inputType))
-          case FloatType   => simple(new Sum[Double](inputType), toDouble[Float])
+          case FloatType   => simple(new Sum[Double](DoubleType), toDouble[Float])
           case _           => mismatchException
         }
       case Operation.UNIQUE_COUNT =>

--- a/online/src/test/scala/ai/chronon/online/TileCodecTest.scala
+++ b/online/src/test/scala/ai/chronon/online/TileCodecTest.scala
@@ -44,7 +44,7 @@ class TileCodecTest {
     Builders.Aggregation(Operation.AVERAGE, "rating", Seq(new Window(1, TimeUnit.DAYS))) -> Seq(4.0),
     Builders.Aggregation(Operation.SUM,
                          "rating",
-                         Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))) -> Seq(12.0f, 12.0f),
+                         Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))) -> Seq(12.0, 12.0),
     Builders.Aggregation(Operation.UNIQUE_COUNT,
                          "title",
                          Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))) -> Seq(3L, 3L),

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -109,6 +109,7 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.types.StringType$",
       "org.apache.spark.sql.types.IntegerType$",
       "org.apache.spark.sql.types.BinaryType",
+      "org.apache.spark.sql.types.FloatType$",
       "org.apache.spark.sql.types.DataType",
       "org.apache.spark.sql.types.NullType$",
       "org.apache.spark.sql.types.DoubleType$",

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -215,7 +215,9 @@ object GroupByUpload {
 
     val kvDf = kvRdd.toAvroDf(jsonPercent = jsonPercent)
     if (showDf) {
-      kvRdd.toFlatDf.prettyPrint()
+      val uploadDf = kvRdd.toFlatDf
+      logger.info(s"schema for uploadDf: \n${uploadDf.schema.pretty}")
+      uploadDf.prettyPrint()
     }
 
     val groupByServingInfo = buildServingInfo(groupByConf, session = tableUtils.sparkSession, endDs).groupByServingInfo

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -614,9 +614,9 @@ class FetcherTest extends TestCase {
     if (endDs != today) {
       responseDf = responseDf.drop("ds").withColumn("ds", lit(endDs))
     }
-    logger.info("expected:")
+    logger.info(s"expected schema: \n ${endDsExpected.schema.pretty} \n expected data frame:")
     endDsExpected.show()
-    logger.info("response:")
+    logger.info(s"response schema: \n ${endDsExpected.schema.pretty} \n response data frame:")
     responseDf.show()
 
     val diff = Comparison.sideBySide(responseDf, endDsExpected, keyishColumns, aName = "online", bName = "offline")

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -143,7 +143,7 @@ class FetcherTest extends TestCase {
     val endPartition = "2021-04-10"
     val rightSource = Builders.Source.entities(
       query = Builders.Query(
-        selects = Map("listing_id" -> "listing", "ts" -> "ts", "rating" -> "rating"),
+        selects = Map("listing_id" -> "listing", "ts" -> "ts", "rating" -> "CAST(rating/1.0 AS FLOAT)"),
         startPartition = startPartition,
         endPartition = endPartition,
         mutationTimeColumn = "mutation_time",


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Thanks @davidhan-stripe for reporting the issue. The PR will cast to double when passing into the Sum aggregator. 

It will run into the below error without this change:
```
java.lang.ClassCastException: class java.lang.Float cannot be cast to class java.lang.Double (java.lang.Float and java.lang.Double are in module java.base of loader 'bootstrap')
at scala.runtime.BoxesRunTime.unboxToDouble(BoxesRunTime.java:116)
at scala.math.Numeric$DoubleIsFractional$.plus(Numeric.scala:194)
at ai.chronon.aggregator.base.Sum.merge(SimpleAggregators.scala:28)
at ai.chronon.aggregator.base.BaseAggregator.$anonfun$bulkMerge$1(BaseAggregator.scala:11)
at scala.collection.TraversableOnce.$anonfun$reduceLeft$1(TraversableOnce.scala:195)
at scala.collection.TraversableOnce.$anonfun$reduceLeft$1$adapted(TraversableOnce.scala:190)
at scala.collection.Iterator.foreach(Iterator.scala:941)
at scala.collection.Iterator.foreach$(Iterator.scala:941)
at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
at scala.collection.TraversableOnce.reduceLeft(TraversableOnce.scala:190)
at scala.collection.TraversableOnce.reduceLeft$(TraversableOnce.scala:183)
at scala.collection.AbstractIterator.reduceLeft(Iterator.scala:1429)
at scala.collection.TraversableOnce.reduce(TraversableOnce.scala:213)
at scala.collection.TraversableOnce.reduce$(TraversableOnce.scala:213)
at scala.collection.AbstractIterator.reduce(Iterator.scala:1429)
at ai.chronon.aggregator.base.BaseAggregator.bulkMerge(BaseAggregator.scala:11)
at ai.chronon.aggregator.base.BaseAggregator.bulkMerge$(BaseAggregator.scala:11)
at ai.chronon.aggregator.base.Sum.bulkMerge(SimpleAggregators.scala:17)
at ai.chronon.aggregator.row.DirectColumnAggregator.bulkMerge(DirectColumnAggregator.scala:29)
at ai.chronon.aggregator.windowing.SawtoothMutationAggregator.updateIrTiledWithTileLayering(SawtoothMutationAggregator.scala:225)
at ai.chronon.aggregator.windowing.SawtoothOnlineAggregator.lambdaAggregateIrTiled(SawtoothOnlineAggregator.scala:117)
at ai.chronon.aggregator.windowing.SawtoothOnlineAggregator.lambdaAggregateFinalizedTiled(SawtoothOnlineAggregator.scala:138)
at ai.chronon.online.BaseFetcher.constructGroupByResponse(BaseFetcher.scala:168)
at ai.chronon.online.BaseFetcher.$anonfun$fetchGroupBys$26(BaseFetcher.scala:421)
```
## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
Before: the rating_sum is typed in float
```
2024-09-24 15:24:01 [INFO] [GroupByUpload$:219] schema for uploadDf: 
  string                                                                                                                                                                                  : user
  struct<list_event_last30:array<struct<epochMillis:bigint,payload:string>>,views_average:struct<sum:double,count:int>,views_average_1d:struct<sum:double,count:int>,rating_sum_1d:float> : collapsedIr
  array<array<struct<list_event_last30:array<struct<epochMillis:bigint,payload:string>>,views_average:struct<sum:double,count:int>,rating_sum:float,ts:bigint>>>                          : tailHopIrs
```
After:
The output schema for float type is now Double. 
```
2024-09-24 15:20:49 [INFO] [GroupByUpload$:219] schema for uploadDf: 
  string                                                                                                                                                                                   : user
  struct<list_event_last30:array<struct<epochMillis:bigint,payload:string>>,views_average:struct<sum:double,count:int>,views_average_1d:struct<sum:double,count:int>,rating_sum_1d:double> : collapsedIr
  array<array<struct<list_event_last30:array<struct<epochMillis:bigint,payload:string>>,views_average:struct<sum:double,count:int>,rating_sum:double,ts:bigint>>>                          : tailHopIrs
```
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@davidhan-stripe @hzding621 
