### PR TITLE
Add support for Delta lake tables in TableUtils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
                       conda activate chronon_py
                       # Increase if we see OOM.
                       export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-                      sbt "++ 2.12.12 test"
+                      sbt "++ 2.12.12 'test -- -l ai.chronon.spark.test.TableUtilsFormatTest'"
             - store_test_results:
                   path: /chronon/spark/target/test-reports
             - store_test_results:
@@ -63,7 +63,7 @@ jobs:
                       conda activate chronon_py
                       # Increase if we see OOM.
                       export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-                      sbt "++ 2.13.6 test"
+                      sbt "++ 2.13.6 'test -- -l ai.chronon.spark.test.TableUtilsFormatTest'"
             - store_test_results:
                   path: /chronon/spark/target/test-reports
             - store_test_results:
@@ -77,6 +77,32 @@ jobs:
                   path: /tmp/spark-warehouse.tar.gz
                   destination: spark_warehouse.tar.gz
                   when: on_fail
+
+    "Scala 13 -- Table Format Tests":
+      executor: docker_baseimg_executor
+      steps:
+        - checkout
+        - run:
+            name: Run Scala 13 table format tests
+            shell: /bin/bash -leuxo pipefail
+            command: |
+              conda activate chronon_py
+              # Increase if we see OOM.
+              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+              sbt "++ 2.13.6 'testOnly ai.chronon.spark.test.TableUtilsFormatTest'"
+        - store_test_results:
+            path: /chronon/spark/target/test-reports
+        - store_test_results:
+            path: /chronon/aggregator/target/test-reports
+        - run:
+            name: Compress spark-warehouse
+            command: |
+              cd /tmp/ && tar -czvf spark-warehouse.tar.gz chronon/spark-warehouse
+            when: on_fail
+        - store_artifacts:
+            path: /tmp/spark-warehouse.tar.gz
+            destination: spark_warehouse.tar.gz
+            when: on_fail
 
     "Scala 11 -- Compile":
       executor: docker_baseimg_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
                       conda activate chronon_py
                       # Increase if we see OOM.
                       export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-                      sbt "++ 2.12.12 'test -- -l ai.chronon.spark.test.TableUtilsFormatTest'"
+                      sbt "++ 2.12.12 test"
             - store_test_results:
                   path: /chronon/spark/target/test-reports
             - store_test_results:
@@ -63,7 +63,7 @@ jobs:
                       conda activate chronon_py
                       # Increase if we see OOM.
                       export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-                      sbt "++ 2.13.6 'test -- -l ai.chronon.spark.test.TableUtilsFormatTest'"
+                      sbt "++ 2.13.6 test"
             - store_test_results:
                   path: /chronon/spark/target/test-reports
             - store_test_results:
@@ -77,32 +77,6 @@ jobs:
                   path: /tmp/spark-warehouse.tar.gz
                   destination: spark_warehouse.tar.gz
                   when: on_fail
-
-    "Scala 13 -- Table Format Tests":
-      executor: docker_baseimg_executor
-      steps:
-        - checkout
-        - run:
-            name: Run Scala 13 table format tests
-            shell: /bin/bash -leuxo pipefail
-            command: |
-              conda activate chronon_py
-              # Increase if we see OOM.
-              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-              sbt "++ 2.13.6 'testOnly ai.chronon.spark.test.TableUtilsFormatTest'"
-        - store_test_results:
-            path: /chronon/spark/target/test-reports
-        - store_test_results:
-            path: /chronon/aggregator/target/test-reports
-        - run:
-            name: Compress spark-warehouse
-            command: |
-              cd /tmp/ && tar -czvf spark-warehouse.tar.gz chronon/spark-warehouse
-            when: on_fail
-        - store_artifacts:
-            path: /tmp/spark-warehouse.tar.gz
-            destination: spark_warehouse.tar.gz
-            when: on_fail
 
     "Scala 11 -- Compile":
       executor: docker_baseimg_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
                   when: on_fail
 
     # run these separately as we need a isolated JVM to not have Spark session settings interfere with other runs
+    # long term goal is to refactor the current testing spark session builder and avoid adding new single test to CI
     "Scala 13 -- Delta Lake Format Tests":
       executor: docker_baseimg_executor
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,35 @@ jobs:
                   destination: spark_warehouse.tar.gz
                   when: on_fail
 
+    # run these separately as we need a isolated JVM to not have Spark session settings interfere with other runs
+    "Scala 13 -- Delta Lake Format Tests":
+      executor: docker_baseimg_executor
+      steps:
+        - checkout
+        - run:
+            name: Run Scala 13 tests for Delta Lake format
+            environment:
+              format_test: deltalake
+            shell: /bin/bash -leuxo pipefail
+            command: |
+              conda activate chronon_py
+              # Increase if we see OOM.
+              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+              sbt '++ 2.13.6' "testOnly ai.chronon.spark.test.TableUtilsFormatTest"
+        - store_test_results:
+            path: /chronon/spark/target/test-reports
+        - store_test_results:
+            path: /chronon/aggregator/target/test-reports
+        - run:
+            name: Compress spark-warehouse
+            command: |
+              cd /tmp/ && tar -czvf spark-warehouse.tar.gz chronon/spark-warehouse
+            when: on_fail
+        - store_artifacts:
+            path: /tmp/spark-warehouse.tar.gz
+            destination: spark_warehouse.tar.gz
+            when: on_fail
+
     "Scala 11 -- Compile":
       executor: docker_baseimg_executor
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,9 @@ workflows:
             - "Scala 13 -- Tests":
                   requires:
                       - "Pull Docker Image"
+            - "Scala 13 -- Delta Lake Format Tests":
+                  requires:
+                    - "Pull Docker Image"
             - "Scalafmt Check":
                   requires:
                       - "Pull Docker Image"

--- a/build.sbt
+++ b/build.sbt
@@ -156,23 +156,13 @@ val VersionMatrix: Map[String, VersionDependency] = Map(
     None,
     Some("1.0.4")
   ),
-  // delta lake has set of deps introduced in 2.12 that weren't
-  // present prior
   "delta-core" -> VersionDependency(
     Seq(
       "io.delta" %% "delta-core"
     ),
     Some("0.6.1"),
-    None,
-    None
-  ),
-  "delta-spark" -> VersionDependency(
-    Seq(
-      "io.delta" %% "delta-spark"
-    ),
-    None,
-    Some("3.1.0"),
-    Some("3.2.1")
+    Some("1.0.1"),
+    Some("2.0.2")
   ),
   "jackson" -> VersionDependency(
     Seq(
@@ -383,7 +373,7 @@ lazy val spark_uber = (project in file("spark"))
     sparkBaseSettings,
     version := git.versionProperty.value,
     crossScalaVersions := supportedVersions,
-    libraryDependencies ++= fromMatrix(scalaVersion.value, "jackson", "spark-all/provided", "delta-core/provided", "delta-spark/provided")
+    libraryDependencies ++= fromMatrix(scalaVersion.value, "jackson", "spark-all/provided", "delta-core/provided")
   )
 
 lazy val spark_embedded = (project in file("spark"))
@@ -392,7 +382,7 @@ lazy val spark_embedded = (project in file("spark"))
     sparkBaseSettings,
     version := git.versionProperty.value,
     crossScalaVersions := supportedVersions,
-    libraryDependencies ++= fromMatrix(scalaVersion.value, "spark-all", "delta-core", "delta-spark"),
+    libraryDependencies ++= fromMatrix(scalaVersion.value, "spark-all", "delta-core"),
     target := target.value.toPath.resolveSibling("target-embedded").toFile,
     Test / test := {}
   )

--- a/build.sbt
+++ b/build.sbt
@@ -156,6 +156,24 @@ val VersionMatrix: Map[String, VersionDependency] = Map(
     None,
     Some("1.0.4")
   ),
+  // delta lake has set of deps introduced in 2.12 that weren't
+  // present prior
+  "delta-core" -> VersionDependency(
+    Seq(
+      "io.delta" %% "delta-core"
+    ),
+    Some("0.6.1"),
+    None,
+    None
+  ),
+  "delta-spark" -> VersionDependency(
+    Seq(
+      "io.delta" %% "delta-spark"
+    ),
+    None,
+    Some("3.1.0"),
+    Some("3.2.1")
+  ),
   "jackson" -> VersionDependency(
     Seq(
       "com.fasterxml.jackson.core" % "jackson-core",
@@ -365,7 +383,7 @@ lazy val spark_uber = (project in file("spark"))
     sparkBaseSettings,
     version := git.versionProperty.value,
     crossScalaVersions := supportedVersions,
-    libraryDependencies ++= fromMatrix(scalaVersion.value, "jackson", "spark-all/provided")
+    libraryDependencies ++= fromMatrix(scalaVersion.value, "jackson", "spark-all/provided", "delta-core/provided", "delta-spark/provided")
   )
 
 lazy val spark_embedded = (project in file("spark"))
@@ -374,7 +392,7 @@ lazy val spark_embedded = (project in file("spark"))
     sparkBaseSettings,
     version := git.versionProperty.value,
     crossScalaVersions := supportedVersions,
-    libraryDependencies ++= fromMatrix(scalaVersion.value, "spark-all"),
+    libraryDependencies ++= fromMatrix(scalaVersion.value, "spark-all", "delta-core", "delta-spark"),
     target := target.value.toPath.resolveSibling("target-embedded").toFile,
     Test / test := {}
   )

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -147,9 +147,9 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$8",
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$5",
       "scala.collection.immutable.ArraySeq$ofRef",
-      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow",
-      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
-      "org.apache.spark.sql.delta.actions.AddFile"
+      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow"
+//      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
+//      "org.apache.spark.sql.delta.actions.AddFile"
     )
     names.foreach { name =>
       try {

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -147,7 +147,9 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$8",
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$5",
       "scala.collection.immutable.ArraySeq$ofRef",
-      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow"
+      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow",
+      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
+      "org.apache.spark.sql.delta.actions.AddFile"
     )
     names.foreach { name =>
       try {

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -147,9 +147,9 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$8",
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$5",
       "scala.collection.immutable.ArraySeq$ofRef",
-      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow"
-//      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
-//      "org.apache.spark.sql.delta.actions.AddFile"
+      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow",
+      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
+      "org.apache.spark.sql.delta.actions.AddFile"
     )
     names.foreach { name =>
       try {

--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -147,23 +147,34 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$8",
       "org.apache.spark.sql.catalyst.InternalRow$$anonfun$getAccessor$5",
       "scala.collection.immutable.ArraySeq$ofRef",
-      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow",
-      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
-      "org.apache.spark.sql.delta.actions.AddFile"
+      "org.apache.spark.sql.catalyst.expressions.GenericInternalRow"
     )
-    names.foreach { name =>
-      try {
-        kryo.register(Class.forName(name))
-        kryo.register(Class.forName(s"[L$name;")) // represents array of a type to jvm
-      } catch {
-        case _: ClassNotFoundException => // do nothing
-      }
-    }
+    names.foreach(name => doRegister(name, kryo))
 
     kryo.register(classOf[Array[Array[Array[AnyRef]]]])
     kryo.register(classOf[Array[Array[AnyRef]]])
     kryo.register(classOf[CpcSketch], new CpcSketchKryoSerializer())
     kryo.register(classOf[Array[ItemSketchSerializable]])
     kryo.register(classOf[ItemsSketchIR[AnyRef]], new ItemsSketchKryoSerializer[AnyRef])
+  }
+
+  def doRegister(name: String, kryo: Kryo): Unit = {
+    try {
+      kryo.register(Class.forName(name))
+      kryo.register(Class.forName(s"[L$name;")) // represents array of a type to jvm
+    } catch {
+      case _: ClassNotFoundException => // do nothing
+    }
+  }
+}
+
+class ChrononDeltaLakeKryoRegistrator extends ChrononKryoRegistrator {
+  override def registerClasses(kryo: Kryo): Unit = {
+    super.registerClasses(kryo)
+    val additionalDeltaNames = Seq(
+      "org.apache.spark.sql.delta.stats.DeltaFileStatistics",
+      "org.apache.spark.sql.delta.actions.AddFile"
+    )
+    additionalDeltaNames.foreach(name => doRegister(name, kryo))
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -82,9 +82,7 @@ object Driver {
                    descr = "Skip the first unfilled partition range if some future partitions have been populated.")
 
     val useDeltaCatalog: ScallopOption[Boolean] =
-      opt[Boolean](required = false,
-        default = Some(false),
-        descr = "Enable the use of the delta lake catalog")
+      opt[Boolean](required = false, default = Some(false), descr = "Enable the use of the delta lake catalog")
 
     val stepDays: ScallopOption[Int] =
       opt[Int](required = false,
@@ -144,14 +142,19 @@ object Driver {
       // use of the delta lake catalog requires a couple of additional spark config options
       val extraDeltaConfigs = useDeltaCatalog.toOption match {
         case Some(true) =>
-          Some(Map(
-            "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
-            "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog"))
+          Some(
+            Map(
+              "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
+              "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+            ))
         case _ => None
       }
 
       if (localTableMapping.nonEmpty) {
-        val localSession = SparkSessionBuilder.build(subcommandName(), local = true, localWarehouseLocation.toOption, additionalConfig = extraDeltaConfigs)
+        val localSession = SparkSessionBuilder.build(subcommandName(),
+                                                     local = true,
+                                                     localWarehouseLocation.toOption,
+                                                     additionalConfig = extraDeltaConfigs)
         localTableMapping.foreach {
           case (table, filePath) =>
             val file = new File(filePath)
@@ -171,7 +174,9 @@ object Driver {
       } else {
         // We use the KryoSerializer for group bys and joins since we serialize the IRs.
         // But since staging query is fairly freeform, it's better to stick to the java serializer.
-        SparkSessionBuilder.build(subcommandName(), enforceKryoSerializer = !subcommandName().contains("staging_query"), additionalConfig = extraDeltaConfigs)
+        SparkSessionBuilder.build(subcommandName(),
+                                  enforceKryoSerializer = !subcommandName().contains("staging_query"),
+                                  additionalConfig = extraDeltaConfigs)
       }
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -16,7 +16,7 @@
 
 package ai.chronon.spark
 
-import java.io.{PrintWriter, StringWriter}
+import java.io.{PrintWriter, Serializable, StringWriter}
 import org.slf4j.LoggerFactory
 import ai.chronon.aggregator.windowing.TsUtils
 import ai.chronon.api.{Constants, PartitionSpec}
@@ -65,7 +65,7 @@ trait Format {
   * cases such as leveraging different library versions from what we support in the Chronon project (e.g. newer delta lake)
   * as well as working with custom internal company logic / checks.
   */
-trait FormatProvider {
+trait FormatProvider extends Serializable {
   def readFormat(tableName: String): Format
   def writeFormat(tableName: String): Format
 }

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -47,7 +47,7 @@ import scala.util.{Failure, Success, Try}
   * Trait to track the table format in use by a Chronon dataset and some utility methods to help
   * retrieve metadata / configure it appropriately at creation time
   */
-sealed trait Format {
+trait Format {
   // Return a sequence for partitions where each partition entry consists of a Map of partition keys to values
   def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]]
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -108,7 +108,7 @@ case class DefaultFormatProvider(sparkSession: SparkSession) extends FormatProvi
         logger.info(s"Delta check: Successfully read the format of table: $tableName as $format")
         format == "delta"
       case _ =>
-        // the describe detail calls fails for Iceberg tables
+        // the describe detail calls fails for Delta Lake tables
         logger.info(s"Delta check: Unable to read the format of the table $tableName using DESCRIBE DETAIL")
         false
     }

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -230,19 +230,10 @@ case class TableUtils(sparkSession: SparkSession) {
   val blockingCacheEviction: Boolean =
     sparkSession.conf.get("spark.chronon.table_write.cache.blocking", "false").toBoolean
 
-  private lazy val tableReadFormatProvider: FormatProvider = {
-    sparkSession.conf.getOption("spark.chronon.table_read.format_provider") match {
+  private lazy val tableFormatProvider: FormatProvider = {
+    sparkSession.conf.getOption("spark.chronon.table.format_provider") match {
       case Some(clazzName) =>
         // Load object instead of class/case class
-        Class.forName(clazzName).getField("MODULE$").get(null).asInstanceOf[FormatProvider]
-      case None =>
-        DefaultFormatProvider(sparkSession)
-    }
-  }
-
-  private lazy val tableWriteFormatProvider: FormatProvider = {
-    sparkSession.conf.getOption("spark.chronon.table_write.format_provider") match {
-      case Some(clazzName) =>
         Class.forName(clazzName).getField("MODULE$").get(null).asInstanceOf[FormatProvider]
       case None =>
         DefaultFormatProvider(sparkSession)
@@ -305,7 +296,7 @@ case class TableUtils(sparkSession: SparkSession) {
     }
   }
 
-  def tableReadFormat(tableName: String): Format = tableReadFormatProvider.readFormat(tableName)
+  def tableReadFormat(tableName: String): Format = tableFormatProvider.readFormat(tableName)
 
   // return all specified partition columns in a table in format of Map[partitionName, PartitionValue]
   def allPartitions(tableName: String, partitionColumnsFilter: Seq[String] = Seq.empty): Seq[Map[String, String]] = {
@@ -667,7 +658,7 @@ case class TableUtils(sparkSession: SparkSession) {
       .filterNot(field => partitionColumns.contains(field.name))
       .map(field => s"`${field.name}` ${field.dataType.catalogString}")
 
-    val writeFormat = tableWriteFormatProvider.writeFormat(tableName)
+    val writeFormat = tableFormatProvider.writeFormat(tableName)
 
     val tableTypString = writeFormat.createTableTypeString
 

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -617,7 +617,8 @@ case class TableUtils(sparkSession: SparkSession) {
       }
 
     logger.info(
-      s"Choosing format: $writeFormat based on useIceberg flag = $useIceberg and writeFormat: $maybeWriteFormat")
+      s"Choosing format: $writeFormat based on useIceberg flag = $useIceberg and " +
+        s"writeFormat: ${sparkSession.conf.getOption("spark.chronon.table_write.format")}")
     val tableTypString = writeFormat.createTableTypeString
 
     val createFragment =

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -50,7 +50,10 @@ import scala.util.{Failure, Success, Try}
 trait Format {
   // Return the primary partitions (based on the 'partitionColumn') filtered down by sub-partition filters if provided
   // If subpartition filters are supplied and the format doesn't support it, we throw an error
-  def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String] = Map.empty)(implicit sparkSession: SparkSession): Seq[String] = {
+  def primaryPartitions(tableName: String,
+                        partitionColumn: String,
+                        subPartitionsFilter: Map[String, String] = Map.empty)(implicit
+      sparkSession: SparkSession): Seq[String] = {
     if (!supportSubPartitionsFilter && subPartitionsFilter.nonEmpty) {
       throw new NotImplementedError(s"subPartitionsFilter is not supported on this format")
     }
@@ -167,7 +170,8 @@ case class DefaultFormatProvider(sparkSession: SparkSession) extends FormatProvi
 }
 
 case object Hive extends Format {
-  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(implicit sparkSession: SparkSession): Seq[String] =
+  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
+      implicit sparkSession: SparkSession): Seq[String] =
     super.primaryPartitions(tableName, partitionColumn, subPartitionsFilter)
 
   def parseHivePartition(pstring: String): Map[String, String] = {
@@ -198,11 +202,12 @@ case object Hive extends Format {
 }
 
 case object Iceberg extends Format {
-  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(implicit sparkSession: SparkSession): Seq[String] = {
+  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
+      implicit sparkSession: SparkSession): Seq[String] = {
     if (!supportSubPartitionsFilter && subPartitionsFilter.nonEmpty) {
       throw new NotImplementedError(s"subPartitionsFilter is not supported on this format")
     }
-    
+
     getIcebergPartitions(tableName)
   }
 
@@ -245,7 +250,8 @@ case object Iceberg extends Format {
 // In such cases, you should implement your own FormatProvider built on the newer Delta lake version
 case object DeltaLake extends Format {
 
-  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(implicit sparkSession: SparkSession): Seq[String] =
+  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
+      implicit sparkSession: SparkSession): Seq[String] =
     super.primaryPartitions(tableName, partitionColumn, subPartitionsFilter)
 
   override def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -616,6 +616,7 @@ case class TableUtils(sparkSession: SparkSession) {
         case (false, None) => Hive
       }
 
+    logger.info(s"Choosing format: $writeFormat based on useIceberg flag = $useIceberg and writeFormat: $maybeWriteFormat")
     val tableTypString = writeFormat.createTableTypeString
 
     val createFragment =

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -616,7 +616,8 @@ case class TableUtils(sparkSession: SparkSession) {
         case (false, None) => Hive
       }
 
-    logger.info(s"Choosing format: $writeFormat based on useIceberg flag = $useIceberg and writeFormat: $maybeWriteFormat")
+    logger.info(
+      s"Choosing format: $writeFormat based on useIceberg flag = $useIceberg and writeFormat: $maybeWriteFormat")
     val tableTypString = writeFormat.createTableTypeString
 
     val createFragment =

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -3,6 +3,7 @@ package ai.chronon.spark.test
 import ai.chronon.api.{DoubleType, IntType, LongType, StringType, StructField, StructType}
 import ai.chronon.spark.test.TestUtils.makeDf
 import ai.chronon.spark.{DeltaLake, Format, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.junit.Assert.{assertEquals, assertTrue}
@@ -33,11 +34,12 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
 
   private def withSparkSession[T](configs: Map[String, String])(test: SparkSession => T): T = {
     val spark = SparkSessionBuilder.build("TableUtilsFormatTest", local = true, additionalConfig = Some(configs))
+    val sc = SparkContext.getOrCreate()
     try {
       test(spark)
     } finally {
+      configs.keys.foreach(cfg => sc.getConf.remove(cfg))
       spark.stop()
-      configs.keys.foreach(cfg => spark.conf.unset(cfg))
     }
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -2,7 +2,7 @@ package ai.chronon.spark.test
 
 import ai.chronon.api.{DoubleType, IntType, LongType, StringType, StructField, StructType}
 import ai.chronon.spark.test.TestUtils.makeDf
-import ai.chronon.spark.{DeltaLake, Format, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
+import ai.chronon.spark.{DeltaLake, Format, Hive, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
@@ -28,8 +28,8 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
   val formats =
     Table(
       ("format", "configs"),
-      (DeltaLake, deltaConfigMap),
-      //(Hive, hiveConfigMap)
+      //(DeltaLake, deltaConfigMap),
+      (Hive, hiveConfigMap)
     )
 
   private def withSparkSession[T](configs: Map[String, String])(test: SparkSession => T): T = {

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -37,6 +37,7 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
       test(spark)
     } finally {
       spark.stop()
+      configs.keys.foreach(cfg => spark.conf.unset(cfg))
     }
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -1,0 +1,3 @@
+package ai.chronon.spark.test class TableUtilsFormatTest {
+
+}

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -1,3 +1,222 @@
-package ai.chronon.spark.test class TableUtilsFormatTest {
+package ai.chronon.spark.test
 
+import ai.chronon.api.{DoubleType, IntType, LongType, StringType, StructField, StructType}
+import ai.chronon.spark.test.TestUtils.makeDf
+import ai.chronon.spark.{DeltaLake, Format, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.prop.TableDrivenPropertyChecks._
+
+import scala.util.Try
+
+class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
+
+  import TableUtilsFormatTest._
+
+  val deltaConfigMap = Map(
+    "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
+    "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+    "spark.chronon.table_write.format" -> "delta"
+  )
+  val hiveConfigMap = Map("spark.chronon.table_write.format" -> "hive")
+
+  // TODO: include Hive + Iceberg support in these tests
+  val formats =
+    Table(
+      ("format", "configs"),
+      (DeltaLake, deltaConfigMap),
+      //(Hive, hiveConfigMap)
+    )
+
+  private def withSparkSession[T](configs: Map[String, String])(test: SparkSession => T): T = {
+    val spark = SparkSessionBuilder.build("TableUtilsFormatTest", local = true, additionalConfig = Some(configs))
+    try {
+      test(spark)
+    } finally {
+      spark.stop()
+    }
+  }
+
+  test("test insertion of partitioned data and adding of columns") {
+    forAll(formats) { (format, configs) =>
+      withSparkSession(configs) { spark =>
+        val tableUtils = TableUtils(spark)
+
+        val tableName = s"db.test_table_1_$format"
+        spark.sql("CREATE DATABASE IF NOT EXISTS db")
+        val columns1 = Array(
+          StructField("long_field", LongType),
+          StructField("int_field", IntType),
+          StructField("string_field", StringType)
+        )
+        val df1 = makeDf(
+          spark,
+          StructType(
+            tableName,
+            columns1 :+ StructField("ds", StringType)
+          ),
+          List(
+            Row(1L, 2, "3", "2022-10-01")
+          )
+        )
+
+        val df2 = makeDf(
+          spark,
+          StructType(
+            tableName,
+            columns1
+              :+ StructField("double_field", DoubleType)
+              :+ StructField("ds", StringType)
+          ),
+          List(
+            Row(4L, 5, "6", 7.0, "2022-10-02")
+          )
+        )
+        testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
+      }
+    }
+  }
+
+  test("test insertion of partitioned data and removal of columns") {
+    forAll(formats) { (format, configs) =>
+      withSparkSession(configs) { spark =>
+        val tableUtils = TableUtils(spark)
+        val tableName = s"db.test_table_2_$format"
+        spark.sql("CREATE DATABASE IF NOT EXISTS db")
+        val columns1 = Array(
+          StructField("long_field", LongType),
+          StructField("int_field", IntType),
+          StructField("string_field", StringType)
+        )
+        val df1 = makeDf(
+          spark,
+          StructType(
+            tableName,
+            columns1
+              :+ StructField("double_field", DoubleType)
+              :+ StructField("ds", StringType)
+          ),
+          List(
+            Row(1L, 2, "3", 4.0, "2022-10-01")
+          )
+        )
+
+        val df2 = makeDf(
+          spark,
+          StructType(
+            tableName,
+            columns1 :+ StructField("ds", StringType)
+          ),
+          List(
+            Row(5L, 6, "7", "2022-10-02")
+          )
+        )
+        testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
+      }
+    }
+  }
+
+  test("test insertion of partitioned data and modification of columns") {
+    forAll(formats) { (format, configs) =>
+      withSparkSession(configs) { spark =>
+        val tableUtils = TableUtils(spark)
+
+        val tableName = s"db.test_table_3_$format"
+        spark.sql("CREATE DATABASE IF NOT EXISTS db")
+        val columns1 = Array(
+          StructField("long_field", LongType),
+          StructField("int_field", IntType)
+        )
+        val df1 = makeDf(
+          spark,
+          StructType(
+            tableName,
+            columns1
+              :+ StructField("string_field", StringType)
+              :+ StructField("ds", StringType)
+          ),
+          List(
+            Row(1L, 2, "3", "2022-10-01")
+          )
+        )
+
+        val df2 = makeDf(
+          spark,
+          StructType(
+            tableName,
+            columns1
+              :+ StructField("string_field", DoubleType) // modified column data type
+              :+ StructField("ds", StringType)
+          ),
+          List(
+            Row(1L, 2, 3.0, "2022-10-02")
+          )
+        )
+
+        testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
+      }
+    }
+  }
+}
+
+object TableUtilsFormatTest {
+  private def testInsertPartitions(spark: SparkSession,
+                                   tableUtils: TableUtils,
+                                   tableName: String,
+                                   format: Format,
+                                   df1: DataFrame,
+                                   df2: DataFrame,
+                                   ds1: String,
+                                   ds2: String): Unit = {
+    tableUtils.insertPartitions(df1, tableName, autoExpand = true)
+    val addedColumns = df2.schema.fieldNames.filterNot(df1.schema.fieldNames.contains)
+    val removedColumns = df1.schema.fieldNames.filterNot(df2.schema.fieldNames.contains)
+    val inconsistentColumns = (
+      for (
+        (name1, dtype1) <- df1.schema.fields.map(structField => (structField.name, structField.dataType));
+        (name2, dtype2) <- df2.schema.fields.map(structField => (structField.name, structField.dataType))
+      ) yield {
+        name1 == name2 && dtype1 != dtype2
+      }
+      ).filter(identity)
+
+    if (inconsistentColumns.nonEmpty) {
+      val insertTry = Try(tableUtils.insertPartitions(df2, tableName, autoExpand = true))
+      val e = insertTry.failed.get.asInstanceOf[IncompatibleSchemaException]
+      assertEquals(inconsistentColumns.length, e.inconsistencies.length)
+      return
+    }
+
+    if (df2.schema != df1.schema) {
+      val insertTry = Try(tableUtils.insertPartitions(df2, tableName))
+      assertTrue(insertTry.failed.get.isInstanceOf[AnalysisException])
+    }
+
+    tableUtils.insertPartitions(df2, tableName, autoExpand = true)
+
+    // check that we wrote out a table in the right format
+    assertTrue(tableUtils.tableFormat(tableName) == format)
+
+    // check we have all the partitions written
+    val returnedPartitions = tableUtils.partitions(tableName)
+    assertTrue(returnedPartitions.toSet == Set(ds1, ds2))
+
+    val dataRead1 = spark.table(tableName).where(col("ds") === ds1)
+    val dataRead2 = spark.table(tableName).where(col("ds") === ds2)
+    assertTrue(dataRead1.columns.length == dataRead2.columns.length)
+
+    val totalColumnsCount = (df1.schema.fieldNames.toSet ++ df2.schema.fieldNames.toSet).size
+    assertEquals(totalColumnsCount, dataRead1.columns.length)
+    assertEquals(totalColumnsCount, dataRead2.columns.length)
+
+    addedColumns.foreach(col => {
+      dataRead1.foreach(row => assertTrue(Option(row.getAs[Any](col)).isEmpty))
+    })
+    removedColumns.foreach(col => {
+      dataRead2.foreach(row => assertTrue(Option(row.getAs[Any](col)).isEmpty))
+    })
+  }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -2,7 +2,7 @@ package ai.chronon.spark.test
 
 import ai.chronon.api.{DoubleType, IntType, LongType, StringType, StructField, StructType}
 import ai.chronon.spark.test.TestUtils.makeDf
-import ai.chronon.spark.{DeltaLake, Format, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
+import ai.chronon.spark.{DeltaLake, Format, Hive, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
@@ -25,14 +25,14 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
     "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
     "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog",
   )
-  val hiveConfigMap = Map.empty
+  val hiveConfigMap = Map.empty[String, String]
 
   // TODO: include Hive + Iceberg support in these tests
   val formats =
     Table(
       ("format", "configs"),
       (DeltaLake, deltaConfigMap),
-      //(Hive, hiveConfigMap)
+      (Hive, hiveConfigMap)
     )
 
   private def withSparkSession[T](configs: Map[String, String])(test: SparkSession => T): T = {
@@ -46,7 +46,7 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
     }
   }
 
-  test("test insertion of partitioned data and adding of columns") {
+  ignore("test insertion of partitioned data and adding of columns") {
     forAll(formats) { (format, configs) =>
       withSparkSession(configs) { spark =>
         val tableUtils = new TestTableUtils(spark, format)
@@ -86,7 +86,7 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
     }
   }
 
-  test("test insertion of partitioned data and removal of columns") {
+  ignore("test insertion of partitioned data and removal of columns") {
     forAll(formats) { (format, configs) =>
       withSparkSession(configs) { spark =>
         val tableUtils = TableUtils(spark)
@@ -125,7 +125,7 @@ class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
     }
   }
 
-  test("test insertion of partitioned data and modification of columns") {
+  ignore("test insertion of partitioned data and modification of columns") {
     forAll(formats) { (format, configs) =>
       withSparkSession(configs) { spark =>
         val tableUtils = TableUtils(spark)

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -7,7 +7,7 @@ import ai.chronon.spark.{IncompatibleSchemaException, SparkSessionBuilder, Table
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 import scala.util.Try
 
@@ -55,7 +55,7 @@ class TableUtilsFormatTest {
     testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
   }
 
-  @Ignore
+  @Test
   def testInsertPartitionsAddRemoveColumns(): Unit = {
     val tableName = s"db.test_table_2_$format"
     spark.sql("CREATE DATABASE IF NOT EXISTS db")
@@ -90,7 +90,7 @@ class TableUtilsFormatTest {
     testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
   }
 
-  @Ignore
+  @Test
   def testInsertPartitionsAddModifyColumns(): Unit = {
     val tableName = s"db.test_table_3_$format"
     spark.sql("CREATE DATABASE IF NOT EXISTS db")

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -164,7 +164,7 @@ object TableUtilsFormatTest {
     tableUtils.insertPartitions(df2, tableName, autoExpand = true)
 
     // check that we wrote out a table in the right format
-    val readTableFormat = tableUtils.tableFormat(tableName).toString
+    val readTableFormat = tableUtils.tableReadFormat(tableName).toString
     assertTrue(s"Mismatch in table format: $readTableFormat; expected: $format", readTableFormat.toLowerCase == format)
 
     // check we have all the partitions written

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -22,8 +22,9 @@ class TableUtilsFormatTest {
 
   @Test
   def testInsertPartitionsAddColumns(): Unit = {
-    val tableName = s"db.test_table_1_$format"
-    spark.sql("CREATE DATABASE IF NOT EXISTS db")
+    val dbName = s"db_${System.currentTimeMillis()}"
+    val tableName = s"$dbName.test_table_1_$format"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
     val columns1 = Array(
       StructField("long_field", LongType),
       StructField("int_field", IntType),
@@ -57,8 +58,9 @@ class TableUtilsFormatTest {
 
   @Test
   def testInsertPartitionsAddRemoveColumns(): Unit = {
-    val tableName = s"db.test_table_2_$format"
-    spark.sql("CREATE DATABASE IF NOT EXISTS db")
+    val dbName = s"db_${System.currentTimeMillis()}"
+    val tableName = s"$dbName.test_table_2_$format"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
     val columns1 = Array(
       StructField("long_field", LongType),
       StructField("int_field", IntType),
@@ -92,8 +94,9 @@ class TableUtilsFormatTest {
 
   @Test
   def testInsertPartitionsAddModifyColumns(): Unit = {
-    val tableName = s"db.test_table_3_$format"
-    spark.sql("CREATE DATABASE IF NOT EXISTS db")
+    val dbName = s"db_${System.currentTimeMillis()}"
+    val tableName = s"$dbName.test_table_3_$format"
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName")
     val columns1 = Array(
       StructField("long_field", LongType),
       StructField("int_field", IntType)

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -7,7 +7,7 @@ import ai.chronon.spark.{IncompatibleSchemaException, SparkSessionBuilder, Table
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Ignore
+import org.junit.{Ignore, Test}
 
 import scala.util.Try
 
@@ -20,7 +20,7 @@ class TableUtilsFormatTest {
   val spark = SparkSessionBuilder.build("TableUtilsFormatTest", local = true)
   val tableUtils = TableUtils(spark)
 
-  @Ignore
+  @Test
   def testInsertPartitionsAddColumns(): Unit = {
     val tableName = s"db.test_table_1_$format"
     spark.sql("CREATE DATABASE IF NOT EXISTS db")

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -27,7 +27,7 @@ class TableUtilsFormatTest extends AnyFunSuite {
     }
   }
 
-  ignore("test insertion of partitioned data and adding of columns") {
+  test("test insertion of partitioned data and adding of columns") {
     withSparkSession { spark =>
       val tableUtils = TableUtils(spark)
 
@@ -65,7 +65,7 @@ class TableUtilsFormatTest extends AnyFunSuite {
     }
   }
 
-  ignore("test insertion of partitioned data and removal of columns") {
+  test("test insertion of partitioned data and removal of columns") {
     withSparkSession { spark =>
       val tableUtils = TableUtils(spark)
       val tableName = s"db.test_table_2_$format"
@@ -102,7 +102,7 @@ class TableUtilsFormatTest extends AnyFunSuite {
     }
   }
 
-  ignore("test insertion of partitioned data and modification of columns") {
+  test("test insertion of partitioned data and modification of columns") {
     withSparkSession { spark =>
       val tableUtils = TableUtils(spark)
 

--- a/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/TableUtilsFormatTest.scala
@@ -1,169 +1,144 @@
 package ai.chronon.spark.test
 
 import ai.chronon.api.{DoubleType, IntType, LongType, StringType, StructField, StructType}
+import ai.chronon.spark.SparkSessionBuilder.FormatTestEnvVar
 import ai.chronon.spark.test.TestUtils.makeDf
-import ai.chronon.spark.{DeltaLake, Format, Hive, IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
-import org.apache.spark.SparkContext
+import ai.chronon.spark.{IncompatibleSchemaException, SparkSessionBuilder, TableUtils}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.junit.Assert.{assertEquals, assertTrue}
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.prop.TableDrivenPropertyChecks._
 
 import scala.util.Try
 
-class TestTableUtils(sparkSession: SparkSession, format: Format) extends TableUtils(sparkSession) {
-  override def getWriteFormat: Format = format
-}
-
-class TableUtilsFormatTest extends AnyFunSuite with BeforeAndAfterEach {
+class TableUtilsFormatTest extends AnyFunSuite {
 
   import TableUtilsFormatTest._
 
-  val deltaConfigMap = Map(
-    "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
-    "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-  )
-  val hiveConfigMap = Map.empty[String, String]
+  // Read the format we want this instantiation of the test to run via environment vars
+  val format: String = sys.env.getOrElse(FormatTestEnvVar, "hive")
 
-  // TODO: include Hive + Iceberg support in these tests
-  val formats =
-    Table(
-      ("format", "configs"),
-      (DeltaLake, deltaConfigMap),
-      (Hive, hiveConfigMap)
-    )
-
-  private def withSparkSession[T](configs: Map[String, String])(test: SparkSession => T): T = {
-    val spark = SparkSessionBuilder.build("TableUtilsFormatTest", local = true, additionalConfig = Some(configs))
-    val sc = SparkContext.getOrCreate()
+  private def withSparkSession[T](test: SparkSession => T): T = {
+    val spark = SparkSessionBuilder.build("TableUtilsFormatTest", local = true)
     try {
       test(spark)
     } finally {
-      configs.keys.foreach(cfg => sc.getConf.remove(cfg))
       spark.stop()
     }
   }
 
   ignore("test insertion of partitioned data and adding of columns") {
-    forAll(formats) { (format, configs) =>
-      withSparkSession(configs) { spark =>
-        val tableUtils = new TestTableUtils(spark, format)
+    withSparkSession { spark =>
+      val tableUtils = TableUtils(spark)
 
-        val tableName = s"db.test_table_1_$format"
-        spark.sql("CREATE DATABASE IF NOT EXISTS db")
-        val columns1 = Array(
-          StructField("long_field", LongType),
-          StructField("int_field", IntType),
-          StructField("string_field", StringType)
+      val tableName = s"db.test_table_1_$format"
+      spark.sql("CREATE DATABASE IF NOT EXISTS db")
+      val columns1 = Array(
+        StructField("long_field", LongType),
+        StructField("int_field", IntType),
+        StructField("string_field", StringType)
+      )
+      val df1 = makeDf(
+        spark,
+        StructType(
+          tableName,
+          columns1 :+ StructField("ds", StringType)
+        ),
+        List(
+          Row(1L, 2, "3", "2022-10-01")
         )
-        val df1 = makeDf(
-          spark,
-          StructType(
-            tableName,
-            columns1 :+ StructField("ds", StringType)
-          ),
-          List(
-            Row(1L, 2, "3", "2022-10-01")
-          )
-        )
+      )
 
-        val df2 = makeDf(
-          spark,
-          StructType(
-            tableName,
-            columns1
-              :+ StructField("double_field", DoubleType)
-              :+ StructField("ds", StringType)
-          ),
-          List(
-            Row(4L, 5, "6", 7.0, "2022-10-02")
-          )
+      val df2 = makeDf(
+        spark,
+        StructType(
+          tableName,
+          columns1
+            :+ StructField("double_field", DoubleType)
+            :+ StructField("ds", StringType)
+        ),
+        List(
+          Row(4L, 5, "6", 7.0, "2022-10-02")
         )
-        testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
-      }
+      )
+      testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
     }
   }
 
   ignore("test insertion of partitioned data and removal of columns") {
-    forAll(formats) { (format, configs) =>
-      withSparkSession(configs) { spark =>
-        val tableUtils = TableUtils(spark)
-        val tableName = s"db.test_table_2_$format"
-        spark.sql("CREATE DATABASE IF NOT EXISTS db")
-        val columns1 = Array(
-          StructField("long_field", LongType),
-          StructField("int_field", IntType),
-          StructField("string_field", StringType)
+    withSparkSession { spark =>
+      val tableUtils = TableUtils(spark)
+      val tableName = s"db.test_table_2_$format"
+      spark.sql("CREATE DATABASE IF NOT EXISTS db")
+      val columns1 = Array(
+        StructField("long_field", LongType),
+        StructField("int_field", IntType),
+        StructField("string_field", StringType)
+      )
+      val df1 = makeDf(
+        spark,
+        StructType(
+          tableName,
+          columns1
+            :+ StructField("double_field", DoubleType)
+            :+ StructField("ds", StringType)
+        ),
+        List(
+          Row(1L, 2, "3", 4.0, "2022-10-01")
         )
-        val df1 = makeDf(
-          spark,
-          StructType(
-            tableName,
-            columns1
-              :+ StructField("double_field", DoubleType)
-              :+ StructField("ds", StringType)
-          ),
-          List(
-            Row(1L, 2, "3", 4.0, "2022-10-01")
-          )
-        )
+      )
 
-        val df2 = makeDf(
-          spark,
-          StructType(
-            tableName,
-            columns1 :+ StructField("ds", StringType)
-          ),
-          List(
-            Row(5L, 6, "7", "2022-10-02")
-          )
+      val df2 = makeDf(
+        spark,
+        StructType(
+          tableName,
+          columns1 :+ StructField("ds", StringType)
+        ),
+        List(
+          Row(5L, 6, "7", "2022-10-02")
         )
-        testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
-      }
+      )
+      testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
     }
   }
 
   ignore("test insertion of partitioned data and modification of columns") {
-    forAll(formats) { (format, configs) =>
-      withSparkSession(configs) { spark =>
-        val tableUtils = TableUtils(spark)
+    withSparkSession { spark =>
+      val tableUtils = TableUtils(spark)
 
-        val tableName = s"db.test_table_3_$format"
-        spark.sql("CREATE DATABASE IF NOT EXISTS db")
-        val columns1 = Array(
-          StructField("long_field", LongType),
-          StructField("int_field", IntType)
+      val tableName = s"db.test_table_3_$format"
+      spark.sql("CREATE DATABASE IF NOT EXISTS db")
+      val columns1 = Array(
+        StructField("long_field", LongType),
+        StructField("int_field", IntType)
+      )
+      val df1 = makeDf(
+        spark,
+        StructType(
+          tableName,
+          columns1
+            :+ StructField("string_field", StringType)
+            :+ StructField("ds", StringType)
+        ),
+        List(
+          Row(1L, 2, "3", "2022-10-01")
         )
-        val df1 = makeDf(
-          spark,
-          StructType(
-            tableName,
-            columns1
-              :+ StructField("string_field", StringType)
-              :+ StructField("ds", StringType)
-          ),
-          List(
-            Row(1L, 2, "3", "2022-10-01")
-          )
-        )
+      )
 
-        val df2 = makeDf(
-          spark,
-          StructType(
-            tableName,
-            columns1
-              :+ StructField("string_field", DoubleType) // modified column data type
-              :+ StructField("ds", StringType)
-          ),
-          List(
-            Row(1L, 2, 3.0, "2022-10-02")
-          )
+      val df2 = makeDf(
+        spark,
+        StructType(
+          tableName,
+          columns1
+            :+ StructField("string_field", DoubleType) // modified column data type
+            :+ StructField("ds", StringType)
+        ),
+        List(
+          Row(1L, 2, 3.0, "2022-10-02")
         )
+      )
 
-        testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
-      }
+      testInsertPartitions(spark, tableUtils, tableName, format, df1, df2, ds1 = "2022-10-01", ds2 = "2022-10-02")
     }
   }
 }
@@ -172,7 +147,7 @@ object TableUtilsFormatTest {
   private def testInsertPartitions(spark: SparkSession,
                                    tableUtils: TableUtils,
                                    tableName: String,
-                                   format: Format,
+                                   format: String,
                                    df1: DataFrame,
                                    df2: DataFrame,
                                    ds1: String,
@@ -204,7 +179,8 @@ object TableUtilsFormatTest {
     tableUtils.insertPartitions(df2, tableName, autoExpand = true)
 
     // check that we wrote out a table in the right format
-    assertTrue(tableUtils.tableFormat(tableName) == format)
+    val readTableFormat = tableUtils.tableFormat(tableName).toString
+    assertTrue(s"Mismatch in table format: $readTableFormat; expected: $format", readTableFormat.toLowerCase == format)
 
     // check we have all the partitions written
     val returnedPartitions = tableUtils.partitions(tableName)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Add delta lake support in Chronon. This PR refactors TableUtils a bit to allow us to support Delta Lake (and other table formats in the future like Hudi). The crux of the PR is the refactor of TableUtils - I've pulled out some of the format specific stuff into per-format objects (e.g. Hive / Iceberg / Delta) to help us cover aspects like creating tables, listing partitions. 

As the versions of the various libraries we build against in Chronon is on the older side (e.g. delta lake - 2.0.x for Spark 3.2), we've structured the code to allow users to override their format providers. This allows folks say on Delta 3.x (Spark 3.5) to write their own Delta3xFormatProvider that is built against the newer version and configure it via the `spark.chronon.table.format_provider` Spark config setting. For users on the same versions / rails as OSS, they can skip configuring this and we'll default to the DefaultFormatProvider (which maintains the existing Iceberg / Hive behavior along with support for delta).  

Notes on testing:
* TableUtilsTest is un-changed. This test covers a bunch of Hive related tests (like creating tables, inserting partitions) and some format agnostic stuff (like schema evolution type of checks). 
* Added a TableUtilsFormat test - for now this covers testing Delta. Can add Iceberg in a follow up (as Iceberg format support is currently untested in the project). 
* Unfortunately the way we create Spark sessions in not ideal in the Chronon project. We kick off *all* our tests in parallel at the same time in CI (same JVM) and we end up triggering code like: [SchemaEvolutionTest](https://github.com/airbnb/chronon/blob/main/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala#L65) where we are creating the SparkSession at the class object construction time. This results in many tests vying to create sessions at the same time - most with the same spark settings but some like the new delta format test with different settings (using the delta catalog, delta spark session extension). Thanks to this we're not able to run the delta tests in the test JVM as the others AND we need to ensure that the other test spark sessions don't end up getting created with the wrong settings as that will cause the delta test to fail. 
* The potentially nice way to handle this would be to refactor all our existing spark tests to postpone session creation till the test body and handle session cleanup etc but as this is a fairly involved / risky change, I've chosen to instead use an env var to have the Spark session builder choose the right delta / non-delta options. It's not the cleanest but it does minimize the blast radius of these changes considerably. 


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Allow folks keen on experimenting with Chronon that use delta lake to do so. Set the stage for supporting additional table formats in the future.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [X] Covered by existing CI
- [ ] Integration tested

@mickjermsurawong-openai was also able to pull these changes and test things out using delta lake tables. We were able to sort out issues with Delta 3.x (as they're on Spark 3.5) using the provider interface. 

## Checklist
- [ ] Documentation update

## Reviewers

