### PR TITLE
fix: Allow upload job to complete when output data is empty

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -242,9 +242,16 @@ object GroupByUpload {
 
     val metricRow =
       kvDfReloaded.selectExpr("sum(bit_length(key_bytes))/8", "sum(bit_length(value_bytes))/8", "count(*)").collect()
-    context.gauge(Metrics.Name.KeyBytes, metricRow(0).getDouble(0).toLong)
-    context.gauge(Metrics.Name.ValueBytes, metricRow(0).getDouble(1).toLong)
-    context.gauge(Metrics.Name.RowCount, metricRow(0).getLong(2))
+
+    val rowCount = metricRow(0).getLong(2)
+    context.gauge(Metrics.Name.RowCount, rowCount)
+    // Allow for upload data to be empty so that we can still update the GroupByServingInfo
+    if (rowCount > 0) {
+      context.gauge(Metrics.Name.KeyBytes, metricRow(0).getDouble(0).toLong)
+      context.gauge(Metrics.Name.ValueBytes, metricRow(0).getDouble(1).toLong)
+    } else {
+      logger.warn(s"Empty upload for ${groupByConf.metaData.name} at $endDs")
+    }
     context.gauge(Metrics.Name.LatencyMinutes, (System.currentTimeMillis() - startTs) / (60 * 1000))
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -246,6 +246,7 @@ object GroupByUpload {
     val rowCount = metricRow(0).getLong(2)
     context.gauge(Metrics.Name.RowCount, rowCount)
     // Allow for upload data to be empty so that we can still update the GroupByServingInfo
+    // TODO: in the long run, consider separating GroupByServingInfo into a separate job
     if (rowCount > 0) {
       context.gauge(Metrics.Name.KeyBytes, metricRow(0).getDouble(0).toLong)
       context.gauge(Metrics.Name.ValueBytes, metricRow(0).getDouble(1).toLong)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Allow GroupByUpload job to complete when output data is empty except for the `group_by_serving_info` row. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

This will ensure that `group_by_serving_info` is being updated into KV store such that metadata is kept up to date. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Reviewers

@pengyu-hou @donghanz 
