### PR TITLE
fix: make logging codec thread safe

### DIFF
--- a/online/src/main/scala/ai/chronon/online/JoinCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/JoinCodec.scala
@@ -61,6 +61,8 @@ case class JoinCodec(conf: JoinOps, keySchema: StructType, baseValueSchema: Stru
 
   @transient lazy val keySchemaStr: String = AvroConversions.fromChrononSchema(keySchema).toString
   @transient lazy val valueSchemaStr: String = AvroConversions.fromChrononSchema(valueSchema).toString
+  def keyCodec: AvroCodec = AvroCodec.of(keySchemaStr)
+  def valueCodec: AvroCodec = AvroCodec.of(valueSchemaStr)
 
   /*
    * Get the serialized string repr. of the logging schema.

--- a/online/src/main/scala/ai/chronon/online/JoinCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/JoinCodec.scala
@@ -16,7 +16,7 @@
 
 package ai.chronon.online
 
-import ai.chronon.api.Extensions.{DerivationOps, JoinOps, MetadataOps}
+import ai.chronon.api.Extensions.{JoinOps, MetadataOps}
 import ai.chronon.api.{DataType, HashUtils, StructField, StructType}
 import com.google.gson.Gson
 import scala.collection.Seq
@@ -26,16 +26,10 @@ import ai.chronon.online.OnlineDerivationUtil.{
   DerivationFunc,
   buildDerivationFunction,
   buildDerivedFields,
-  buildRenameOnlyDerivationFunction,
-  timeFields
+  buildRenameOnlyDerivationFunction
 }
 
-case class JoinCodec(conf: JoinOps,
-                     keySchema: StructType,
-                     baseValueSchema: StructType,
-                     keyCodec: AvroCodec,
-                     baseValueCodec: AvroCodec)
-    extends Serializable {
+case class JoinCodec(conf: JoinOps, keySchema: StructType, baseValueSchema: StructType) extends Serializable {
 
   @transient lazy val valueSchema: StructType = {
     val fields = if (conf.join == null || conf.join.derivations == null || baseValueSchema.fields.isEmpty) {
@@ -65,7 +59,8 @@ case class JoinCodec(conf: JoinOps,
   @transient lazy val renameOnlyDeriveFunc: (Map[String, Any], Map[String, Any]) => Map[String, Any] =
     buildRenameOnlyDerivationFunction(conf.derivationsScala)
 
-  @transient lazy val valueCodec: AvroCodec = AvroCodec.of(AvroConversions.fromChrononSchema(valueSchema).toString)
+  @transient lazy val keySchemaStr: String = AvroConversions.fromChrononSchema(keySchema).toString
+  @transient lazy val valueSchemaStr: String = AvroConversions.fromChrononSchema(valueSchema).toString
 
   /*
    * Get the serialized string repr. of the logging schema.
@@ -74,7 +69,7 @@ case class JoinCodec(conf: JoinOps,
    * Example:
    * {"join_name":"unit_test/test_join","key_schema":"{\"type\":\"record\",\"name\":\"unit_test_test_join_key\",\"namespace\":\"ai.chronon.data\",\"doc\":\"\",\"fields\":[{\"name\":\"listing\",\"type\":[\"null\",\"long\"],\"doc\":\"\"}]}","value_schema":"{\"type\":\"record\",\"name\":\"unit_test_test_join_value\",\"namespace\":\"ai.chronon.data\",\"doc\":\"\",\"fields\":[{\"name\":\"unit_test_listing_views_v1_m_guests_sum\",\"type\":[\"null\",\"long\"],\"doc\":\"\"},{\"name\":\"unit_test_listing_views_v1_m_views_sum\",\"type\":[\"null\",\"long\"],\"doc\":\"\"}]}"}
    */
-  lazy val loggingSchema: String = JoinCodec.buildLoggingSchema(conf.join.metaData.name, keyCodec, valueCodec)
+  lazy val loggingSchema: String = JoinCodec.buildLoggingSchema(conf.join.metaData.name, keySchemaStr, valueSchemaStr)
   lazy val loggingSchemaHash: String = HashUtils.md5Base64(loggingSchema)
 
   val keys: Array[String] = keySchema.fields.iterator.map(_.name).toArray
@@ -88,11 +83,11 @@ case class JoinCodec(conf: JoinOps,
 
 object JoinCodec {
 
-  def buildLoggingSchema(joinName: String, keyCodec: AvroCodec, valueCodec: AvroCodec): String = {
+  def buildLoggingSchema(joinName: String, keySchemaStr: String, valueSchemaStr: String): String = {
     val schemaMap = Map(
       "join_name" -> joinName,
-      "key_schema" -> keyCodec.schemaStr,
-      "value_schema" -> valueCodec.schemaStr
+      "key_schema" -> keySchemaStr,
+      "value_schema" -> valueSchemaStr
     )
     new Gson().toJson(schemaMap.toJava)
   }

--- a/spark/src/main/scala/ai/chronon/spark/LoggingSchema.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LoggingSchema.scala
@@ -31,7 +31,8 @@ case class LoggingSchema(keyCodec: AvroCodec, valueCodec: AvroCodec) {
   lazy val keyIndices: Map[StructField, Int] = keyFields.zipWithIndex.toMap
   lazy val valueIndices: Map[StructField, Int] = valueFields.zipWithIndex.toMap
 
-  def hash(joinName: String): String = HashUtils.md5Base64(JoinCodec.buildLoggingSchema(joinName, keyCodec, valueCodec))
+  def hash(joinName: String): String =
+    HashUtils.md5Base64(JoinCodec.buildLoggingSchema(joinName, keyCodec.schemaStr, valueCodec.schemaStr))
 }
 
 object LoggingSchema {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

`AvroCodec` is not thread-safe, and in particular, the `outputStream = new ByteArrayOutputStream()` is a point of contention. Currently we use `keyCodec` and `valueCodec` which are cached in `getJoinCodecs` and accessed across multiple threads during the logging stage. During logging, we work-around errors by doing brute-force encode and try-decode, up to 3 trials, to ensure the encoding process succeeds, which was definitely not an ideal solution ([code](https://github.com/airbnb/chronon/blob/v0.0.83/online/src/main/scala/ai/chronon/online/Fetcher.scala#L300)). 

The fix is to move the construction (the `AvroCodec.of` call) inside logging, which will generate thread local cached instances of codecs. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Attempt to fix a production logging failure issue, which only affects a particular join. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers


@yuli-han @pengyu-hou @donghanz @rohitgirme 