### PR TITLE
Fix Flaky CI Failure: use random namespace to avoid racing condition

### DIFF
--- a/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
@@ -30,23 +30,21 @@ import scala.util.Random
 class FeatureWithLabelJoinTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   val spark: SparkSession = SparkSessionBuilder.build("FeatureWithLabelJoinTest", local = true)
-
-  private val namespace = "final_join" + "_" + Random.alphanumeric.take(6).mkString
   private val tableName = "test_feature_label_join"
   private val tableUtils = TableUtils(spark)
-  tableUtils.createDatabase(namespace)
-
   private val labelDS = "2022-10-30"
-  private val viewsGroupBy = TestUtils.createViewsGroupBy(namespace, spark)
-  private val left = viewsGroupBy.groupByConf.sources.get(0)
 
   @Test
   def testFinalViews(): Unit = {
+       val namespace = "final_join" + "_" + Random.alphanumeric.take(6).mkString
+      tableUtils.createDatabase(namespace)
+       val viewsGroupBy = TestUtils.createViewsGroupBy(namespace, spark)
+       val left = viewsGroupBy.groupByConf.sources.get(0)
     // create test feature join table
     val featureTable = s"${namespace}.${tableName}"
     createTestFeatureTable().write.saveAsTable(featureTable)
 
-    val labelJoinConf = createTestLabelJoin(50, 20)
+    val labelJoinConf = createTestLabelJoin(50, 20,namespace=namespace)
     val joinConf = Builders.Join(
       Builders.MetaData(name = tableName, namespace = namespace, team = "chronon"),
       left,
@@ -105,6 +103,8 @@ class FeatureWithLabelJoinTest {
 
   @Test
   def testFinalViewsWithAggLabel(): Unit = {
+    val namespace = "final_join" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     // create test feature join table
     val tableName = "label_agg_table"
     val featureTable = s"${namespace}.${tableName}"
@@ -131,7 +131,7 @@ class FeatureWithLabelJoinTest {
       .groupByConf
       .sources
       .get(0)
-    val labelJoinConf = createTestAggLabelJoin(5, "listing_labels_agg")
+    val labelJoinConf = createTestAggLabelJoin(5, "listing_labels_agg", namespace=namespace)
     val joinConf = Builders.Join(
       Builders.MetaData(name = tableName, namespace = namespace, team = "chronon"),
       leftSource,
@@ -217,7 +217,8 @@ class FeatureWithLabelJoinTest {
 
   def createTestLabelJoin(startOffset: Int,
                           endOffset: Int,
-                          groupByTableName: String = "listing_labels"): ai.chronon.api.LabelPart = {
+                          groupByTableName: String = "listing_labels",
+                          namespace: String): ai.chronon.api.LabelPart = {
     val labelGroupBy = TestUtils.createRoomTypeGroupBy(namespace, spark, groupByTableName)
     Builders.LabelPart(
       labels = Seq(
@@ -229,7 +230,8 @@ class FeatureWithLabelJoinTest {
   }
 
   def createTestAggLabelJoin(windowSize: Int,
-                             groupByTableName: String = "listing_labels_agg"): ai.chronon.api.LabelPart = {
+                             groupByTableName: String = "listing_labels_agg",
+                             namespace: String): ai.chronon.api.LabelPart = {
     val labelGroupBy = TestUtils.createOrUpdateLabelGroupByWithAgg(namespace, spark, windowSize, groupByTableName)
     Builders.LabelPart(
       labels = Seq(

--- a/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FeatureWithLabelJoinTest.scala
@@ -36,10 +36,10 @@ class FeatureWithLabelJoinTest {
 
   @Test
   def testFinalViews(): Unit = {
-       val namespace = "final_join" + "_" + Random.alphanumeric.take(6).mkString
-      tableUtils.createDatabase(namespace)
-       val viewsGroupBy = TestUtils.createViewsGroupBy(namespace, spark)
-       val left = viewsGroupBy.groupByConf.sources.get(0)
+    val namespace = "final_join" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    val viewsGroupBy = TestUtils.createViewsGroupBy(namespace, spark)
+    val left = viewsGroupBy.groupByConf.sources.get(0)
     // create test feature join table
     val featureTable = s"${namespace}.${tableName}"
     createTestFeatureTable().write.saveAsTable(featureTable)

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -42,23 +42,26 @@ import scala.collection.Seq
 import scala.compat.java8.FutureConverters
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.concurrent.{Await, ExecutionContext}
+import scala.util.Random
 import scala.util.ScalaJavaConversions._
 
 class FetcherTest extends TestCase {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   val sessionName = "FetcherTest"
-  val spark: SparkSession = SparkSessionBuilder.build(sessionName, local = true)
-  private val tableUtils = TableUtils(spark)
+  val dummySpark: SparkSession = SparkSessionBuilder.build(sessionName, local = true)
+  private val dummyTableUtils = TableUtils(dummySpark)
   private val topic = "test_topic"
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-  private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-  private val yesterday = tableUtils.partitionSpec.before(today)
+  private val today = dummyTableUtils.partitionSpec.at(System.currentTimeMillis())
+  private val yesterday = dummyTableUtils.partitionSpec.before(today)
 
 
   /**
     * Generate deterministic data for testing and checkpointing IRs and streaming data.
     */
   def generateMutationData(namespace: String): api.Join = {
+    val spark: SparkSession = SparkSessionBuilder.build(sessionName + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     tableUtils.createDatabase(namespace)
     def toTs(arg: String): Long = TsUtils.datetimeToTs(arg)
     val eventData = Seq(
@@ -196,6 +199,8 @@ class FetcherTest extends TestCase {
   }
 
   def generateRandomData(namespace: String, keyCount: Int = 10, cardinality: Int = 100): api.Join = {
+    val spark: SparkSession = SparkSessionBuilder.build(sessionName + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     tableUtils.createDatabase(namespace)
     val rowCount = cardinality * keyCount
     val userCol = Column("user", StringType, keyCount)
@@ -381,8 +386,9 @@ class FetcherTest extends TestCase {
   }
 
   def generateEventOnlyData(namespace: String, groupByCustomJson: Option[String] = None): api.Join = {
+    val spark: SparkSession = SparkSessionBuilder.build(sessionName + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     tableUtils.createDatabase(namespace)
-
     def toTs(arg: String): Long = TsUtils.datetimeToTs(arg)
 
     val listingEventData = Seq(
@@ -508,7 +514,8 @@ class FetcherTest extends TestCase {
                            consistencyCheck: Boolean,
                            dropDsOnWrite: Boolean): Unit = {
     implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
-    implicit val tableUtils: TableUtils = TableUtils(spark)
+    val spark: SparkSession = SparkSessionBuilder.build(sessionName + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val kvStoreFunc = () => OnlineUtils.buildInMemoryKVStore("FetcherTest")
     val inMemoryKvStore = kvStoreFunc()
     val mockApi = new MockApi(kvStoreFunc, namespace)
@@ -645,7 +652,7 @@ class FetcherTest extends TestCase {
     val namespace = "generated_fetch"
     val joinConf = generateRandomData(namespace)
     compareTemporalFetch(joinConf,
-                         tableUtils.partitionSpec.at(System.currentTimeMillis()),
+                         dummyTableUtils.partitionSpec.at(System.currentTimeMillis()),
                          namespace,
                          consistencyCheck = true,
                          dropDsOnWrite = false)
@@ -659,6 +666,7 @@ class FetcherTest extends TestCase {
 
   // test soft-fail on missing keys
   def testEmptyRequest(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build(sessionName + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val namespace = "empty_request"
     val joinConf = generateRandomData(namespace, 5, 5)
     implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -19,19 +19,7 @@ package ai.chronon.spark.test
 import ai.chronon.aggregator.test.{CStream, Column, NaiveAggregator}
 import ai.chronon.aggregator.windowing.FiveMinuteResolution
 import ai.chronon.api.Extensions._
-import ai.chronon.api.{
-  Aggregation,
-  Builders,
-  Constants,
-  DoubleType,
-  IntType,
-  LongType,
-  Operation,
-  Source,
-  StringType,
-  TimeUnit,
-  Window
-}
+import ai.chronon.api.{Aggregation, Builders, Constants, DoubleType, IntType, LongType, Operation, Source, StringType, TimeUnit, Window}
 import ai.chronon.online.{RowWrapper, SparkConversions}
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark._
@@ -43,14 +31,15 @@ import org.junit.Assert._
 import org.junit.Test
 
 import scala.collection.mutable
+import scala.util.Random
 
 class GroupByTest {
-
-  lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest", local = true)
-  implicit val tableUtils = TableUtils(spark)
-
+//  lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest", local = true)
+//  implicit val tableUtils = TableUtils(spark)
   @Test
   def testSnapshotEntities(): Unit = {
+  lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+  implicit val tableUtils = TableUtils(spark)
     val schema = List(
       Column("user", StringType, 10),
       Column(Constants.TimeColumn, LongType, 100), // ts = last 100 days
@@ -85,6 +74,8 @@ class GroupByTest {
 
   @Test
   def testSnapshotEvents(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     val schema = List(
       Column("user", StringType, 10), // ts = last 10 days
       Column("session_length", IntType, 2),
@@ -137,6 +128,8 @@ class GroupByTest {
 
   @Test
   def eventsLastKTest(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     val eventSchema = List(
       Column("user", StringType, 10),
       Column("listing_view", StringType, 100)
@@ -206,6 +199,8 @@ class GroupByTest {
   }
   @Test
   def testTemporalEvents(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     val eventSchema = List(
       Column("user", StringType, 10),
       Column("session_length", IntType, 10000)
@@ -271,6 +266,7 @@ class GroupByTest {
   // Test that the output of Group by with Step Days is the same as the output without Steps (full data range)
   @Test
   def testStepDaysConsistency(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource()
     val tableUtils = TableUtils(spark)
     val testSteps = Option(30)
@@ -290,6 +286,7 @@ class GroupByTest {
 
   @Test
   def testGroupByAnalyzer(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource(30)
     val tableUtils = TableUtils(spark)
     val namespace = "test_analyzer_testGroupByAnalyzer"
@@ -318,9 +315,9 @@ class GroupByTest {
 
   @Test
   def testGroupByNoAggregationAnalyzer(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource(30)
     val testName = "unit_analyze_test_item_no_agg"
-
     val tableUtils = TableUtils(spark)
     val namespace = "test_analyzer_testGroupByNoAggregationAnalyzer"
     val groupByConf = Builders.GroupBy(
@@ -349,8 +346,8 @@ class GroupByTest {
   // test that OrderByLimit and OrderByLimitTimed serialization works well with Spark's data type
   @Test
   def testFirstKLastKTopKBottomKApproxUniqueCount(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource()
-
     val tableUtils = TableUtils(spark)
     val namespace = "test_order_by_limit"
     val aggs = Seq(
@@ -398,6 +395,8 @@ class GroupByTest {
   }
 
   private def createTestSource(windowSize: Int = 365, suffix: String = ""): (Source, String) = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val startPartition = tableUtils.partitionSpec.minus(today, new Window(windowSize, TimeUnit.DAYS))
     val endPartition = tableUtils.partitionSpec.at(System.currentTimeMillis())
@@ -443,6 +442,8 @@ class GroupByTest {
                        source: Source,
                        namespace: String,
                        additionalAgg: Seq[Aggregation] = Seq.empty): ai.chronon.api.GroupBy = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     Builders.GroupBy(
       sources = Seq(source),
       keyColumns = Seq("item"),
@@ -466,6 +467,7 @@ class GroupByTest {
   // Test percentile Impl on Spark.
   @Test
   def testPercentiles(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource(suffix = "_percentile")
     val tableUtils = TableUtils(spark)
     val namespace = "test_percentiles"
@@ -490,6 +492,7 @@ class GroupByTest {
 
   @Test
   def testApproxHistograms(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource(suffix = "_approx_histogram")
     val tableUtils = TableUtils(spark)
     val namespace = "test_approx_histograms"
@@ -544,6 +547,8 @@ class GroupByTest {
 
   @Test
   def testReplaceJoinSource(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     val namespace = "replace_join_source_ns"
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
 
@@ -559,6 +564,8 @@ class GroupByTest {
 
   @Test
   def testGroupByFromChainingGB(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
     val namespace = "test_chaining_gb"
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val joinName = "parent_join_table"
@@ -619,6 +626,7 @@ class GroupByTest {
 
   @Test
   def testDescriptiveStats(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val (source, endPartition) = createTestSource(suffix = "_descriptive_stats")
     val tableUtils = TableUtils(spark)
     val namespace = "test_descriptive_stats"

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -272,7 +272,6 @@ class GroupByTest {
   @Test
   def testStepDaysConsistency(): Unit = {
     val (source, endPartition) = createTestSource()
-
     val tableUtils = TableUtils(spark)
     val testSteps = Option(30)
     val namespace = "test_steps"
@@ -292,9 +291,8 @@ class GroupByTest {
   @Test
   def testGroupByAnalyzer(): Unit = {
     val (source, endPartition) = createTestSource(30)
-
     val tableUtils = TableUtils(spark)
-    val namespace = "test_analyzer"
+    val namespace = "test_analyzer_testGroupByAnalyzer"
     val groupByConf = getSampleGroupBy("unit_analyze_test_item_views", source, namespace)
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val (aggregationsMetadata, _) =
@@ -324,7 +322,7 @@ class GroupByTest {
     val testName = "unit_analyze_test_item_no_agg"
 
     val tableUtils = TableUtils(spark)
-    val namespace = "test_analyzer"
+    val namespace = "test_analyzer_testGroupByNoAggregationAnalyzer"
     val groupByConf = Builders.GroupBy(
       sources = Seq(source),
       keyColumns = Seq("item"),

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
@@ -36,13 +36,11 @@ import scala.util.ScalaJavaConversions.{JMapOps, ListOps, MapOps}
 
 class GroupByUploadTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
-
-  lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByUploadTest", local = true)
-  private val tableUtils = TableUtils(spark)
-
   @Test
   def temporalEventsLastKTest(): Unit = {
-    val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByUploadTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
+    val namespace = "group_by_upload_test" + "_" + Random.alphanumeric.take(6).mkString
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
     tableUtils.createDatabase(namespace)
@@ -72,6 +70,8 @@ class GroupByUploadTest {
 
   @Test
   def structSupportTest(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByUploadTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
@@ -115,6 +115,8 @@ class GroupByUploadTest {
 
   @Test
   def multipleAvgCountersTest(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByUploadTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
@@ -151,6 +153,8 @@ class GroupByUploadTest {
   // groupBy = keys:[listing, category], aggs:[avg(rating)]
   @Test
   def listingRatingCategoryJoinSourceTest(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByUploadTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     tableUtils.sql(s"USE $namespace")

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByUploadTest.scala
@@ -38,11 +38,11 @@ class GroupByUploadTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
 
   lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByUploadTest", local = true)
-  private val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
   private val tableUtils = TableUtils(spark)
 
   @Test
   def temporalEventsLastKTest(): Unit = {
+    val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
     tableUtils.createDatabase(namespace)
@@ -72,6 +72,7 @@ class GroupByUploadTest {
 
   @Test
   def structSupportTest(): Unit = {
+    val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
     tableUtils.createDatabase(namespace)
@@ -114,6 +115,7 @@ class GroupByUploadTest {
 
   @Test
   def multipleAvgCountersTest(): Unit = {
+    val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val yesterday = tableUtils.partitionSpec.before(today)
     tableUtils.createDatabase(namespace)
@@ -149,6 +151,7 @@ class GroupByUploadTest {
   // groupBy = keys:[listing, category], aggs:[avg(rating)]
   @Test
   def listingRatingCategoryJoinSourceTest(): Unit = {
+    val namespace = "group_by_upload_test"  + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     tableUtils.sql(s"USE $namespace")
 

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinFlowTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinFlowTest.scala
@@ -18,11 +18,11 @@ class JoinFlowTest {
   val spark: SparkSession = SparkSessionBuilder.build("JoinFlowTest", local = true)
   private val tableUtils = TableUtils(spark)
 
-  private val namespace = "test_namespace_joinflowtest" + "_" + Random.alphanumeric.take(6).mkString
-  tableUtils.createDatabase(namespace)
-
   @Test
   def testBootstrapAndDerivation(): Unit = {
+    val namespace = "test_namespace_joinflowtest" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+
     // in JoinBackfill Flow mode, left, rights and final steps are triggered by separate Driver mode
 
     val prefix = "test_bootstrap_and_derivation"

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -53,17 +53,17 @@ import scala.util.ScalaJavaConversions.ListOps
 import scala.util.Try
 
 class JoinTest {
-
-  val spark: SparkSession = SparkSessionBuilder.build("JoinTest", local = true)
-  private val tableUtils = TableUtils(spark)
-
-  private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-  private val monthAgo = tableUtils.partitionSpec.minus(today, new Window(30, TimeUnit.DAYS))
-  private val yearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
-  private val dayAndMonthBefore = tableUtils.partitionSpec.before(monthAgo)
+  val dummySpark: SparkSession = SparkSessionBuilder.build("JoinTest", local = true)
+  private val dummyTableUtils = TableUtils(dummySpark)
+  private val today = dummyTableUtils.partitionSpec.at(System.currentTimeMillis())
+  private val monthAgo = dummyTableUtils.partitionSpec.minus(today, new Window(30, TimeUnit.DAYS))
+  private val yearAgo = dummyTableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
+  private val dayAndMonthBefore = dummyTableUtils.partitionSpec.before(monthAgo)
 
   @Test
   def testEventsEntitiesSnapshot(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val dollarTransactions = List(
@@ -270,6 +270,8 @@ class JoinTest {
 
   @Test
   def testEntitiesEntities(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // untimed/unwindowed entities on right
@@ -393,6 +395,8 @@ class JoinTest {
 
   @Test
   def testEntitiesEntitiesNoHistoricalBackfill(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // Only backfill latest partition if historical_backfill is turned off
@@ -449,6 +453,8 @@ class JoinTest {
 
   @Test
   def testEventsEventsSnapshot(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val viewsSchema = List(
@@ -521,6 +527,8 @@ class JoinTest {
 
   @Test
   def testEventsEventsTemporal(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val joinConf = getEventsEventsTemporal("temporal", namespace)
@@ -600,6 +608,8 @@ class JoinTest {
 
   @Test
   def testEventsEventsCumulative(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // Create a cumulative source GroupBy
@@ -660,6 +670,8 @@ class JoinTest {
   }
 
   def getGroupByForIncrementalSourceTest() = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val messageData = Seq(
@@ -704,6 +716,8 @@ class JoinTest {
 
   @Test
   def testSourceQueryRender(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // Test cumulative
@@ -737,6 +751,8 @@ class JoinTest {
 
   @Test
   def testNoAgg(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // Left side entities, right side entities no agg
@@ -820,6 +836,8 @@ class JoinTest {
 
   @Test
   def testVersioning(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val joinConf = getEventsEventsTemporal("versioning", namespace)
@@ -924,7 +942,8 @@ class JoinTest {
       Column("item", api.StringType, 100),
       Column("time_spent_ms", api.LongType, 5000)
     )
-
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val viewsTable = s"$namespace.view_$suffix"
     val df = DataFrameGen.events(spark, viewsSchema, count = 1000, partitions = 200)
 
@@ -958,6 +977,8 @@ class JoinTest {
   }
 
   private def getEventsEventsTemporal(nameSuffix: String = "", namespace: String) = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     // left side
     val itemQueries = List(Column("item", api.StringType, 100))
     val itemQueriesTable = s"$namespace.item_queries"
@@ -979,6 +1000,8 @@ class JoinTest {
 
   @Test
   def testEndPartitionJoin(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val join = getEventsEventsTemporal("end_partition_test", namespace)
@@ -999,6 +1022,8 @@ class JoinTest {
 
   @Test
   def testSkipBloomFilterJoinBackfill(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val testSpark: SparkSession = SparkSessionBuilder.build(
@@ -1051,6 +1076,8 @@ class JoinTest {
 
   @Test
   def testStructJoin(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val nameSuffix = "_struct_test"
@@ -1112,6 +1139,8 @@ class JoinTest {
 
   @Test
   def testMigrationForBootstrap(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespaceMigration = "test_namespace_jointest"
     tableUtils.createDatabase(namespaceMigration)
 
@@ -1164,6 +1193,8 @@ class JoinTest {
   }
 
   private def prepareTopicTestConfs(prefix: String): (api.Join, String) = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left part
@@ -1229,8 +1260,8 @@ class JoinTest {
           Constants.SemanticHashExcludeTopic -> "false"
         ).asJava)
     )
-    tableUtils.alterTableProperties(join.metaData.outputTable, oldTableProperties)
-    tableUtils.alterTableProperties(join.metaData.bootstrapTable, oldTableProperties)
+    dummyTableUtils.alterTableProperties(join.metaData.outputTable, oldTableProperties)
+    dummyTableUtils.alterTableProperties(join.metaData.bootstrapTable, oldTableProperties)
   }
 
   private def hasExcludeTopicFlag(tableProps: Map[String, String], gson: Gson): Boolean = {
@@ -1241,6 +1272,8 @@ class JoinTest {
 
   @Test
   def testMigrationForTopicSuccess(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val (join, endDs) = prepareTopicTestConfs("test_migration_for_topic_success")
     def runJob(join: api.Join, shiftDays: Int): Unit = {
       val deepCopy = join.deepCopy()
@@ -1289,6 +1322,8 @@ class JoinTest {
 
   @Test
   def testMigrationForTopicManualArchive(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val (join, endDs) = prepareTopicTestConfs("test_migration_for_topic_manual_archive")
     def runJob(join: api.Join, shiftDays: Int, unsetSemanticHash: Boolean = false): Unit = {
       val deepCopy = join.deepCopy()
@@ -1330,6 +1365,8 @@ class JoinTest {
 
   @Test
   def testKeyMappingOverlappingFields(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // test the scenario when a key_mapping is a -> b, (right key b is mapped to left key a) and
@@ -1391,6 +1428,8 @@ class JoinTest {
     */
   @Test
   def testSelectedJoinParts(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // Left

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
@@ -36,8 +36,6 @@ class JoinUtilsTest {
 
   lazy val spark: SparkSession = SparkSessionBuilder.build("JoinUtilsTest", local = true)
   private val tableUtils = TableUtils(spark)
-  private val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
-  tableUtils.createDatabase(namespace)
   @Test
   def testUDFSetAdd(): Unit = {
     val data = Seq(
@@ -236,6 +234,8 @@ class JoinUtilsTest {
 
   @Test
   def testCreateJoinView(): Unit = {
+    val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     val finalViewName = "testCreateView"
     val leftTableName = s"${namespace}.testFeatureTable"
     val rightTableName = s"${namespace}.testLabelTable"
@@ -274,6 +274,8 @@ class JoinUtilsTest {
 
   @Test
   def testCreateLatestLabelView(): Unit = {
+    val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     val finalViewName = s"${namespace}.testFinalView"
     val leftTableName = s"${namespace}.testFeatureTable2"
     val rightTableName = s"${namespace}.testLabelTable2"
@@ -327,6 +329,8 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFill(): Unit = {
+    val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
     val itemQueriesTable = s"${namespace}.item_queries_table"
@@ -343,7 +347,8 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFillWithOverride(): Unit = {
-
+    val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
     val itemQueriesTable = s"${namespace}.queries_table"
@@ -361,7 +366,8 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFillWithEndPartition(): Unit = {
-
+    val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     // left table
     val itemQueries = List(Column("item", api.StringType, 100))
     val itemQueriesTable = s"${namespace}.queries_table"

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
@@ -236,7 +236,7 @@ class JoinUtilsTest {
   def testCreateJoinView(): Unit = {
     val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
-    val finalViewName = "testCreateView"
+    val finalViewName = s"${namespace}.testCreateView"
     val leftTableName = s"${namespace}.testFeatureTable"
     val rightTableName = s"${namespace}.testLabelTable"
     TestUtils.createSampleFeatureTableDf(spark).write.saveAsTable(leftTableName)

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
@@ -33,11 +33,10 @@ import scala.collection.mutable
 import scala.util.{Random, Try}
 
 class JoinUtilsTest {
-
-  lazy val spark: SparkSession = SparkSessionBuilder.build("JoinUtilsTest", local = true)
-  private val tableUtils = TableUtils(spark)
   @Test
   def testUDFSetAdd(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val data = Seq(
       Row(Seq("a", "b", "c"), "a"),
       Row(Seq("a", "b", "c"), "d"),
@@ -72,6 +71,8 @@ class JoinUtilsTest {
 
   @Test
   def testUDFContainsAny(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val data = Seq(
       Row(Seq("a", "b", "c"), Seq("a")),
       Row(Seq("a", "b", "c"), Seq("a", "b")),
@@ -105,6 +106,8 @@ class JoinUtilsTest {
                                rightSchema: StructType,
                                keys: Seq[String],
                                isFailure: Boolean): Try[DataFrame] = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val df = Try(
       JoinUtils.coalescedJoin(
         // using empty dataframe is sufficient to test spark query planning
@@ -234,6 +237,9 @@ class JoinUtilsTest {
 
   @Test
   def testCreateJoinView(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val finalViewName = s"${namespace}.testCreateView"
@@ -274,6 +280,9 @@ class JoinUtilsTest {
 
   @Test
   def testCreateLatestLabelView(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val finalViewName = s"${namespace}.testFinalView"
@@ -321,7 +330,10 @@ class JoinUtilsTest {
 
   @Test
   def testFilterColumns(): Unit = {
-    val testDf = createSampleTable()
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
+    val testDf = createSampleTable(spark = spark, tableUtils = tableUtils)
     val filter = Array("listing", "ds", "feature_review")
     val filteredDf = JoinUtils.filterColumns(testDf, filter)
     assertTrue(filteredDf.schema.fieldNames.sorted sameElements filter.sorted)
@@ -329,6 +341,9 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFill(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left table
@@ -347,6 +362,9 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFillWithOverride(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left table
@@ -366,6 +384,9 @@ class JoinUtilsTest {
 
   @Test
   def testGetRangesToFillWithEndPartition(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinUtilsTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "joinUtil" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left table
@@ -379,14 +400,17 @@ class JoinUtilsTest {
     val startBackfillDs = "2023-08-01"
     val endBackfillDs = "2023-08-08"
     val endQueryDs = "2023-08-15"
-    val leftSource = Builders.Source.events(Builders.Query(startPartition = startQueryDs, endPartition = endQueryDs), table = itemQueriesTable)
+    val leftSource = Builders.Source
+      .events(Builders.Query(startPartition = startQueryDs, endPartition = endQueryDs), table = itemQueriesTable)
     val range = JoinUtils.getRangesToFill(leftSource, tableUtils, endBackfillDs, Some(startBackfillDs))
     assertEquals(range, PartitionRange(startBackfillDs, endBackfillDs)(tableUtils))
   }
 
   import ai.chronon.api.{LongType, StringType, StructField, StructType}
 
-  def createSampleTable(tableName: String = "testSampleTable"): DataFrame = {
+  def createSampleTable(tableName: String = "testSampleTable",
+                        spark: SparkSession,
+                        tableUtils: TableUtils): DataFrame = {
     val schema = StructType(
       tableName,
       Array(

--- a/spark/src/test/scala/ai/chronon/spark/test/MigrationCompareTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MigrationCompareTest.scala
@@ -34,12 +34,10 @@ class MigrationCompareTest {
   private val tableUtils = TableUtils(spark)
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   private val ninetyDaysAgo = tableUtils.partitionSpec.minus(today, new Window(90, TimeUnit.DAYS))
-  private val namespace = "migration_compare_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
   private val monthAgo = tableUtils.partitionSpec.minus(today, new Window(30, TimeUnit.DAYS))
   private val yearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
-  tableUtils.createDatabase(namespace)
 
-  def setupTestData(): (api.Join, api.StagingQuery) = {
+  def setupTestData(namespace: String): (api.Join, api.StagingQuery) = {
     // ------------------------------------------JOIN------------------------------------------
     val viewsSchema = List(
       Column("user", api.StringType, 10000),
@@ -95,7 +93,9 @@ class MigrationCompareTest {
 
   @Test
   def testMigrateCompare(): Unit = {
-    val (joinConf, stagingQueryConf) = setupTestData()
+    val namespace = "migration_compare_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    val (joinConf, stagingQueryConf) = setupTestData(namespace)
 
     val (compareDf, metricsDf, metrics: DataMetrics) =
       new CompareJob(tableUtils, joinConf, stagingQueryConf, ninetyDaysAgo, today).run()
@@ -105,7 +105,9 @@ class MigrationCompareTest {
 
   @Test
   def testMigrateCompareWithLessColumns(): Unit = {
-    val (joinConf, _) = setupTestData()
+    val namespace = "migration_compare_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    val (joinConf, _) = setupTestData(namespace)
 
     // Run the staging query to generate the corresponding table for comparison
     val stagingQueryConf = Builders.StagingQuery(
@@ -124,7 +126,9 @@ class MigrationCompareTest {
 
   @Test
   def testMigrateCompareWithWindows(): Unit = {
-    val (joinConf, stagingQueryConf) = setupTestData()
+    val namespace = "migration_compare_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    val (joinConf, stagingQueryConf) = setupTestData(namespace )
 
     val (compareDf, metricsDf, metrics: DataMetrics) =
       new CompareJob(tableUtils, joinConf, stagingQueryConf, ninetyDaysAgo, today).run()
@@ -134,7 +138,9 @@ class MigrationCompareTest {
 
   @Test
   def testMigrateCompareWithLessData(): Unit = {
-    val (joinConf, _) = setupTestData()
+    val namespace = "migration_compare_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    val (joinConf, _) = setupTestData(namespace)
 
     val stagingQueryConf = Builders.StagingQuery(
       query = s"select * from ${joinConf.metaData.outputTable} where ds BETWEEN '${monthAgo}' AND '${today}'",

--- a/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
@@ -35,11 +35,11 @@ class StagingQueryTest {
 
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   private val ninetyDaysAgo = tableUtils.partitionSpec.minus(today, new Window(90, TimeUnit.DAYS))
-  private val namespace = "staging_query_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
-  tableUtils.createDatabase(namespace)
 
   @Test
   def testStagingQuery(): Unit = {
+    val namespace = "staging_query_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     val schema = List(
       Column("user", StringType, 10),
       Column("session_length", IntType, 1000)
@@ -107,6 +107,8 @@ class StagingQueryTest {
     */
   @Test
   def testStagingQueryAutoExpand(): Unit = {
+    val namespace = "staging_query_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     val schema = List(
       Column("user", StringType, 10),
       Column("session_length", IntType, 50),
@@ -183,6 +185,8 @@ class StagingQueryTest {
     */
   @Test
   def testStagingQueryLatestDate(): Unit = {
+    val namespace = "staging_query_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     val schema = List(
       Column("user", StringType, 10),
       Column("session_length", IntType, 1000)
@@ -235,6 +239,8 @@ class StagingQueryTest {
 
   @Test
   def testStagingQueryMaxDate(): Unit = {
+    val namespace = "staging_query_chronon_test" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
     val schema = List(
       Column("user", StringType, 10),
       Column("session_length", IntType, 1000)

--- a/spark/src/test/scala/ai/chronon/spark/test/StatsComputeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StatsComputeTest.scala
@@ -31,7 +31,6 @@ class StatsComputeTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   lazy val spark: SparkSession = SparkSessionBuilder.build("StatsComputeTest", local = true)
   implicit val tableUtils = TableUtils(spark)
-  val namespace: String = "stats_compute_test"
 
   @Test
   def summaryTest(): Unit = {
@@ -53,6 +52,7 @@ class StatsComputeTest {
 
   @Test
   def snapshotSummaryTest(): Unit = {
+    val namespace: String = "stats_compute_test"
     tableUtils.createDatabase(namespace)
     val data = Seq(
       ("1", Some(1L), Some(1.0), Some("a")),


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
The unit test suite is running in parallel in CI. Due to the massive table creations, it might lead to racing condition during different test cases. This PR will create a different randomized namespace for each test case to isolate the table content. It should fix the flaky CI checks. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Improve code quality and fix flaky testing CI

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@yuli-han @hzding621 
