### PR TITLE
Add fetcher metrics

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -40,7 +40,7 @@ case class FinalBatchIr(collapsed: Array[Any], tailHops: HopsAggregator.OutputAr
 class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
                                  inputSchema: Seq[(String, DataType)],
                                  resolution: Resolution = FiveMinuteResolution,
-                                 tailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis)
+                                 val tailBufferMillis: Long = new Window(2, TimeUnit.DAYS).millis)
     extends SawtoothAggregator(aggregations: Seq[Aggregation],
                                inputSchema: Seq[(String, DataType)],
                                resolution: Resolution) {

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -84,7 +84,6 @@ class FetcherBase(kvStore: KVStore,
                                       servingInfo,
                                       keys)
     } else if (streamingResponsesOpt.isEmpty) { // snapshot accurate
-
       val batchResponseDecodeStartTime = System.currentTimeMillis()
       val response = getMapResponseFromBatchResponse(batchResponses,
                                                      batchBytes,
@@ -741,7 +740,7 @@ class FetcherBase(kvStore: KVStore,
                                          windows: Seq[Window]): Long = {
     val groupByContainsLongerWinThanTailBuffer = windows.exists(p => p.millis > tailBufferMillis)
     if (queryTimeMs > (tailBufferMillis + batchEndTsMillis) && groupByContainsLongerWinThanTailBuffer) {
-      println(
+      logger.warn(
         s"Encountered a request for $groupByName at $queryTimeMs which is more than $tailBufferMillis ms after the " +
           s"batch dataset landing at $batchEndTsMillis. ")
       1L

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -91,7 +91,7 @@ class FetcherBase(kvStore: KVStore,
                                                      servingInfo.outputCodec.decodeMap,
                                                      servingInfo,
                                                      keys)
-      context.histogramTagged("group_by.batchir_decode.latency.millis",
+      context.distribution("group_by.batchir_decode.latency.millis",
                               System.currentTimeMillis() - batchResponseDecodeStartTime)
       response
     } else { // temporal accurate
@@ -113,7 +113,7 @@ class FetcherBase(kvStore: KVStore,
         (batchResponses.isInstanceOf[KvStoreBatchResponse] && batchBytes == null)
       ) {
         if (debug) logger.info("Both batch and streaming data are null")
-        context.histogramTagged("group_by.latency.millis", System.currentTimeMillis() - startTimeMs)
+        context.distribution("group_by.latency.millis", System.currentTimeMillis() - startTimeMs)
         return null
       }
 
@@ -128,7 +128,7 @@ class FetcherBase(kvStore: KVStore,
       val batchIrDecodeStartTime = System.currentTimeMillis()
       val batchIr: FinalBatchIr =
         getBatchIrFromBatchResponse(batchResponses, batchBytes, servingInfo, toBatchIr, keys)
-      context.histogramTagged("group_by.batchir_decode.latency.millis",
+      context.distribution("group_by.batchir_decode.latency.millis",
                               System.currentTimeMillis() - batchIrDecodeStartTime)
 
       // check if we have late batch data for this GroupBy resulting in degraded counters
@@ -166,7 +166,7 @@ class FetcherBase(kvStore: KVStore,
           .toArray
           .iterator
 
-        context.histogramTagged("group_by.all_streamingir_decode.latency.millis",
+        context.distribution("group_by.all_streamingir_decode.latency.millis",
                                 System.currentTimeMillis() - allStreamingIrDecodeStartTime)
 
         if (debug) {
@@ -181,7 +181,7 @@ class FetcherBase(kvStore: KVStore,
 
         val aggregatorStartTime = System.currentTimeMillis()
         aggregator.lambdaAggregateFinalizedTiled(batchIr, streamingIrs, queryTimeMs)
-        context.histogramTagged("group_by.aggregator.latency.millis", System.currentTimeMillis() - aggregatorStartTime)
+        context.distribution("group_by.aggregator.latency.millis", System.currentTimeMillis() - aggregatorStartTime)
       } else {
         val selectedCodec = servingInfo.groupByOps.dataModel match {
           case DataModel.Events   => servingInfo.valueAvroCodec

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -86,9 +86,13 @@ class FetcherBase(kvStore: KVStore,
     } else if (streamingResponsesOpt.isEmpty) { // snapshot accurate
 
       val batchResponseDecodeStartTime = System.currentTimeMillis()
-      val response = getMapResponseFromBatchResponse(batchResponses, batchBytes, servingInfo.outputCodec.decodeMap, servingInfo, keys)
+      val response = getMapResponseFromBatchResponse(batchResponses,
+                                                     batchBytes,
+                                                     servingInfo.outputCodec.decodeMap,
+                                                     servingInfo,
+                                                     keys)
       context.histogramTagged("group_by.batchir_decode.latency.millis",
-        System.currentTimeMillis() - batchResponseDecodeStartTime)
+                              System.currentTimeMillis() - batchResponseDecodeStartTime)
       response
     } else { // temporal accurate
       val streamingResponses = streamingResponsesOpt.get
@@ -125,14 +129,14 @@ class FetcherBase(kvStore: KVStore,
       val batchIr: FinalBatchIr =
         getBatchIrFromBatchResponse(batchResponses, batchBytes, servingInfo, toBatchIr, keys)
       context.histogramTagged("group_by.batchir_decode.latency.millis",
-        System.currentTimeMillis() - batchIrDecodeStartTime)
+                              System.currentTimeMillis() - batchIrDecodeStartTime)
 
       // check if we have late batch data for this GroupBy resulting in degraded counters
       val degradedCount = checkLateBatchData(queryTimeMs,
-        servingInfo.groupBy.metaData.name,
-        servingInfo.batchEndTsMillis,
-        aggregator.tailBufferMillis,
-        aggregator.perWindowAggs.map(_.window))
+                                             servingInfo.groupBy.metaData.name,
+                                             servingInfo.batchEndTsMillis,
+                                             aggregator.tailBufferMillis,
+                                             aggregator.perWindowAggs.map(_.window))
       context.count("group_by.degraded_counter.count", degradedCount)
 
       val output: Array[Any] = if (servingInfo.isTilingEnabled) {
@@ -163,7 +167,7 @@ class FetcherBase(kvStore: KVStore,
           .iterator
 
         context.histogramTagged("group_by.all_streamingir_decode.latency.millis",
-          System.currentTimeMillis() - allStreamingIrDecodeStartTime)
+                                System.currentTimeMillis() - allStreamingIrDecodeStartTime)
 
         if (debug) {
           val gson = new Gson()

--- a/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
@@ -254,7 +254,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
   }
 
   @Test
-  def test_checkLateBatchData_ShouldHandle_BatchDataIsNotLate(): Unit = {
+  def testCheckLateBatchDataShouldHandleBatchDataIsNotLate(): Unit = {
     val fetcherBase = new FetcherBase(mock[KVStore])
 
     // lookup request - 03/20/2024 01:00 UTC

--- a/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
@@ -22,7 +22,7 @@ import ai.chronon.api.{Builders, GroupBy, MetaData, TimeUnit, Window}
 import ai.chronon.online.Fetcher.{ColumnSpec, Request, Response}
 import ai.chronon.online.FetcherCache.BatchResponses
 import ai.chronon.online.KVStore.TimedValue
-import org.junit.Assert.{assertFalse, assertTrue, fail}
+import org.junit.Assert.{assertFalse, assertTrue, assertSame, fail}
 import org.junit.{Before, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -226,7 +226,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
     val flagStore: FlagStore = (flagName: String, attributes: java.util.Map[String, String]) => {
       flagName match {
         case "enable_entity_validity_check" => true
-        case _ => false
+        case _                              => false
       }
     }
 
@@ -238,7 +238,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
 
   @Test
   def test_checkLateBatchData_ShouldHandle_BatchDataIsLate(): Unit = {
-    val fetcherBase = new FetcherBase(mock[KVStore], mock[BiPredicate[String, java.util.Map[String, String]]])
+    val fetcherBase = new FetcherBase(mock[KVStore])
 
     // lookup request - 03/20/2024 01:00 UTC
     // batch landing time 03/17/2024 00:00 UTC
@@ -255,7 +255,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
 
   @Test
   def test_checkLateBatchData_ShouldHandle_BatchDataIsNotLate(): Unit = {
-    val fetcherBase = new FetcherBase(mock[KVStore], mock[BiPredicate[String, java.util.Map[String, String]]])
+    val fetcherBase = new FetcherBase(mock[KVStore])
 
     // lookup request - 03/20/2024 01:00 UTC
     // batch landing time 03/19/2024 00:00 UTC

--- a/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
@@ -238,35 +238,35 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
 
   @Test
   def test_checkLateBatchData_ShouldHandle_BatchDataIsLate(): Unit = {
-    val baseFetcher = new BaseFetcher(mock[KVStore], mock[BiPredicate[String, java.util.Map[String, String]]])
+    val fetcherBase = new FetcherBase(mock[KVStore], mock[BiPredicate[String, java.util.Map[String, String]]])
 
     // lookup request - 03/20/2024 01:00 UTC
     // batch landing time 03/17/2024 00:00 UTC
     val longWindows = Seq(new Window(7, TimeUnit.DAYS), new Window(10, TimeUnit.DAYS))
     val tailHops2d = new Window(2, TimeUnit.DAYS).millis
-    val result = baseFetcher.checkLateBatchData(1710896400000L, "myGroupBy", 1710633600000L, tailHops2d, longWindows)
+    val result = fetcherBase.checkLateBatchData(1710896400000L, "myGroupBy", 1710633600000L, tailHops2d, longWindows)
     assertSame(result, 1L)
 
     // try the same with a shorter lookback window
     val shortWindows = Seq(new Window(1, TimeUnit.DAYS), new Window(10, TimeUnit.HOURS))
-    val result2 = baseFetcher.checkLateBatchData(1710896400000L, "myGroupBy", 1710633600000L, tailHops2d, shortWindows)
+    val result2 = fetcherBase.checkLateBatchData(1710896400000L, "myGroupBy", 1710633600000L, tailHops2d, shortWindows)
     assertSame(result2, 0L)
   }
 
   @Test
   def test_checkLateBatchData_ShouldHandle_BatchDataIsNotLate(): Unit = {
-    val baseFetcher = new BaseFetcher(mock[KVStore], mock[BiPredicate[String, java.util.Map[String, String]]])
+    val fetcherBase = new FetcherBase(mock[KVStore], mock[BiPredicate[String, java.util.Map[String, String]]])
 
     // lookup request - 03/20/2024 01:00 UTC
     // batch landing time 03/19/2024 00:00 UTC
     val longWindows = Seq(new Window(7, TimeUnit.DAYS), new Window(10, TimeUnit.DAYS))
     val tailHops2d = new Window(2, TimeUnit.DAYS).millis
-    val result = baseFetcher.checkLateBatchData(1710896400000L, "myGroupBy", 1710806400000L, tailHops2d, longWindows)
+    val result = fetcherBase.checkLateBatchData(1710896400000L, "myGroupBy", 1710806400000L, tailHops2d, longWindows)
     assertSame(result, 0L)
 
     // try the same with a shorter lookback window
     val shortWindows = Seq(new Window(1, TimeUnit.DAYS), new Window(10, TimeUnit.HOURS))
-    val result2 = baseFetcher.checkLateBatchData(1710896400000L, "myGroupBy", 1710633600000L, tailHops2d, shortWindows)
+    val result2 = fetcherBase.checkLateBatchData(1710896400000L, "myGroupBy", 1710633600000L, tailHops2d, shortWindows)
     assertSame(result2, 0L)
   }
 }

--- a/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
@@ -237,7 +237,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
   }
 
   @Test
-  def test_checkLateBatchData_ShouldHandle_BatchDataIsLate(): Unit = {
+  def testCheckLateBatchDataShouldHandleBatchDataIsLate(): Unit = {
     val fetcherBase = new FetcherBase(mock[KVStore])
 
     // lookup request - 03/20/2024 01:00 UTC


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adds some metrics to the Chronon fetcher:
* Latency metrics
  * Batch data/IR decode time
  * Streaming data/IR decode time
  * Aggregation time
* Stale batch data counter. When batch data is older than the size of the tailHops, this metric will start receiving firing.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
At Stripe, these metrics have facilitated explaining and optimizing Chronon latency.

The stale data counter has helped us identify feature correctness incidents.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [X] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@piyush-zlai 
@pengyu-hou 