### PR TITLE
Use builder pattern to create java fetcher and add a default log publish error rate of 0.1%

### DIFF
--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -46,6 +46,57 @@ public class JavaFetcher {
     this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, flagStore, disableErrorThrows);
   }
 
+  // user builder pattern to create JavaFetcher
+  private JavaFetcher(Builder builder) {
+    this.fetcher = new Fetcher(builder.kvStore, builder.metaDataSet, builder.timeoutMillis, builder.logFunc,
+            builder.debug, builder.registry, builder.callerName, builder.flagStore, builder.disableErrorThrows);
+  }
+
+  public static class Builder {
+    private KVStore kvStore;
+    private String metaDataSet;
+    private Long timeoutMillis;
+    private Consumer<LoggableResponse> logFunc;
+    private ExternalSourceRegistry registry;
+    private String callerName;
+    private Boolean debug;
+    private FlagStore flagStore;
+    private Boolean disableErrorThrows;
+
+    public Builder(KVStore kvStore, String metaDataSet, Long timeoutMillis,
+                   Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
+      this.kvStore = kvStore;
+      this.metaDataSet = metaDataSet;
+      this.timeoutMillis = timeoutMillis;
+      this.logFunc = logFunc;
+      this.registry = registry;
+    }
+
+    public Builder callerName(String callerName) {
+      this.callerName = callerName;
+      return this;
+    }
+
+    public Builder flagStore(FlagStore flagStore) {
+      this.flagStore = flagStore;
+      return this;
+    }
+
+    public Builder disableErrorThrows(Boolean disableErrorThrows) {
+      this.disableErrorThrows = disableErrorThrows;
+      return this;
+    }
+
+    public Builder debug(Boolean debug) {
+      this.debug = debug;
+      return this;
+    }
+
+    public JavaFetcher build() {
+      return new JavaFetcher(this);
+    }
+  }
+
 
   public static List<JavaResponse> toJavaResponses(Seq<Response> responseSeq) {
     List<JavaResponse> result = new ArrayList<>(responseSeq.size());

--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -32,181 +32,196 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class JavaFetcher {
-  Fetcher fetcher;
+    Fetcher fetcher;
 
-  public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry, String callerName, Boolean disableErrorThrows) {
-    this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, null, disableErrorThrows);
-  }
-
-  public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
-    this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, null, null, false);
-  }
-
-  public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry, String callerName, FlagStore flagStore, Boolean disableErrorThrows) {
-    this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, flagStore, disableErrorThrows);
-  }
-
-  // user builder pattern to create JavaFetcher
-  private JavaFetcher(Builder builder) {
-    this.fetcher = new Fetcher(builder.kvStore, builder.metaDataSet, builder.timeoutMillis, builder.logFunc,
-            builder.debug, builder.registry, builder.callerName, builder.flagStore, builder.disableErrorThrows);
-  }
-
-  public static class Builder {
-    private KVStore kvStore;
-    private String metaDataSet;
-    private Long timeoutMillis;
-    private Consumer<LoggableResponse> logFunc;
-    private ExternalSourceRegistry registry;
-    private String callerName;
-    private Boolean debug;
-    private FlagStore flagStore;
-    private Boolean disableErrorThrows;
-
-    public Builder(KVStore kvStore, String metaDataSet, Long timeoutMillis,
-                   Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
-      this.kvStore = kvStore;
-      this.metaDataSet = metaDataSet;
-      this.timeoutMillis = timeoutMillis;
-      this.logFunc = logFunc;
-      this.registry = registry;
+    public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry, String callerName, Boolean disableErrorThrows) {
+        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, null, disableErrorThrows);
     }
 
-    public Builder callerName(String callerName) {
-      this.callerName = callerName;
-      return this;
+    public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
+        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, null, null, false);
     }
 
-    public Builder flagStore(FlagStore flagStore) {
-      this.flagStore = flagStore;
-      return this;
+    public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry, String callerName, FlagStore flagStore, Boolean disableErrorThrows) {
+        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, flagStore, disableErrorThrows);
     }
 
-    public Builder disableErrorThrows(Boolean disableErrorThrows) {
-      this.disableErrorThrows = disableErrorThrows;
-      return this;
+    /* user builder pattern to create JavaFetcher
+    example way to create the java fetcher
+    JavaFetcher fetcher = new JavaFetcher.Builder(kvStore, metaDataSet, timeoutMillis, logFunc, registry)
+                                        .callerName(callerName)
+                                        .flagStore(flagStore)
+                                        .disableErrorThrows(disableErrorThrows)
+                                        .build();
+     */
+    private JavaFetcher(Builder builder) {
+        this.fetcher = new Fetcher(builder.kvStore,
+                builder.metaDataSet,
+                builder.timeoutMillis,
+                builder.logFunc,
+                builder.debug,
+                builder.registry,
+                builder.callerName,
+                builder.flagStore,
+                builder.disableErrorThrows);
     }
 
-    public Builder debug(Boolean debug) {
-      this.debug = debug;
-      return this;
+    public static class Builder {
+        private KVStore kvStore;
+        private String metaDataSet;
+        private Long timeoutMillis;
+        private Consumer<LoggableResponse> logFunc;
+        private ExternalSourceRegistry registry;
+        private String callerName;
+        private Boolean debug;
+        private FlagStore flagStore;
+        private Boolean disableErrorThrows;
+
+        public Builder(KVStore kvStore, String metaDataSet, Long timeoutMillis,
+                       Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
+            this.kvStore = kvStore;
+            this.metaDataSet = metaDataSet;
+            this.timeoutMillis = timeoutMillis;
+            this.logFunc = logFunc;
+            this.registry = registry;
+        }
+
+        public Builder callerName(String callerName) {
+            this.callerName = callerName;
+            return this;
+        }
+
+        public Builder flagStore(FlagStore flagStore) {
+            this.flagStore = flagStore;
+            return this;
+        }
+
+        public Builder disableErrorThrows(Boolean disableErrorThrows) {
+            this.disableErrorThrows = disableErrorThrows;
+            return this;
+        }
+
+        public Builder debug(Boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+
+        public JavaFetcher build() {
+            return new JavaFetcher(this);
+        }
     }
 
-    public JavaFetcher build() {
-      return new JavaFetcher(this);
+
+    public static List<JavaResponse> toJavaResponses(Seq<Response> responseSeq) {
+        List<JavaResponse> result = new ArrayList<>(responseSeq.size());
+        Iterator<Response> it = responseSeq.iterator();
+        while (it.hasNext()) {
+            result.add(new JavaResponse(it.next()));
+        }
+        return result;
     }
-  }
 
-
-  public static List<JavaResponse> toJavaResponses(Seq<Response> responseSeq) {
-    List<JavaResponse> result = new ArrayList<>(responseSeq.size());
-    Iterator<Response> it = responseSeq.iterator();
-    while (it.hasNext()) {
-      result.add(new JavaResponse(it.next()));
+    private CompletableFuture<List<JavaResponse>> convertResponsesWithTs(Future<FetcherResponseWithTs> responses, boolean isGroupBy, long startTs) {
+        return FutureConverters.toJava(responses).toCompletableFuture().thenApply(resps -> {
+            List<JavaResponse> jResps = toJavaResponses(resps.responses());
+            List<String> requestNames = jResps.stream().map(jResp -> jResp.request.name).collect(Collectors.toList());
+            instrument(requestNames, isGroupBy, "java.response_conversion.latency.millis", resps.endTs());
+            instrument(requestNames, isGroupBy, "java.overall.latency.millis", startTs);
+            return jResps;
+        });
     }
-    return result;
-  }
 
-  private CompletableFuture<List<JavaResponse>> convertResponsesWithTs(Future<FetcherResponseWithTs> responses, boolean isGroupBy, long startTs) {
-    return FutureConverters.toJava(responses).toCompletableFuture().thenApply(resps -> {
-      List<JavaResponse> jResps = toJavaResponses(resps.responses());
-      List<String> requestNames = jResps.stream().map(jResp -> jResp.request.name).collect(Collectors.toList());
-      instrument(requestNames, isGroupBy, "java.response_conversion.latency.millis", resps.endTs());
-      instrument(requestNames, isGroupBy, "java.overall.latency.millis", startTs);
-      return jResps;
-    });
-  }
-
-  public static List<JavaStatsResponse> toJavaStatsResponses(Seq<Fetcher.StatsResponse> responseSeq) {
-    List<JavaStatsResponse> result = new ArrayList<>(responseSeq.size());
-    Iterator<Fetcher.StatsResponse> it = responseSeq.iterator();
-    while(it.hasNext()) {
-      result.add(toJavaStatsResponse(it.next()));
+    public static List<JavaStatsResponse> toJavaStatsResponses(Seq<Fetcher.StatsResponse> responseSeq) {
+        List<JavaStatsResponse> result = new ArrayList<>(responseSeq.size());
+        Iterator<Fetcher.StatsResponse> it = responseSeq.iterator();
+        while (it.hasNext()) {
+            result.add(toJavaStatsResponse(it.next()));
+        }
+        return result;
     }
-    return result;
-  }
 
-  public static JavaStatsResponse toJavaStatsResponse(Fetcher.StatsResponse response) {
-    return new JavaStatsResponse(response);
-  }
-  public static JavaSeriesStatsResponse toJavaSeriesStatsResponse(Fetcher.SeriesStatsResponse response) {
-    return new JavaSeriesStatsResponse(response);
-  }
-
-  private CompletableFuture<List<JavaStatsResponse>> convertStatsResponses(Future<Seq<Fetcher.StatsResponse>> responses) {
-    return FutureConverters
-            .toJava(responses)
-            .toCompletableFuture()
-            .thenApply(JavaFetcher::toJavaStatsResponses);
-  }
-
-  private Seq<Request> convertJavaRequestList(List<JavaRequest> requests, boolean isGroupBy, long startTs) {
-    ArrayBuffer<Request> scalaRequests = new ArrayBuffer<>();
-    for (JavaRequest request : requests) {
-      Request convertedRequest = request.toScalaRequest();
-      scalaRequests.$plus$eq(convertedRequest);
+    public static JavaStatsResponse toJavaStatsResponse(Fetcher.StatsResponse response) {
+        return new JavaStatsResponse(response);
     }
-    Seq<Request> scalaRequestsSeq = scalaRequests.toSeq();
-    instrument(requests.stream().map(jReq -> jReq.name).collect(Collectors.toList()), isGroupBy, "java.request_conversion.latency.millis", startTs);
-    return scalaRequestsSeq;
-  }
 
-  public CompletableFuture<List<JavaResponse>> fetchGroupBys(List<JavaRequest> requests) {
-    long startTs = System.currentTimeMillis();
-    // Convert java requests to scala requests
-    Seq<Request> scalaRequests = convertJavaRequestList(requests, true, startTs);
-    // Get responses from the fetcher
-    Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchGroupBys(scalaRequests));
-    // Convert responses to CompletableFuture
-    return convertResponsesWithTs(scalaResponses, true, startTs);
-  }
-
-  public CompletableFuture<List<JavaResponse>> fetchJoin(List<JavaRequest> requests) {
-    long startTs = System.currentTimeMillis();
-    // Convert java requests to scala requests
-    Seq<Request> scalaRequests = convertJavaRequestList(requests, false, startTs);
-    // Get responses from the fetcher
-    Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchJoin(scalaRequests, Option.empty()));
-    // Convert responses to CompletableFuture
-    return convertResponsesWithTs(scalaResponses, false, startTs);
-  }
-
-  private void instrument(List<String> requestNames, boolean isGroupBy, String metricName, Long startTs) {
-    long endTs = System.currentTimeMillis();
-    for (String s : requestNames) {
-      Metrics.Context ctx;
-      if (isGroupBy) {
-        ctx = getGroupByContext(s);
-      } else {
-        ctx = getJoinContext(s);
-      }
-      ctx.distribution(metricName, endTs - startTs);
+    public static JavaSeriesStatsResponse toJavaSeriesStatsResponse(Fetcher.SeriesStatsResponse response) {
+        return new JavaSeriesStatsResponse(response);
     }
-  }
 
-  private Metrics.Context getJoinContext(String joinName) {
-    return new Metrics.Context("join.fetch", joinName, null, null, false, null, null, null, null);
-  }
+    private CompletableFuture<List<JavaStatsResponse>> convertStatsResponses(Future<Seq<Fetcher.StatsResponse>> responses) {
+        return FutureConverters
+                .toJava(responses)
+                .toCompletableFuture()
+                .thenApply(JavaFetcher::toJavaStatsResponses);
+    }
 
-  private Metrics.Context getGroupByContext(String groupByName) {
-    return new Metrics.Context("group_by.fetch", null, groupByName, null, false, null, null, null, null);
-  }
+    private Seq<Request> convertJavaRequestList(List<JavaRequest> requests, boolean isGroupBy, long startTs) {
+        ArrayBuffer<Request> scalaRequests = new ArrayBuffer<>();
+        for (JavaRequest request : requests) {
+            Request convertedRequest = request.toScalaRequest();
+            scalaRequests.$plus$eq(convertedRequest);
+        }
+        Seq<Request> scalaRequestsSeq = scalaRequests.toSeq();
+        instrument(requests.stream().map(jReq -> jReq.name).collect(Collectors.toList()), isGroupBy, "java.request_conversion.latency.millis", startTs);
+        return scalaRequestsSeq;
+    }
 
-  public CompletableFuture<JavaSeriesStatsResponse> fetchStatsTimeseries(JavaStatsRequest request) {
-    Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchStatsTimeseries(request.toScalaRequest());
-    // Convert responses to CompletableFuture
-    return FutureConverters.toJava(response).toCompletableFuture().thenApply(JavaFetcher::toJavaSeriesStatsResponse);
-  }
+    public CompletableFuture<List<JavaResponse>> fetchGroupBys(List<JavaRequest> requests) {
+        long startTs = System.currentTimeMillis();
+        // Convert java requests to scala requests
+        Seq<Request> scalaRequests = convertJavaRequestList(requests, true, startTs);
+        // Get responses from the fetcher
+        Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchGroupBys(scalaRequests));
+        // Convert responses to CompletableFuture
+        return convertResponsesWithTs(scalaResponses, true, startTs);
+    }
 
-  public CompletableFuture<JavaSeriesStatsResponse> fetchLogStatsTimeseries(JavaStatsRequest request) {
-    Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchLogStatsTimeseries(request.toScalaRequest());
-    // Convert responses to CompletableFuture
-    return FutureConverters.toJava(response).toCompletableFuture().thenApply(JavaFetcher::toJavaSeriesStatsResponse);
-  }
+    public CompletableFuture<List<JavaResponse>> fetchJoin(List<JavaRequest> requests) {
+        long startTs = System.currentTimeMillis();
+        // Convert java requests to scala requests
+        Seq<Request> scalaRequests = convertJavaRequestList(requests, false, startTs);
+        // Get responses from the fetcher
+        Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchJoin(scalaRequests, Option.empty()));
+        // Convert responses to CompletableFuture
+        return convertResponsesWithTs(scalaResponses, false, startTs);
+    }
 
-  public CompletableFuture<JavaSeriesStatsResponse> fetchConsistencyMetricsTimeseries(JavaStatsRequest request) {
-    Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchConsistencyMetricsTimeseries(request.toScalaRequest());
-    // Convert responses to CompletableFuture
-    return FutureConverters.toJava(response).toCompletableFuture().thenApply(JavaFetcher::toJavaSeriesStatsResponse);
-  }
+    private void instrument(List<String> requestNames, boolean isGroupBy, String metricName, Long startTs) {
+        long endTs = System.currentTimeMillis();
+        for (String s : requestNames) {
+            Metrics.Context ctx;
+            if (isGroupBy) {
+                ctx = getGroupByContext(s);
+            } else {
+                ctx = getJoinContext(s);
+            }
+            ctx.distribution(metricName, endTs - startTs);
+        }
+    }
+
+    private Metrics.Context getJoinContext(String joinName) {
+        return new Metrics.Context("join.fetch", joinName, null, null, false, null, null, null, null);
+    }
+
+    private Metrics.Context getGroupByContext(String groupByName) {
+        return new Metrics.Context("group_by.fetch", null, groupByName, null, false, null, null, null, null);
+    }
+
+    public CompletableFuture<JavaSeriesStatsResponse> fetchStatsTimeseries(JavaStatsRequest request) {
+        Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchStatsTimeseries(request.toScalaRequest());
+        // Convert responses to CompletableFuture
+        return FutureConverters.toJava(response).toCompletableFuture().thenApply(JavaFetcher::toJavaSeriesStatsResponse);
+    }
+
+    public CompletableFuture<JavaSeriesStatsResponse> fetchLogStatsTimeseries(JavaStatsRequest request) {
+        Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchLogStatsTimeseries(request.toScalaRequest());
+        // Convert responses to CompletableFuture
+        return FutureConverters.toJava(response).toCompletableFuture().thenApply(JavaFetcher::toJavaSeriesStatsResponse);
+    }
+
+    public CompletableFuture<JavaSeriesStatsResponse> fetchConsistencyMetricsTimeseries(JavaStatsRequest request) {
+        Future<Fetcher.SeriesStatsResponse> response = this.fetcher.fetchConsistencyMetricsTimeseries(request.toScalaRequest());
+        // Convert responses to CompletableFuture
+        return FutureConverters.toJava(response).toCompletableFuture().thenApply(JavaFetcher::toJavaSeriesStatsResponse);
+    }
 }

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -30,6 +30,7 @@ import com.timgroup.statsd.Event
 import com.timgroup.statsd.Event.AlertType
 import org.apache.avro.generic.GenericRecord
 import org.json4s.BuildInfo
+import org.slf4j.LoggerFactory
 
 import java.util.function.Consumer
 import scala.collection.JavaConverters._
@@ -87,7 +88,6 @@ class Fetcher(val kvStore: KVStore,
               flagStore: FlagStore = null,
               disableErrorThrows: Boolean = false)
     extends FetcherBase(kvStore, metaDataSet, timeoutMillis, debug, flagStore, disableErrorThrows) {
-
   private def reportCallerNameFetcherVersion(): Unit = {
     val message = s"CallerName: ${Option(callerName).getOrElse("N/A")}, FetcherVersion: ${BuildInfo.version}"
     val ctx = Metrics.Context(Environment.Fetcher)
@@ -364,6 +364,7 @@ class Fetcher(val kvStore: KVStore,
     loggingTry.failed.map { exception =>
       // to handle GroupByServingInfo staleness that results in encoding failure
       getJoinCodecs.refresh(resp.request.name)
+      logger.error(s"Logging failed due to: ${exception.traceString}")
       joinContext.foreach(
         _.withSuffix("logging_request")
           .incrementException(new Exception(s"Logging failed due to: ${exception.traceString}", exception)))

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -30,7 +30,6 @@ import com.timgroup.statsd.Event
 import com.timgroup.statsd.Event.AlertType
 import org.apache.avro.generic.GenericRecord
 import org.json4s.BuildInfo
-import org.slf4j.LoggerFactory
 
 import java.util.function.Consumer
 import scala.collection.JavaConverters._


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We noticed log publish failures but the exception message is not clear. 
This PR will sample the error logs at 0.1% by default is no sample percentage is set in the metadata. Otherwise, it will take the number from the metadata.samplePercent.

To simplify the java fetcher debug process, refactored the code to use builder pattern so that different params can be set separately. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Improve debuggability 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
