### PR TITLE
fix: fix analyzer args in driver

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -444,7 +444,8 @@ object Driver {
                    args.count(),
                    args.sample(),
                    args.enableHitter(),
-                   args.skipTimestampCheck()).run
+                   silenceMode = false,
+                   skipTimestampCheck = args.skipTimestampCheck()).run
     }
   }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

`silenceMode` was not set in Driver analyzer mode, and `skipTimestampCheck` was incorrectly passed in to as `slienceMode`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

small bug fix

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pkundurthy @yuli-han 
