### PR TITLE
[Backfill]Remove exception when the keys are all null in unfilledLeftDf

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -304,11 +304,10 @@ object JoinUtils {
               s"KeyName: $keyName, leftSide KeyName: $leftSideKeyName , Join right to left: ${joinPart.rightToLeft
                 .mkString(", ")}")
             val values = collectedLeft.map(row => row.getAs[Any](leftSideKeyName))
-            // Check for null keys, warn if found, err if all null
+            // Check for null keys, warn if found
             val (notNullValues, nullValues) = values.partition(_ != null)
             if (notNullValues.isEmpty) {
-              throw new RuntimeException(
-                s"No not-null keys found for key: $keyName. Check source table or where clauses.")
+              logger.warn(s"No not-null keys found for key: $keyName. Check source table or where clauses.")
             } else if (!nullValues.isEmpty) {
               logger.warn(s"Found ${nullValues.length} null keys for key: $keyName.")
             }

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -319,9 +319,9 @@ object JoinUtils {
             }.toSet
 
             if (valueSet.isEmpty) {
-              s"$groupByKeyExpression in (${valueSet.mkString(sep = ",")})"
-            } else {
               "false"
+            } else {
+              s"$groupByKeyExpression in (${valueSet.mkString(sep = ",")})"
             }
         }
         .foreach { whereClause =>

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -307,7 +307,7 @@ object JoinUtils {
             // Check for null keys, warn if found
             val (notNullValues, nullValues) = values.partition(_ != null)
             if (notNullValues.isEmpty) {
-              logger.warn(s"No not-null keys found for key: $keyName. Check source table or where clauses.")
+              logger.warn(s"No not-null keys found for key: $keyName.")
             } else if (!nullValues.isEmpty) {
               logger.warn(s"Found ${nullValues.length} null keys for key: $keyName.")
             }

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -318,8 +318,11 @@ object JoinUtils {
               case other     => other.toString // Keep other types (like Int) as they are
             }.toSet
 
-            // Form the final WHERE clause for injection
-            s"$groupByKeyExpression in (array(${valueSet.mkString(sep = ",")}))"
+            if (valueSet.isEmpty) {
+              s"$groupByKeyExpression in (${valueSet.mkString(sep = ",")})"
+            } else {
+              "false"
+            }
         }
         .foreach { whereClause =>
           // Skip adding the filter if it is a join source

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -319,7 +319,7 @@ object JoinUtils {
             }.toSet
 
             // Form the final WHERE clause for injection
-            s"$groupByKeyExpression in (${valueSet.mkString(sep = ",")})"
+            s"$groupByKeyExpression in (array(${valueSet.mkString(sep = ",")}))"
         }
         .foreach { whereClause =>
           // Skip adding the filter if it is a join source


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
When we run the join part backfill on the left, we used to error out when the key are all empty in left table. This doesn't work when we run the join part backfill after bootstrap, because the unfilledLeftDf keys can be all null. 

This PR is to remove the exception throw statement in genKeyFilter function. When the keys in unfilledLeftDf are all empty, we will build an empty filter(`where keys in ()`) in join part and the computeRightTable function will return an empty dataframe, like the case when the bootstrap table covers everything. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @donghanz @pengyu-hou 
