### PR TITLE
[Metadata]Support derived feature in GroupBy Metadata Export

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -180,7 +180,9 @@ class Analyzer(tableUtils: TableUtils,
                         aggPart.inputColumn.toLowerCase)
   }
 
-  private def toAggregationMetadata(columnName: String, columnType: DataType, hasDerivation: Boolean = false): AggregationMetadata = {
+  private def toAggregationMetadata(columnName: String,
+                                    columnType: DataType,
+                                    hasDerivation: Boolean = false): AggregationMetadata = {
     val operation = if (hasDerivation) "Derivation" else "No Operation"
     AggregationMetadata(columnName, columnType, operation, "Unbounded", columnName)
   }

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -172,7 +172,7 @@ class Analyzer(tableUtils: TableUtils,
 
   }
 
-  def toAggregationMetadata(aggPart: AggregationPart, columnType: DataType): AggregationMetadata = {
+  private def toAggregationMetadata(aggPart: AggregationPart, columnType: DataType): AggregationMetadata = {
     AggregationMetadata(aggPart.outputColumnName,
                         columnType,
                         aggPart.operation.toString.toLowerCase,
@@ -180,8 +180,9 @@ class Analyzer(tableUtils: TableUtils,
                         aggPart.inputColumn.toLowerCase)
   }
 
-  def toAggregationMetadata(columnName: String, columnType: DataType): AggregationMetadata = {
-    AggregationMetadata(columnName, columnType, "No operation", "Unbounded", columnName)
+  private def toAggregationMetadata(columnName: String, columnType: DataType, hasDerivation: Boolean = false): AggregationMetadata = {
+    val operation = if (hasDerivation) "Derivation" else "No Operation"
+    AggregationMetadata(columnName, columnType, operation, "Unbounded", columnName)
   }
 
   def analyzeGroupBy(
@@ -248,7 +249,7 @@ class Analyzer(tableUtils: TableUtils,
     }
 
     val aggMetadata = if (groupByConf.hasDerivations || groupByConf.aggregations == null) {
-      schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
+      schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType, groupByConf.hasDerivations) }.toArray
     } else {
       groupBy.aggPartWithSchema.map { entry => toAggregationMetadata(entry._1, entry._2) }.toArray
     }

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -247,7 +247,11 @@ class Analyzer(tableUtils: TableUtils,
            |""".stripMargin)
     }
 
-    val aggMetadata = schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
+    val aggMetadata = if (groupByConf.hasDerivations) {
+      schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
+    } else {
+      groupBy.aggPartWithSchema.map { entry => toAggregationMetadata(entry._1, entry._2) }.toArray
+    }
 
     val keySchemaMap = groupBy.keySchema.map { field =>
       field.name -> SparkConversions.toChrononType(field.name, field.dataType)

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -247,11 +247,8 @@ class Analyzer(tableUtils: TableUtils,
            |""".stripMargin)
     }
 
-    val aggMetadata = if (groupByConf.aggregations != null) {
-      groupBy.aggPartWithSchema.map { entry => toAggregationMetadata(entry._1, entry._2) }.toArray
-    } else {
-      schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
-    }
+    val aggMetadata = schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
+
     val keySchemaMap = groupBy.keySchema.map { field =>
       field.name -> SparkConversions.toChrononType(field.name, field.dataType)
     }.toMap

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -247,7 +247,7 @@ class Analyzer(tableUtils: TableUtils,
            |""".stripMargin)
     }
 
-    val aggMetadata = if (groupByConf.hasDerivations || groupByConf.aggregation == null) {
+    val aggMetadata = if (groupByConf.hasDerivations || groupByConf.aggregations == null) {
       schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
     } else {
       groupBy.aggPartWithSchema.map { entry => toAggregationMetadata(entry._1, entry._2) }.toArray

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -247,7 +247,7 @@ class Analyzer(tableUtils: TableUtils,
            |""".stripMargin)
     }
 
-    val aggMetadata = if (groupByConf.isSetBackfillStartDate && groupByConf.hasDerivations) {
+    val aggMetadata = if (groupByConf.hasDerivations || groupByConf.aggregation == null) {
       schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
     } else {
       groupBy.aggPartWithSchema.map { entry => toAggregationMetadata(entry._1, entry._2) }.toArray

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -247,7 +247,7 @@ class Analyzer(tableUtils: TableUtils,
            |""".stripMargin)
     }
 
-    val aggMetadata = if (groupByConf.hasDerivations) {
+    val aggMetadata = if (groupByConf.isSetBackfillStartDate && groupByConf.hasDerivations) {
       schema.map { tup => toAggregationMetadata(tup.name, tup.fieldType) }.toArray
     } else {
       groupBy.aggPartWithSchema.map { entry => toAggregationMetadata(entry._1, entry._2) }.toArray

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -366,7 +366,7 @@ class GroupByTest {
     aggregationsMetadata
       .foreach(
         agg => {
-          assertTrue(expectedSchema.contains(s"${agg.name} => ${agg.columnType})"))
+          assertTrue(expectedSchema.contains(s"${agg.name} => ${agg.columnType}"))
           assertTrue(agg.operation == "Derivation")
         }
       )

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -361,6 +361,8 @@ class GroupByTest {
       tableUtils = tableUtils)
     val df = tableUtils.sql(s"SELECT * FROM  ${outputTable}")
     val expectedSchema = df.schema.fields.map(field => s"${field.name} => ${field.dataType}")
+
+    // When the groupBy has derivations, the aggMetadata will only contains the name and type, which will be the same with the schema in output table.
     aggregationsMetadata
       .map(agg => s"${agg.name} => ${agg.columnType}")
       .foreach(s => assertTrue(expectedSchema.contains(s)))

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -364,8 +364,12 @@ class GroupByTest {
 
     // When the groupBy has derivations, the aggMetadata will only contains the name and type, which will be the same with the schema in output table.
     aggregationsMetadata
-      .map(agg => s"${agg.name} => ${agg.columnType}")
-      .foreach(s => assertTrue(expectedSchema.contains(s)))
+      .foreach(
+        agg => {
+          assertTrue(expectedSchema.contains(s"${agg.name} => ${agg.columnType})"))
+          assertTrue(agg.operation == "Derivation")
+        }
+      )
   }
 
   // test that OrderByLimit and OrderByLimitTimed serialization works well with Spark's data type

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -19,7 +19,8 @@ package ai.chronon.spark.test
 import ai.chronon.aggregator.test.{CStream, Column, NaiveAggregator}
 import ai.chronon.aggregator.windowing.FiveMinuteResolution
 import ai.chronon.api.Extensions._
-import ai.chronon.api.{Aggregation, Builders, Constants, DoubleType, IntType, LongType, Operation, Source, StringType, TimeUnit, Window, Derivation}
+import ai.chronon.api.{Aggregation, Builders, Constants, DoubleType, IntType, LongType, Operation, Source, StringType, TimeUnit, Window}
+import ai.chronon.api.Builders.Derivation
 import ai.chronon.online.{RowWrapper, SparkConversions}
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark._
@@ -349,7 +350,8 @@ class GroupByTest {
     val (source, endPartition) = createTestSource(30)
     val tableUtils = TableUtils(spark)
     val namespace = "test_analyzer_testGroupByDerivation"
-    val groupByConf = getSampleGroupBy("unit_analyze_test_item_views", source, namespace, Seq.empty, derivations = Seq(Derivation(name = "*", expression = "*")))
+    val derivation = Builders.Derivation(name = "*", expression = "*")
+    val groupByConf = getSampleGroupBy("unit_analyze_test_item_views", source, namespace, Seq.empty, derivations = Seq(derivation))
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val (aggregationsMetadata, _) =
       new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -19,8 +19,7 @@ package ai.chronon.spark.test
 import ai.chronon.aggregator.test.{CStream, Column, NaiveAggregator}
 import ai.chronon.aggregator.windowing.FiveMinuteResolution
 import ai.chronon.api.Extensions._
-import ai.chronon.api.{Aggregation, Builders, Constants, DoubleType, IntType, LongType, Operation, Source, StringType, TimeUnit, Window}
-import ai.chronon.api.Builders.Derivation
+import ai.chronon.api.{Aggregation, Builders, Constants, Derivation, DoubleType, IntType, LongType, Operation, Source, StringType, TimeUnit, Window}
 import ai.chronon.online.{RowWrapper, SparkConversions}
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark._


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We want to export feature after derivation for groupBy metadata export. This PR updates the aggMetadata generation logic for groupBy like

1. Use output schema for groupBys with derivation and groupBys without aggregation.
2. Use aggregated column for groupBys without derivation and with aggregation defined.  

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @SophieYu41 @hzding621 
