### PR TITLE
[Compile] Update compile.py table_display option to also display output for stating queries

### DIFF
--- a/api/py/ai/chronon/repo/compile.py
+++ b/api/py/ai/chronon/repo/compile.py
@@ -370,12 +370,14 @@ def _handle_deprecation_warning(
             )
 
 
-def _print_tables(obj: Union[Join, GroupBy], obj_class: Type[Union[Join, GroupBy]]) -> None:
+def _print_tables(obj: utils.ChrononJobTypes, obj_class: Type[utils.ChrononJobTypes]) -> None:
     tables = utils.get_modes_tables(obj)
     if obj_class is Join:
         _print_modes_tables("Output Join Tables", tables)
     if obj_class is GroupBy:
         _print_modes_tables("Output GroupBy Tables", tables)
+    if obj_class is StagingQuery:
+        _print_modes_tables("Output StagingQuery Tables", tables)
 
 
 def _handle_extra_conf_objects_to_materialize(
@@ -515,7 +517,10 @@ def _print_features_names(left, right):
 
 def _print_modes_tables(left, right):
     text = textwrap.indent(json.dumps(right, indent=2), " " * 27)
-    print(f"{left:>25} - \u001b[32m\n{text}\u001b[0m")
+    json_start = "json.start"
+    json_end = "json.end\n"
+
+    print(f"{left:>25} - \n{json_start:>25} \u001b[32m\n{text}\u001b[0m \n{json_end:>25}")
 
 
 def _print_error(left, right):

--- a/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
@@ -4,7 +4,7 @@
     "production": 0,
     "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
     "dependencies": [
-      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
     ],
     "tableProperties": {
       "sample_config_json": "{\"sample_key\": \"sample_value\"}",
@@ -17,7 +17,7 @@
   "sources": [
     {
       "events": {
-        "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
+        "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill",
         "query": {
           "selects": {
             "event": "event_expr",

--- a/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
@@ -6,7 +6,7 @@
     "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
-      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
     ],
     "tableProperties": {
       "source": "chronon"
@@ -39,7 +39,7 @@
           "production": 0,
           "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
           "dependencies": [
-            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
           "tableProperties": {
             "sample_config_json": "{\"sample_key\": \"sample_value\"}",
@@ -52,7 +52,7 @@
         "sources": [
           {
             "events": {
-              "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
+              "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill",
               "query": {
                 "selects": {
                   "event": "event_expr",


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- A change in the compile.py logic for table_display should also display tables generated by staging quries

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- Missed from earlier PRs on this.
- This will provide clarity for all use-cases in addition to Joins and GroupBy configs

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [X] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @hzding621 
