### PR TITLE
Update metadata exporter directory traverse logic

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -60,6 +60,8 @@ object MetadataExporter {
             }
           }
         }
+      } else {
+        fileBuffer += currentDir.getAbsolutePath
       }
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -107,7 +107,11 @@ object MetadataExporter {
     val processSuccess = getFilePaths(inputPath).map { path =>
       try {
         val data = enrichMetadata(path)
-        writeOutput(data, path, outputPath)
+        if (path.contains(GROUPBY_PATH_SUFFIX)) {
+          writeOutput(data, path, outputPath + GROUPBY_PATH_SUFFIX)
+        } else if (path.contains(JOIN_PATH_SUFFIX)) {
+          writeOutput(data, path, outputPath + JOIN_PATH_SUFFIX)
+        }
         (path, true, None)
       } catch {
         case exception: Throwable => (path, false, ExceptionUtils.getStackTrace(exception))

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -17,16 +17,17 @@
 package ai.chronon.spark
 
 import org.slf4j.LoggerFactory
+
 import java.io.{BufferedWriter, File, FileWriter}
 import ai.chronon.api
 import ai.chronon.api.{DataType, ThriftJsonCodec}
+import java.nio.file.{Files, Paths, SimpleFileVisitor, FileVisitResult}
+import java.nio.file.attribute.BasicFileAttributes
+
+import collection.mutable.ListBuffer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.commons.lang.exception.ExceptionUtils
-
-import java.nio.file.Files
-import java.nio.file.Paths
-import scala.collection.immutable.Map
 
 object MetadataExporter {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -42,10 +43,28 @@ object MetadataExporter {
 
   def getFilePaths(inputPath: String): Seq[String] = {
     val rootDir = new File(inputPath)
-    rootDir.listFiles
-      .filter(!_.isFile)
-      .flatMap(_.listFiles())
-      .map(_.getPath)
+    if (!rootDir.exists()) {
+      throw new Exception(f"Directory $inputPath does not exist!")
+    }
+    val fileBuffer = new ListBuffer[String]()
+
+    def traverseDirectory(currentDir: File): Unit = {
+      if (currentDir.isDirectory) {
+        val files = currentDir.listFiles()
+        if (files != null) {
+          for (file <- files) {
+            if (file.isFile) {
+              fileBuffer += file.getAbsolutePath
+            } else if (file.isDirectory) {
+              traverseDirectory(file)
+            }
+          }
+        }
+      }
+    }
+
+    traverseDirectory(rootDir)
+    fileBuffer.toList
   }
 
   def enrichMetadata(path: String): String = {
@@ -56,11 +75,13 @@ object MetadataExporter {
         if (path.contains(GROUPBY_PATH_SUFFIX)) {
           val groupBy = ThriftJsonCodec.fromJsonFile[api.GroupBy](path, check = false)
           configData + { "features" -> analyzer.analyzeGroupBy(groupBy)._1.map(_.asMap) }
-        } else {
+        } else if (path.contains(JOIN_PATH_SUFFIX)){
           val join = ThriftJsonCodec.fromJsonFile[api.Join](path, check = false)
           val joinAnalysis = analyzer.analyzeJoin(join, validateTablePermission = false)
           val featureMetadata: Seq[Map[String, String]] = joinAnalysis._2.toSeq.map(_.asMap)
           configData + { "features" -> featureMetadata }
+        } else {
+          throw new Exception(f"Unknown entity type for $path")
         }
       } catch {
         case exception: Throwable =>
@@ -80,11 +101,11 @@ object MetadataExporter {
     logger.info(s"${path} : Wrote to output directory successfully")
   }
 
-  def processEntities(inputPath: String, outputPath: String, suffix: String): Unit = {
-    val processSuccess = getFilePaths(inputPath + suffix).map { path =>
+  def processEntities(inputPath: String, outputPath: String): Unit = {
+    val processSuccess = getFilePaths(inputPath).map { path =>
       try {
         val data = enrichMetadata(path)
-        writeOutput(data, path, outputPath + suffix)
+        writeOutput(data, path, outputPath)
         (path, true, None)
       } catch {
         case exception: Throwable => (path, false, ExceptionUtils.getStackTrace(exception))
@@ -92,12 +113,11 @@ object MetadataExporter {
     }
     val failuresAndTraces = processSuccess.filter(!_._2)
     logger.info(
-      s"Successfully processed ${processSuccess.filter(_._2).length} from $suffix \n " +
+      s"Successfully processed ${processSuccess.filter(_._2).length} from $inputPath \n " +
         s"Failed to process ${failuresAndTraces.length}: \n ${failuresAndTraces.mkString("\n")}")
   }
 
   def run(inputPath: String, outputPath: String): Unit = {
-    processEntities(inputPath, outputPath, GROUPBY_PATH_SUFFIX)
-    processEntities(inputPath, outputPath, JOIN_PATH_SUFFIX)
+    processEntities(inputPath, outputPath)
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -77,7 +77,7 @@ object MetadataExporter {
         if (path.contains(GROUPBY_PATH_SUFFIX)) {
           val groupBy = ThriftJsonCodec.fromJsonFile[api.GroupBy](path, check = false)
           configData + { "features" -> analyzer.analyzeGroupBy(groupBy)._1.map(_.asMap) }
-        } else if (path.contains(JOIN_PATH_SUFFIX)){
+        } else if (path.contains(JOIN_PATH_SUFFIX)) {
           val join = ThriftJsonCodec.fromJsonFile[api.Join](path, check = false)
           val joinAnalysis = analyzer.analyzeJoin(join, validateTablePermission = false)
           val featureMetadata: Seq[Map[String, String]] = joinAnalysis._2.toSeq.map(_.asMap)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
The current metadata exporter only support to be run under the production folder. This PR updates the directory traverse logic to make it runnable under teams folder or on single file. 

Before the change:
python3 ~/.local/bin/run.py --mode=metadata-export  --input-root-path production

After the change:
python3 ~/.local/bin/run.py --mode=metadata-export  --input-root-path production
python3 ~/.local/bin/run.py --mode=metadata-export  --input-root-path production/joins/ml_infra
python3 ~/.local/bin/run.py --mode=metadata-export  --input-root-path production/joins
python3 ~/.local/bin/run.py --mode=metadata-export  --input-root-path production/joins/ml_infra/test_config.v1

Will all be supported. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested
Tested by local run metadata exporter
## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @SophieYu41 
