### PR TITLE
Adding a new logErrorSamplePercent param to metadata

### DIFF
--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -259,6 +259,8 @@ struct MetaData {
     14: optional bool historicalBackfill
     // Optional expected deprecation date
     15: optional string deprecationDate
+    // Optional error sample percent for logging
+    16: optional double logErrorSamplePercent
 }
 
 // Equivalent to a FeatureSet in chronon terms

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -366,13 +366,14 @@ class Fetcher(val kvStore: KVStore,
       if (debug) {
         val rand = new Random
         val number = rand.nextDouble
-        val defaultSamplePercent = 0.001
+        // 0.1% default sample rate for logging failed requests
+        val defaultSamplePercent = 0.1
         val logSamplePercent = refreshedJoinCodec
           .map(codec =>
-            if (codec.conf.join.metaData.isSetSamplePercent) codec.conf.join.metaData.getSamplePercent
+            if (codec.conf.join.metaData.isSetLogErrorSamplePercent) codec.conf.join.metaData.logErrorSamplePercent
             else defaultSamplePercent)
           .getOrElse(defaultSamplePercent)
-        if (number < logSamplePercent) {
+        if (number * (100 * 1000) < logSamplePercent * 1000) {
           logger.error(s"Logging failed due to: ${exception.traceString}, join codec status: ${joinCodecTry.isSuccess}")
           if (joinCodecTry.isFailure) {
             joinCodecTry.failed.foreach { exception =>


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR will separate the log sample rate and log error sample rate to spamming the logs. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/zipline-maintainers 
