### PR TITLE
Fix flaky CI - Part II: derivation test and the mutation test

### DIFF
--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/DataGen.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/DataGen.scala
@@ -29,13 +29,13 @@ abstract class CStream[+T: ClassTag] {
   def next(): T
 
   // roll a dice that gives max to min uniformly, with nulls interspersed as per null rate
-  protected def rollDouble(max: JDouble, min: JDouble = 0, nullRate: Double = 0.1): JDouble = {
+  protected def rollDouble(max: JDouble, min: JDouble = 0, nullRate: Double = 0.05): JDouble = {
     val dice: Double = math.random
     if (dice < nullRate) null
     else min + ((max - min) * math.random)
   }
 
-  protected def rollFloat(max: Double, min: Double = 0.0, nullRate: Double = 0.1): JFloat = {
+  protected def rollFloat(max: Double, min: Double = 0.0, nullRate: Double = 0.05): JFloat = {
     val dice: Double = math.random
     if (dice < nullRate)
       return null
@@ -44,7 +44,7 @@ abstract class CStream[+T: ClassTag] {
   }
 
   // roll a dice that gives max to min uniformly, with nulls interspersed as per null rate
-  protected def roll(max: JLong, min: JLong = 0, nullRate: Double = 0.1): JLong = {
+  protected def roll(max: JLong, min: JLong = 0, nullRate: Double = 0.05): JLong = {
     val roll = rollDouble(max.toDouble, min.toDouble, nullRate)
     if (roll == null) null else roll.toLong
   }
@@ -53,7 +53,7 @@ abstract class CStream[+T: ClassTag] {
     Stream.fill(count)(next())
   }
 
-  def chunk(minSize: Long = 0, maxSize: Long = 10, nullRate: Double = 0.1): CStream[Seq[T]] = {
+  def chunk(minSize: Long = 0, maxSize: Long = 10, nullRate: Double = 0.05): CStream[Seq[T]] = {
     def innerNext(): T = next()
     new CStream[Seq[T]] {
       override def next(): Seq[T] = {
@@ -94,7 +94,7 @@ object CStream {
     override def next(): String = Option(roll(keys.length, nullRate = 0)).map(dice => keys(dice.toInt)).get
   }
 
-  class StringStream(count: Int, prefix: String, nullRate: Double = 0.2) extends CStream[String] {
+  class StringStream(count: Int, prefix: String, nullRate: Double = 0.05) extends CStream[String] {
     val keyCount: Int = (count * (1 - nullRate)).ceil.toInt
     val keys: Array[String] = {
       val fullKeySet = (1 until (count + 1)).map(i => s"$prefix$i")
@@ -115,22 +115,22 @@ object CStream {
     }
   }
 
-  class IntStream(max: Int = 10000, nullRate: Double = 0.1) extends CStream[Integer] {
+  class IntStream(max: Int = 10000, nullRate: Double = 0.05) extends CStream[Integer] {
     override def next(): Integer =
       Option(roll(max, 1, nullRate = nullRate)).map(dice => Integer.valueOf(dice.toInt)).orNull
   }
 
-  class LongStream(max: Int = 10000, nullRate: Double = 0.1) extends CStream[JLong] {
+  class LongStream(max: Int = 10000, nullRate: Double = 0.05) extends CStream[JLong] {
     override def next(): JLong =
       Option(roll(max, 1, nullRate = nullRate)).map(java.lang.Long.valueOf(_)).orNull
   }
 
-  class DoubleStream(max: Double = 10000, nullRate: Double = 0.1) extends CStream[JDouble] {
+  class DoubleStream(max: Double = 10000, nullRate: Double = 0.05) extends CStream[JDouble] {
     override def next(): JDouble =
       Option(rollDouble(max, 1, nullRate = nullRate)).map(java.lang.Double.valueOf(_)).orNull
   }
 
-  class FloatStream(max: Double = 10000, nullRate: Double = 0.1) extends CStream[JFloat] {
+  class FloatStream(max: Double = 10000, nullRate: Double = 0.05) extends CStream[JFloat] {
     override def next(): JFloat =
       Option(rollFloat(max, 1, nullRate = nullRate)).map(java.lang.Float.valueOf(_)).orNull
   }
@@ -153,7 +153,7 @@ object CStream {
   }
 }
 
-case class Column(name: String, `type`: DataType, cardinality: Int, chunkSize: Int = 10, nullRate: Double = 0.1) {
+case class Column(name: String, `type`: DataType, cardinality: Int, chunkSize: Int = 10, nullRate: Double = 0.05) {
   def genImpl(dtype: DataType, partitionColumn: String, partitionSpec: PartitionSpec): CStream[Any] =
     dtype match {
       case StringType =>

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/DataGen.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/DataGen.scala
@@ -29,13 +29,13 @@ abstract class CStream[+T: ClassTag] {
   def next(): T
 
   // roll a dice that gives max to min uniformly, with nulls interspersed as per null rate
-  protected def rollDouble(max: JDouble, min: JDouble = 0, nullRate: Double = 0.05): JDouble = {
+  protected def rollDouble(max: JDouble, min: JDouble = 0, nullRate: Double = 0.01): JDouble = {
     val dice: Double = math.random
     if (dice < nullRate) null
     else min + ((max - min) * math.random)
   }
 
-  protected def rollFloat(max: Double, min: Double = 0.0, nullRate: Double = 0.05): JFloat = {
+  protected def rollFloat(max: Double, min: Double = 0.0, nullRate: Double = 0.01): JFloat = {
     val dice: Double = math.random
     if (dice < nullRate)
       return null
@@ -44,7 +44,7 @@ abstract class CStream[+T: ClassTag] {
   }
 
   // roll a dice that gives max to min uniformly, with nulls interspersed as per null rate
-  protected def roll(max: JLong, min: JLong = 0, nullRate: Double = 0.05): JLong = {
+  protected def roll(max: JLong, min: JLong = 0, nullRate: Double = 0.01): JLong = {
     val roll = rollDouble(max.toDouble, min.toDouble, nullRate)
     if (roll == null) null else roll.toLong
   }
@@ -53,7 +53,7 @@ abstract class CStream[+T: ClassTag] {
     Stream.fill(count)(next())
   }
 
-  def chunk(minSize: Long = 0, maxSize: Long = 10, nullRate: Double = 0.05): CStream[Seq[T]] = {
+  def chunk(minSize: Long = 0, maxSize: Long = 10, nullRate: Double = 0.01): CStream[Seq[T]] = {
     def innerNext(): T = next()
     new CStream[Seq[T]] {
       override def next(): Seq[T] = {
@@ -94,7 +94,7 @@ object CStream {
     override def next(): String = Option(roll(keys.length, nullRate = 0)).map(dice => keys(dice.toInt)).get
   }
 
-  class StringStream(count: Int, prefix: String, nullRate: Double = 0.05) extends CStream[String] {
+  class StringStream(count: Int, prefix: String, nullRate: Double = 0.01) extends CStream[String] {
     val keyCount: Int = (count * (1 - nullRate)).ceil.toInt
     val keys: Array[String] = {
       val fullKeySet = (1 until (count + 1)).map(i => s"$prefix$i")
@@ -115,22 +115,22 @@ object CStream {
     }
   }
 
-  class IntStream(max: Int = 10000, nullRate: Double = 0.05) extends CStream[Integer] {
+  class IntStream(max: Int = 10000, nullRate: Double = 0.01) extends CStream[Integer] {
     override def next(): Integer =
       Option(roll(max, 1, nullRate = nullRate)).map(dice => Integer.valueOf(dice.toInt)).orNull
   }
 
-  class LongStream(max: Int = 10000, nullRate: Double = 0.05) extends CStream[JLong] {
+  class LongStream(max: Int = 10000, nullRate: Double = 0.01) extends CStream[JLong] {
     override def next(): JLong =
       Option(roll(max, 1, nullRate = nullRate)).map(java.lang.Long.valueOf(_)).orNull
   }
 
-  class DoubleStream(max: Double = 10000, nullRate: Double = 0.05) extends CStream[JDouble] {
+  class DoubleStream(max: Double = 10000, nullRate: Double = 0.01) extends CStream[JDouble] {
     override def next(): JDouble =
       Option(rollDouble(max, 1, nullRate = nullRate)).map(java.lang.Double.valueOf(_)).orNull
   }
 
-  class FloatStream(max: Double = 10000, nullRate: Double = 0.05) extends CStream[JFloat] {
+  class FloatStream(max: Double = 10000, nullRate: Double = 0.01) extends CStream[JFloat] {
     override def next(): JFloat =
       Option(rollFloat(max, 1, nullRate = nullRate)).map(java.lang.Float.valueOf(_)).orNull
   }
@@ -153,7 +153,7 @@ object CStream {
   }
 }
 
-case class Column(name: String, `type`: DataType, cardinality: Int, chunkSize: Int = 10, nullRate: Double = 0.05) {
+case class Column(name: String, `type`: DataType, cardinality: Int, chunkSize: Int = 10, nullRate: Double = 0.01) {
   def genImpl(dtype: DataType, partitionColumn: String, partitionSpec: PartitionSpec): CStream[Any] =
     dtype match {
       case StringType =>

--- a/build.sbt
+++ b/build.sbt
@@ -340,10 +340,10 @@ lazy val online_unshaded = (project in file("online"))
 
 
 def cleanSparkMeta(): Unit = {
-  Folder.clean(file(".") / "spark" / "spark-warehouse",
-               file(tmp_warehouse) / "spark-warehouse",
-               file(".") / "spark" / "metastore_db",
-               file(tmp_warehouse) / "metastore_db")
+  Folder.clean(file(".") / "spark" / "spark-warehouse*",
+               file(tmp_warehouse) / "spark-warehouse*",
+               file(".") / "spark" / "metastore_db*",
+               file(tmp_warehouse) / "metastore_db*")
 }
 
 val sparkBaseSettings: Seq[Setting[_]] = Seq(

--- a/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
@@ -27,10 +27,6 @@ import scala.util.Properties
 
 object SparkSessionBuilder {
   @transient private lazy val logger = LoggerFactory.getLogger(getClass)
-
-  private val warehouseId = java.util.UUID.randomUUID().toString.takeRight(6)
-  private val DefaultWarehouseDir = new File("/tmp/chronon/spark-warehouse_" + warehouseId)
-
   def expandUser(path: String): String = path.replaceFirst("~", System.getProperty("user.home"))
   // we would want to share locally generated warehouse during CI testing
   def build(name: String,
@@ -42,6 +38,8 @@ object SparkSessionBuilder {
       //required to run spark locally with hive support enabled - for sbt test
       System.setSecurityManager(null)
     }
+    val warehouseId = java.util.UUID.randomUUID().toString.takeRight(6)
+    val DefaultWarehouseDir = new File("/tmp/chronon/spark-warehouse_" + warehouseId)
     val userName = Properties.userName
     val warehouseDir = localWarehouseLocation.map(expandUser).getOrElse(DefaultWarehouseDir.getAbsolutePath)
     var baseBuilder = SparkSession

--- a/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SparkSessionBuilder.scala
@@ -27,6 +27,10 @@ import scala.util.Properties
 
 object SparkSessionBuilder {
   @transient private lazy val logger = LoggerFactory.getLogger(getClass)
+
+  private val warehouseId = java.util.UUID.randomUUID().toString.takeRight(6)
+  private val DefaultWarehouseDir = new File("/tmp/chronon/spark-warehouse_" + warehouseId)
+
   def expandUser(path: String): String = path.replaceFirst("~", System.getProperty("user.home"))
   // we would want to share locally generated warehouse during CI testing
   def build(name: String,
@@ -38,8 +42,6 @@ object SparkSessionBuilder {
       //required to run spark locally with hive support enabled - for sbt test
       System.setSecurityManager(null)
     }
-    val warehouseId = java.util.UUID.randomUUID().toString.takeRight(6)
-    val DefaultWarehouseDir = new File("/tmp/chronon/spark-warehouse_" + warehouseId)
     val userName = Properties.userName
     val warehouseDir = localWarehouseLocation.map(expandUser).getOrElse(DefaultWarehouseDir.getAbsolutePath)
     var baseBuilder = SparkSession

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -31,17 +31,19 @@ import scala.util.Random
 
 class AnalyzerTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
-  val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest", local = true)
-  private val tableUtils = TableUtils(spark)
+  val dummySpark: SparkSession = SparkSessionBuilder.build("AnalyzerTest", local = true)
+  private val dummyTableUtils = TableUtils(dummySpark)
 
-  private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-  private val oneMonthAgo = tableUtils.partitionSpec.minus(today, new Window(30, TimeUnit.DAYS))
-  private val oneYearAgo = tableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
+  private val today = dummyTableUtils.partitionSpec.at(System.currentTimeMillis())
+  private val oneMonthAgo = dummyTableUtils.partitionSpec.minus(today, new Window(30, TimeUnit.DAYS))
+  private val oneYearAgo = dummyTableUtils.partitionSpec.minus(today, new Window(365, TimeUnit.DAYS))
 
   @Test
   def testJoinAnalyzerSchemaWithValidation(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest", local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
-      tableUtils.createDatabase(namespace)
+    tableUtils.createDatabase(namespace)
     val viewsGroupBy = getViewsGroupBy("join_analyzer_test.item_gb", Operation.AVERAGE, source = getTestEventSource(namespace), namespace = namespace)
     val anotherViewsGroupBy = getViewsGroupBy("join_analyzer_test.another_item_gb", Operation.SUM,source = getTestEventSource(namespace), namespace = namespace)
 
@@ -89,6 +91,8 @@ class AnalyzerTest {
 
   @Test(expected = classOf[java.lang.AssertionError])
   def testJoinAnalyzerValidationFailure(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val viewsGroupBy = getViewsGroupBy("join_analyzer_test.item_gb", Operation.AVERAGE, source = getTestGBSource(namespace), namespace = namespace)
@@ -120,6 +124,8 @@ class AnalyzerTest {
 
   @Test(expected = classOf[java.lang.AssertionError])
   def testJoinAnalyzerValidationDataAvailability(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left side
@@ -158,6 +164,8 @@ class AnalyzerTest {
 
   @Test
   def testJoinAnalyzerValidationDataAvailabilityMultipleSources(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val leftSchema = List(Column("item", api.StringType, 100))
@@ -227,6 +235,8 @@ class AnalyzerTest {
 
   @Test
   def testJoinAnalyzerCheckTimestampHasValues(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left side
@@ -260,6 +270,8 @@ class AnalyzerTest {
 
   @Test(expected = classOf[java.lang.AssertionError])
   def testJoinAnalyzerCheckTimestampOutOfRange(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left side
@@ -293,6 +305,8 @@ class AnalyzerTest {
 
   @Test(expected = classOf[java.lang.AssertionError])
   def testJoinAnalyzerCheckTimestampAllNulls(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left side
@@ -326,6 +340,8 @@ class AnalyzerTest {
 
   @Test
   def testGroupByAnalyzerCheckTimestampHasValues(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val tableGroupBy = Builders.GroupBy(
@@ -346,6 +362,8 @@ class AnalyzerTest {
 
   @Test(expected = classOf[java.lang.AssertionError])
   def testGroupByAnalyzerCheckTimestampAllNulls(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val tableGroupBy = Builders.GroupBy(
@@ -365,6 +383,8 @@ class AnalyzerTest {
 
   @Test(expected = classOf[java.lang.AssertionError])
   def testGroupByAnalyzerCheckTimestampOutOfRange(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     val tableGroupBy = Builders.GroupBy(
@@ -384,6 +404,7 @@ class AnalyzerTest {
   }
 
   def getTestGBSourceWithTs(option: String = "default", namespace: String): api.Source = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val testSchema = List(
       Column("key", api.StringType, 10),
       Column("col1", api.IntType, 10),
@@ -421,6 +442,7 @@ class AnalyzerTest {
   }
 
   def getTestGBSource(namespace: String): api.Source = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val viewsSchema = List(
       Column("user", api.StringType, 10000),
       Column("item_id", api.IntType, 100), // type mismatch
@@ -438,6 +460,7 @@ class AnalyzerTest {
   }
 
   def getTestEventSource(namespace: String): api.Source = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val viewsSchema = List(
       Column("user", api.StringType, 10000),
       Column("item_id", api.StringType, 100),

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinUtilsTest.scala
@@ -308,7 +308,7 @@ class JoinUtilsTest {
     assertEquals(6, view.count())
 
     //verity latest label view
-    val latestLabelView = "testLatestLabel"
+    val latestLabelView = s"${namespace}.testLatestLabel"
     JoinUtils.createLatestLabelView(latestLabelView,
                                     finalViewName,
                                     tableUtils,

--- a/spark/src/test/scala/ai/chronon/spark/test/MutationsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MutationsTest.scala
@@ -283,10 +283,10 @@ class MutationsTest {
          |     mutations.ds AS mutation_ds,
          |     COALESCE(snapshot.rating_std, 0)      AS rating_std,
          |     COALESCE(snapshot.rating_ctd, 0)      AS rating_ctd,
-         |     SUM(IF($includeCondition, mutations.rating, 0)) AS rating_add_sum,
-         |     SUM(IF($excludeCondition, mutations.rating, 0)) AS rating_sub_sum,
-         |     COUNT(IF($includeCondition, mutations.rating, NULL)) AS rating_add_cnt,
-         |     COUNT(IF($excludeCondition, mutations.rating, NULL)) AS rating_sub_cnt
+         |     COALESCE(SUM(IF($includeCondition, mutations.rating, 0)), 0) AS rating_add_sum,
+         |     COALESCE(SUM(IF($excludeCondition, mutations.rating, 0)), 0) AS rating_sub_sum,
+         |     COALESCE(COUNT(IF($includeCondition, mutations.rating, NULL)), 0) AS rating_add_cnt,
+         |     COALESCE(COUNT(IF($excludeCondition, mutations.rating, NULL)), 0) AS rating_sub_cnt
          |   FROM queries
          |   LEFT OUTER JOIN snapshot
          |     ON queries.listing_id = snapshot.listing_id
@@ -989,7 +989,7 @@ class MutationsTest {
       "MutationsTest" + "_" + Random.alphanumeric.take(6).mkString,
       local = true,
       additionalConfig = Some(Map("spark.chronon.backfill.validation.enabled" -> "false")))
-    implicit val tableUtils: TableUtils = TableUtils(spark)
+    val tableUtils: TableUtils = TableUtils(spark)
     val suffix = "generated" + "_" + Random.alphanumeric.take(6).mkString
     val reviews = List(
       Column("listing_id", api.StringType, 100),

--- a/spark/src/test/scala/ai/chronon/spark/test/MutationsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MutationsTest.scala
@@ -37,7 +37,7 @@ import scala.util.Random
 class MutationsTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
 
-  private def namespace(suffix: String) = s"test_mutations_$suffix"
+  private def namespace(suffix: String) = s"test_mutations_${suffix}"
   private val groupByName = s"group_by_test.v0"
   private val joinName = s"join_test.v0"
 
@@ -150,7 +150,6 @@ class MutationsTest {
       "MutationsTest" + "_" + Random.alphanumeric.take(6).mkString,
       local = true,
       additionalConfig = Some(Map("spark.chronon.backfill.validation.enabled" -> "false")))
-    implicit val tableUtils: TableUtils = TableUtils(spark)
     val testNamespace = namespace(suffix)
     spark.sql(s"CREATE DATABASE IF NOT EXISTS $testNamespace")
     spark.createDataFrame(spark.sparkContext.parallelize(eventData), leftSchema).save(s"$testNamespace.$eventTable")
@@ -451,7 +450,7 @@ class MutationsTest {
     */
   @Test
   def testSimplestCase(): Unit = {
-    val suffix = "simple"
+    val suffix = "simple" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       Row(1, 1, TsUtils.datetimeToTs("2021-04-10 01:00:00"), "2021-04-10"),
       Row(1, 1, TsUtils.datetimeToTs("2021-04-10 02:30:00"), "2021-04-10"),
@@ -524,7 +523,7 @@ class MutationsTest {
     */
   @Test
   def testUpdateValueCase(): Unit = {
-    val suffix = "update_value"
+    val suffix = "update_value" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       // {listing_id, ts, event, ds}
       Row(1, 1, TsUtils.datetimeToTs("2021-04-10 01:00:00"), "2021-04-10"),
@@ -596,7 +595,7 @@ class MutationsTest {
     */
   @Test
   def testUpdateKeyCase(): Unit = {
-    val suffix = "update_key"
+    val suffix = "update_key" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       Row(1, 1, TsUtils.datetimeToTs("2021-04-10 01:00:00"), "2021-04-10"),
       Row(2, 1, TsUtils.datetimeToTs("2021-04-10 02:30:00"), "2021-04-10"),
@@ -674,7 +673,7 @@ class MutationsTest {
     */
   @Test
   def testInconsistentTsLeftCase(): Unit = {
-    val suffix = "inconsistent_ts"
+    val suffix = "inconsistent_ts" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       Row(1, 1, TsUtils.datetimeToTs("2021-04-10 01:00:00"), "2021-04-10"),
       Row(2, 1, TsUtils.datetimeToTs("2021-04-09 04:30:00"), "2021-04-10"),
@@ -774,7 +773,7 @@ class MutationsTest {
     */
   @Test
   def testDecayedWindowCase(): Unit = {
-    val suffix = "decayed"
+    val suffix = "decayed" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       Row(2, 1, TsUtils.datetimeToTs("2021-04-09 01:30:00"), "2021-04-10"),
       Row(2, 1, TsUtils.datetimeToTs("2021-04-09 04:30:00"), "2021-04-10"),
@@ -871,7 +870,7 @@ class MutationsTest {
     */
   @Test
   def testDecayedWindowCaseNoMutation(): Unit = {
-    val suffix = "decayed_v2"
+    val suffix = "decayed_v2" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       Row(2, 1, TsUtils.datetimeToTs("2021-04-10 01:00:00"), "2021-04-10"),
       Row(2, 1, TsUtils.datetimeToTs("2021-04-10 23:00:00"), "2021-04-10")
@@ -925,7 +924,7 @@ class MutationsTest {
     */
   @Test
   def testNoSnapshotJustMutation(): Unit = {
-    val suffix = "no_mutation"
+    val suffix = "no_mutation" + "_" + Random.alphanumeric.take(6).mkString
     val eventData = Seq(
       Row(2, 1, TsUtils.datetimeToTs("2021-04-10 00:07:00"), "2021-04-10"),
       Row(2, 1, TsUtils.datetimeToTs("2021-04-10 01:07:00"), "2021-04-10"),
@@ -991,7 +990,7 @@ class MutationsTest {
       local = true,
       additionalConfig = Some(Map("spark.chronon.backfill.validation.enabled" -> "false")))
     implicit val tableUtils: TableUtils = TableUtils(spark)
-    val suffix = "generated"
+    val suffix = "generated" + "_" + Random.alphanumeric.take(6).mkString
     val reviews = List(
       Column("listing_id", api.StringType, 100),
       Column("rating", api.LongType, 100)

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
@@ -33,17 +33,20 @@ import org.junit.Test
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import scala.util.Random
 import scala.util.ScalaJavaConversions.JListOps
 
 class DerivationTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
 
-  val spark: SparkSession = SparkSessionBuilder.build("DerivationTest", local = true)
-  private val tableUtils = TableUtils(spark)
-  private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+  val dummySpark: SparkSession = SparkSessionBuilder.build("DerivationTest", local = true)
+  private val dummyTableUtils = TableUtils(dummySpark)
+  private val today = dummyTableUtils.partitionSpec.at(System.currentTimeMillis())
 
   @Test
   def testBootstrapToDerivations(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("DerivationTest"+ "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_derivations"
     tableUtils.createDatabase(namespace)
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
@@ -291,6 +294,8 @@ class DerivationTest {
 
   @Test
   def testBootstrapToDerivationsNoStar(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("DerivationTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_derivations_no_star"
     tableUtils.createDatabase(namespace)
 
@@ -374,6 +379,8 @@ class DerivationTest {
   }
 
   private def runLoggingTest(namespace: String, wildcardSelection: Boolean): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("DerivationTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     tableUtils.createDatabase(namespace)
 
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
@@ -499,6 +506,8 @@ class DerivationTest {
 
   @Test
   def testContextual(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("DerivationTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_contextual"
     tableUtils.createDatabase(namespace)
     val queryTable = BootstrapUtils.buildQuery(namespace, spark)
@@ -628,6 +637,8 @@ class DerivationTest {
 
   @Test
   def testGroupByDerivations(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("DerivationTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
     val namespace = "test_group_by_derivations"
     tableUtils.createDatabase(namespace)
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
@@ -194,7 +194,8 @@ class DerivationTest {
         (rand() * 30000)
           .cast(org.apache.spark.sql.types.LongType)
           .as("ext_payments_service_user_txn_count_15d"),
-        col("ds")
+        col("ds"),
+        col("user")
       )
       .sample(0.8)
     val externalBootstrapTable = s"$namespace.bootstrap_external"
@@ -202,7 +203,7 @@ class DerivationTest {
     val externalBootstrapRange = externalBootstrapDf.partitionRange
     val externalBootstrapPart = Builders.BootstrapPart(
       query = Builders.Query(
-        selects = Builders.Selects("request_id", "ext_payments_service_user_txn_count_15d"),
+        selects = Builders.Selects("request_id", "ext_payments_service_user_txn_count_15d", "user"),
         startPartition = externalBootstrapRange.start,
         endPartition = externalBootstrapRange.end
       ),


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR is the second part to fix the flaky CI. The first PR is at: https://github.com/airbnb/chronon/pull/842

For derivation test, `user` is missing the select query to construct the result.

For the mutation test, this has been failing for the long time for the repo, the rating average can be null from the sql query result, whereas the join has a valid average. This could be caused by the existence of a null value in the nominator or the denominator. If any value in the numerator (rating_std + rating_add_sum - rating_sub_sum) is null, then the whole expression will be null. Vice versa for the denominator. 
The fix is to use `COALESCE` to avoid null in the formula.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Improve CI robustness. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @yuli-han 
