### PR TITLE
Add a Chronon service module to add support for serving features

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val flink = (project in file("flink"))
   )
 
 lazy val service = (project in file("service"))
-  .dependsOn(online)
+  .dependsOn(online.%("compile->compile;test->test"))
   .settings(
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
     assembly / artifact := {

--- a/build.sbt
+++ b/build.sbt
@@ -409,6 +409,7 @@ lazy val service = (project in file("service"))
     },
     addArtifact(assembly / artifact, assembly),
     publishSettings,
+    crossScalaVersions := supportedVersions,
     libraryDependencies ++= Seq(
       "io.vertx" % "vertx-core" % "4.5.10",
       "io.vertx" % "vertx-web" % "4.5.10",

--- a/build.sbt
+++ b/build.sbt
@@ -402,6 +402,13 @@ lazy val flink = (project in file("flink"))
 lazy val service = (project in file("service"))
   .dependsOn(online)
   .settings(
+    assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
+    assembly / artifact := {
+      val art = (assembly / artifact).value
+      art.withClassifier(Some("assembly"))
+    },
+    addArtifact(assembly / artifact, assembly),
+    publishSettings,
     libraryDependencies ++= Seq(
       "io.vertx" % "vertx-core" % "4.5.10",
       "io.vertx" % "vertx-web" % "4.5.10",

--- a/build.sbt
+++ b/build.sbt
@@ -420,6 +420,8 @@ lazy val service = (project in file("service"))
       // use mockito 4.x as Chronon builds on Java8
       "org.mockito" % "mockito-core" % "4.11.0" % Test,
       "io.vertx" % "vertx-unit" % "4.5.10" % Test,
+      // add codegen dep to help with mockito errors
+      "io.vertx" % "vertx-codegen" % "4.5.10" % Test,
     ),
     // Assembly settings
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",

--- a/build.sbt
+++ b/build.sbt
@@ -406,8 +406,8 @@ lazy val service = (project in file("service"))
       "io.vertx" % "vertx-core" % "4.5.10",
       "io.vertx" % "vertx-web" % "4.5.10",
       "io.vertx" % "vertx-config" % "4.5.10",
-      "ch.qos.logback" % "logback-classic" % "1.5.6",
-      "org.slf4j" % "slf4j-api" % "2.0.12",
+      "ch.qos.logback" % "logback-classic" % "1.2.11",
+      "org.slf4j" % "slf4j-api" % "1.7.36",
       "com.typesafe" % "config" % "1.4.3",
       // force netty versions -> without this we conflict with the versions pulled in from
       // our online module's spark deps which causes the web-app to not serve up content

--- a/build.sbt
+++ b/build.sbt
@@ -414,8 +414,8 @@ lazy val service = (project in file("service"))
       "io.netty" % "netty-all" % "4.1.111.Final",
       "junit" % "junit" % "4.13.2" % Test,
       "com.novocode" % "junit-interface" % "0.11" % Test,
+      "org.mockito" % "mockito-core" % "5.12.0" % Test,
       "io.vertx" % "vertx-unit" % "4.5.10" % Test,
-      "org.mockito" % "mockito-core" % "3.4.0" % Test
     ),
     // Assembly settings
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",

--- a/build.sbt
+++ b/build.sbt
@@ -417,7 +417,8 @@ lazy val service = (project in file("service"))
       "io.micrometer" % "micrometer-registry-statsd" % "1.13.6",
       "junit" % "junit" % "4.13.2" % Test,
       "com.novocode" % "junit-interface" % "0.11" % Test,
-      "org.mockito" % "mockito-core" % "5.12.0" % Test,
+      // use mockito 4.x as Chronon builds on Java8
+      "org.mockito" % "mockito-core" % "4.11.0" % Test,
       "io.vertx" % "vertx-unit" % "4.5.10" % Test,
     ),
     // Assembly settings

--- a/build.sbt
+++ b/build.sbt
@@ -412,6 +412,10 @@ lazy val service = (project in file("service"))
       // force netty versions -> without this we conflict with the versions pulled in from
       // our online module's spark deps which causes the web-app to not serve up content
       "io.netty" % "netty-all" % "4.1.111.Final",
+      "junit" % "junit" % "4.13.2" % Test,
+      "com.novocode" % "junit-interface" % "0.11" % Test,
+      "io.vertx" % "vertx-unit" % "4.5.10" % Test,
+      "org.mockito" % "mockito-core" % "3.4.0" % Test
     ),
     // Assembly settings
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",

--- a/build.sbt
+++ b/build.sbt
@@ -412,6 +412,9 @@ lazy val service = (project in file("service"))
       // force netty versions -> without this we conflict with the versions pulled in from
       // our online module's spark deps which causes the web-app to not serve up content
       "io.netty" % "netty-all" % "4.1.111.Final",
+      // wire up metrics using micro meter and statsd
+      "io.vertx" % "vertx-micrometer-metrics" % "4.5.10",
+      "io.micrometer" % "micrometer-registry-statsd" % "1.13.6",
       "junit" % "junit" % "4.13.2" % Test,
       "com.novocode" % "junit-interface" % "0.11" % Test,
       "org.mockito" % "mockito-core" % "5.12.0" % Test,
@@ -421,9 +424,9 @@ lazy val service = (project in file("service"))
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
 
     // Main class configuration
-    // For now we use the built-in vertx launcher, we can extend this in the future
-    Compile / mainClass := Some("io.vertx.core.Launcher"),
-    assembly / mainClass := Some("io.vertx.core.Launcher"),
+    // We use a custom launcher to help us wire up our statsd metrics
+    Compile / mainClass := Some("ai.chronon.service.ChrononServiceLauncher"),
+    assembly / mainClass := Some("ai.chronon.service.ChrononServiceLauncher"),
 
     // Merge strategy for assembly
     assembly / assemblyMergeStrategy := {

--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val flink = (project in file("flink"))
   )
 
 lazy val service = (project in file("service"))
-  //.dependsOn(online.%("compile->compile;test->test"))
+  .dependsOn(online)
   .settings(
     libraryDependencies ++= Seq(
       "io.vertx" % "vertx-core" % "4.5.10",
@@ -408,7 +408,10 @@ lazy val service = (project in file("service"))
       "io.vertx" % "vertx-config" % "4.5.10",
       "ch.qos.logback" % "logback-classic" % "1.5.6",
       "org.slf4j" % "slf4j-api" % "2.0.12",
-      "com.typesafe" % "config" % "1.4.3"
+      "com.typesafe" % "config" % "1.4.3",
+      // force netty versions -> without this we conflict with the versions pulled in from
+      // our online module's spark deps which causes the web-app to not serve up content
+      "io.netty" % "netty-all" % "4.1.111.Final",
     ),
     // Assembly settings
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",

--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -125,6 +125,9 @@ object Metrics {
       )
     }
 
+    // Host can also be a Unix socket like: unix:///opt/datadog-agent/run/dogstatsd.sock
+    // In the unix socket case port is configured to be 0
+    val statsHost: String = System.getProperty("ai.chronon.metrics.host", "localhost")
     val statsPort: Int = System.getProperty("ai.chronon.metrics.port", "8125").toInt
     val tagCache: TTLCache[Context, String] = new TTLCache[Context, String](
       { ctx => ctx.toTags.reverse.mkString(",") },
@@ -132,7 +135,7 @@ object Metrics {
       ttlMillis = 5 * 24 * 60 * 60 * 1000 // 5 days
     )
 
-    val statsClient: NonBlockingStatsDClient = new NonBlockingStatsDClient("ai.zipline", "localhost", statsPort)
+    val statsClient: NonBlockingStatsDClient = new NonBlockingStatsDClient("ai.zipline", statsHost, statsPort)
   }
 
   case class Context(environment: Environment,

--- a/service/README.md
+++ b/service/README.md
@@ -1,4 +1,4 @@
-# Chronon Feature Service
+# Chronon Feature Fetching Service
 
 The feature service module consists of code to bring up a service that provides a thin shim around the Fetcher code. This 
 is meant to aid Chronon adopters who either need a quicker way to get a feature serving layer up and running or need to 

--- a/service/README.md
+++ b/service/README.md
@@ -74,3 +74,39 @@ StatsD Metric: ai.zipline.join.fetch.join_request.count 1|c|#null,null,null,null
 StatsD Metric: ai.zipline.join.fetch.group_by_request.count 1|c|#null,null,accuracy:SNAPSHOT,environment:join.fetch,owner:quickstart,team:quickstart,production:false,group_by:quickstart_purchases_v1,join:quickstart_training_set_v2
 ...
 ```
+
+## Features Lookup Response Structure
+
+The /v1/features/join and /v1/features/groupby endpoints are bulkGet endpoints (against a single GroupBy or Join). Users can request multiple lookups, for example:
+```bash
+$ curl -X POST   'http://localhost:9000/v1/features/join/quickstart%2Ftraining_set.v2'   -H 'Content-Type: application/json'   -d '[{"user_id": "5"}, {"user_id": "7"}]'
+```
+
+The response status is 4xx (in case of errors parsing the incoming json request payload), 5xx (internal error like the KV store being unreachable) or 200 (some / all successful lookups).
+In case of the 200 response, the payload looks like the example shown below:
+```json
+{
+  "results": [
+    {
+      "status": "Success",
+      "entityKeys": {
+        "user_id": "5"
+      },
+      "features": {
+        "A": 12,
+        "B": 24
+      }
+    },
+    {
+      "status": "Success",
+      "entityKeys": {
+        "user_id": "7"
+      },
+      "features": {
+        "A": 36,
+        "B": 48,
+      }
+    }
+  ]
+}
+```

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,76 @@
+# Chronon Feature Service
+
+The feature service module consists of code to bring up a service that provides a thin shim around the Fetcher code. This 
+is meant to aid Chronon adopters who either need a quicker way to get a feature serving layer up and running or need to 
+build a way to retrieve features and typically work in a non-JVM based organization. 
+
+## Core Technology
+
+The Chronon Feature Service is built on top of the [Vert.x](https://vertx.io/) JVM framework. Vert.x is a high-performance
+web framework which supports HTTP and gRPC based services. 
+
+## Running locally
+
+To build the service sub-module:
+```bash
+~/workspace/chronon $ sbt "project service" clean assembly
+```
+
+To test out the service, you also need to build a concrete instantiation of the [Api](https://github.com/airbnb/chronon/blob/main/online/src/main/scala/ai/chronon/online/Api.scala#L187).
+We can leverage the [quickstart Mongo API](https://github.com/airbnb/chronon/tree/main/quickstart/mongo-online-impl) for this:
+```bash
+~/workspace/chronon $ cd quickstart/mongo-online-impl
+~/workspace/chronon/quickstart/mongo-online-impl $ sbt assembly
+...
+[success] Total time: 1 s, completed Nov 6, 2024, 2:35:26 PM
+```
+This command will write out a file in the target/scala-2.12 sub-directory.
+
+We can now use this to start up the feature service:
+```bash
+~/workspace/chronon $ java -jar service/target/scala-2.12/service-vertx_service-*.jar run ai.chronon.service.WebServiceVerticle \
+-Dserver.port=9000 -conf service/src/main/resources/example_config.json
+...
+14:39:26.626 [vert.x-eventloop-thread-1] INFO  a.chronon.service.WebServiceVerticle - HTTP server started on port 9000
+14:39:26.627 [vert.x-eventloop-thread-0] INFO  i.v.c.i.l.c.VertxIsolatedDeployer - Succeeded in deploying verticle
+```
+
+A few things to call out so you can customize:
+- Choose your port (this is where you'll hit your webservice with traffic)
+- Update the example_config.json (specifically confirm the path to the mongo-online-impl assembly jar matches your setup)
+
+If you'd like some real data to query from the feature service, make sure to run through the relevant steps of the 
+[Quickstart - Online Flows](https://chronon.ai/getting_started/Tutorial.html#online-flows) tutorial. 
+
+Some examples to curl the webservice:
+```bash
+$ curl 'http://localhost:9000/ping'
+$ curl 'http://localhost:9000/config'
+$ curl -X POST   'http://localhost:9000/v1/features/join/quickstart%2Ftraining_set.v2'   -H 'Content-Type: application/json'   -d '[{"user_id": "5"}]'
+```
+
+## Metrics
+
+The Vert.x feature service relies on the same statsd host / port coordinates as the rest of the Chronon project - 
+[Metrics](https://github.com/airbnb/chronon/blob/main/online/src/main/scala/ai/chronon/online/Metrics.scala#L135). When configured correctly,
+the service will emit metrics captured by [Vert.x](https://vertx.io/docs/vertx-micrometer-metrics/java/#_http_client), JVM metrics as well as metrics
+captured by existing Chronon Fetcher code.
+
+To view these metrics for your locally running feature service:
+- Install the [statsd-logger](https://github.com/jimf/statsd-logger) npm module (`npm install -g statsd-logger`)
+- Run the command - `statsd-logger`
+
+Now you should see metrics of the format:
+```bash
+$ statsd-logger 
+Server listening on 0.0.0.0:8125
+StatsD Metric: jvm.buffer.memory.used 12605920|g|#statistic:value,id:direct
+StatsD Metric: jvm.threads.states 0|g|#statistic:value,state:blocked
+StatsD Metric: jvm.memory.used 8234008|g|#statistic:value,area:nonheap,id:Compressed Class Space
+StatsD Metric: jvm.threads.states 19|g|#statistic:value,state:runnable
+StatsD Metric: system.load.average.1m 1.504883|g|#statistic:value
+StatsD Metric: vertx.http.server.active.requests 0|g|#statistic:value,method:GET,path:/ping
+StatsD Metric: ai.zipline.join.fetch.join_request.count 1|c|#null,null,null,null,environment:join.fetch,owner:quickstart,team:quickstart,production:false,join:quickstart_training_set_v2
+StatsD Metric: ai.zipline.join.fetch.group_by_request.count 1|c|#null,null,accuracy:SNAPSHOT,environment:join.fetch,owner:quickstart,team:quickstart,production:false,group_by:quickstart_purchases_v1,join:quickstart_training_set_v2
+...
+```

--- a/service/src/main/java/ai/chronon/service/ApiProvider.java
+++ b/service/src/main/java/ai/chronon/service/ApiProvider.java
@@ -25,7 +25,7 @@ public class ApiProvider {
     public static Api buildApi(ConfigStore configStore) throws Exception {
         Optional<String> maybeJarPath = configStore.getOnlineJar();
         Optional<String> maybeClass = configStore.getOnlineClass();
-        if (maybeJarPath.isEmpty() || maybeClass.isEmpty()) {
+        if (!(maybeJarPath.isPresent() && maybeClass.isPresent())) {
             throw new IllegalArgumentException("Both 'online.jar' and 'online.class' configs must be set.");
         }
 

--- a/service/src/main/java/ai/chronon/service/ApiProvider.java
+++ b/service/src/main/java/ai/chronon/service/ApiProvider.java
@@ -1,0 +1,54 @@
+package ai.chronon.service;
+
+import ai.chronon.online.Api;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.util.ScalaVersionSpecificCollectionsConverter;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Map;
+import java.util.Optional;
+
+public class ApiProvider {
+    public final Api api;
+    private static final Logger logger = LoggerFactory.getLogger(ApiProvider.class);
+
+    public ApiProvider(ConfigStore configStore) throws Exception {
+        Optional<String> maybeJarPath = configStore.getOnlineJar();
+        Optional<String> maybeClass = configStore.getOnlineClass();
+        if (maybeJarPath.isEmpty() || maybeClass.isEmpty()) {
+            throw new IllegalArgumentException("Both 'online.jar' and 'online.class' configs must be set.");
+        }
+
+        String jarPath = maybeJarPath.get();
+        String className = maybeClass.get();
+        File jarFile = new File(jarPath);
+        if (!jarFile.exists()) {
+            throw new IllegalArgumentException("JAR file does not exist: " + jarPath);
+        }
+
+        logger.info("Loading API implementation from JAR: {}, class: {}", jarPath, className);
+
+        // Create class loader for the API JAR
+        URL jarUrl = jarFile.toURI().toURL();
+        URLClassLoader apiClassLoader = new URLClassLoader(
+                new URL[]{jarUrl},
+                this.getClass().getClassLoader()
+        );
+
+        // Load and instantiate the API implementation
+        Class<?> apiClass = Class.forName(className, true, apiClassLoader);
+        if (!Api.class.isAssignableFrom(apiClass)) {
+            throw new IllegalArgumentException(
+                    "Class " + className + " does not extend the Api abstract class"
+            );
+        }
+
+        Map<String, String> propsMap = configStore.getOnlineApiProps();
+        scala.collection.immutable.Map<String, String> scalaPropsMap = ScalaVersionSpecificCollectionsConverter.convertJavaMapToScala(propsMap);
+
+        this.api = (Api) apiClass.getConstructors()[0].newInstance(scalaPropsMap);
+    }
+}

--- a/service/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -1,4 +1,60 @@
 package ai.chronon.service;
 
-public class ChrononServiceLauncher {
+import ai.chronon.online.Metrics;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.statsd.StatsdConfig;
+import io.micrometer.statsd.StatsdMeterRegistry;
+import io.vertx.core.Launcher;
+import io.vertx.core.VertxOptions;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MicrometerMetricsFactory;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+
+import java.util.Map;
+
+/**
+ * Custom launcher to help configure the Chronon vertx feature service
+ * to handle things like setting up a statsd metrics registry.
+ * We use statsd here to be consistent with the rest of our project (e.g. fetcher code).
+ * This allows us to send Vertx webservice metrics along with fetcher related metrics to allow users
+ * to debug performance issues and set alerts etc.
+ */
+public class ChrononServiceLauncher extends Launcher {
+
+    @Override
+    public void beforeStartingVertx(VertxOptions options) {
+
+        StatsdConfig config = new StatsdConfig() {
+            private final String statsdHost = Metrics.Context$.MODULE$.statsHost();
+            private final String statsdPort = String.valueOf(Metrics.Context$.MODULE$.statsPort());
+
+            final Map<String, String> statsProps = Map.of(
+                    prefix() + "." + "port", statsdPort,
+                    prefix() + "." + "host", statsdHost,
+                    prefix() + "." + "protocol", Integer.parseInt(statsdPort) == 0 ? "UDS_DATAGRAM" : "UDP"
+                    );
+
+            @Override
+            public String get(String key) {
+                return statsProps.get(key);
+            }
+        };
+
+        MeterRegistry registry = new StatsdMeterRegistry(config, Clock.SYSTEM);
+        MicrometerMetricsFactory metricsFactory = new MicrometerMetricsFactory(registry);
+
+        // Configure metrics via statsd
+        MicrometerMetricsOptions metricsOptions = new MicrometerMetricsOptions()
+                .setEnabled(true)
+                .setJvmMetricsEnabled(true)
+                .setFactory(metricsFactory)
+                .addLabels(Label.HTTP_METHOD, Label.HTTP_CODE, Label.HTTP_PATH);
+
+        options.setMetricsOptions(metricsOptions);
+    }
+
+    public static void main(String[] args) {
+        new ChrononServiceLauncher().dispatch(args);
+    }
 }

--- a/service/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -1,0 +1,4 @@
+package ai.chronon.service;
+
+public class ChrononServiceLauncher {
+}

--- a/service/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
+++ b/service/src/main/java/ai/chronon/service/ChrononServiceLauncher.java
@@ -11,6 +11,7 @@ import io.vertx.micrometer.Label;
 import io.vertx.micrometer.MicrometerMetricsFactory;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -29,11 +30,11 @@ public class ChrononServiceLauncher extends Launcher {
             private final String statsdHost = Metrics.Context$.MODULE$.statsHost();
             private final String statsdPort = String.valueOf(Metrics.Context$.MODULE$.statsPort());
 
-            final Map<String, String> statsProps = Map.of(
-                    prefix() + "." + "port", statsdPort,
-                    prefix() + "." + "host", statsdHost,
-                    prefix() + "." + "protocol", Integer.parseInt(statsdPort) == 0 ? "UDS_DATAGRAM" : "UDP"
-                    );
+            final Map<String, String> statsProps = new HashMap<String, String>() {{
+                put(prefix() + "." + "port", statsdPort);
+                put(prefix() + "." + "host", statsdHost);
+                put(prefix() + "." + "protocol", Integer.parseInt(statsdPort) == 0 ? "UDS_DATAGRAM" : "UDP");
+            }};
 
             @Override
             public String get(String key) {

--- a/service/src/main/java/ai/chronon/service/ConfigStore.java
+++ b/service/src/main/java/ai/chronon/service/ConfigStore.java
@@ -4,6 +4,10 @@ import io.vertx.config.ConfigRetriever;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * Helps keep track of the various Chronon fetcher service configs.
  * We currently read configs once at startup - this makes sense for configs
@@ -13,7 +17,11 @@ import io.vertx.core.json.JsonObject;
 public class ConfigStore {
 
     private static final int DEFAULT_PORT = 8080;
+
     private static final String SERVER_PORT = "server.port";
+    private static final String ONLINE_JAR = "online.jar";
+    private static final String ONLINE_CLASS = "online.class";
+    private static final String ONLINE_API_PROPS = "online.api.props";
 
     private JsonObject jsonConfig;
 
@@ -29,6 +37,26 @@ public class ConfigStore {
 
     public int getServerPort() {
         return jsonConfig.getInteger(SERVER_PORT, DEFAULT_PORT);
+    }
+
+    public Optional<String> getOnlineJar() {
+        return Optional.ofNullable(jsonConfig.getString(ONLINE_JAR));
+    }
+
+    public Optional<String> getOnlineClass() {
+        return Optional.ofNullable(jsonConfig.getString(ONLINE_CLASS));
+    }
+
+    public Map<String, String> getOnlineApiProps() {
+        JsonObject apiProps = jsonConfig.getJsonObject(ONLINE_API_PROPS);
+        if (apiProps == null) {
+            return Map.of();
+        }
+
+        return apiProps.stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> String.valueOf(e.getValue())
+        ));
     }
 
     public String encodeConfig() {

--- a/service/src/main/java/ai/chronon/service/ConfigStore.java
+++ b/service/src/main/java/ai/chronon/service/ConfigStore.java
@@ -1,0 +1,37 @@
+package ai.chronon.service;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Helps keep track of the various Chronon fetcher service configs.
+ * We currently read configs once at startup - this makes sense for configs
+ * such as the server port and we can revisit / extend things in the future to
+ * be able to hot-refresh configs like Vertx supports under the hood.
+ */
+public class ConfigStore {
+
+    private static final int DEFAULT_PORT = 8080;
+    private static final String SERVER_PORT = "server.port";
+
+    private JsonObject jsonConfig;
+
+    public ConfigStore(Vertx vertx) {
+        ConfigRetriever configRetriever = ConfigRetriever.create(vertx);
+        configRetriever.getConfig().onComplete(ar -> {
+            if (ar.failed()) {
+                throw new IllegalStateException("Unable to load service config", ar.cause());
+            }
+            jsonConfig = ar.result();
+        });
+    }
+
+    public int getServerPort() {
+        return jsonConfig.getInteger(SERVER_PORT, DEFAULT_PORT);
+    }
+
+    public String encodeConfig() {
+        return jsonConfig.encodePrettily();
+    }
+}

--- a/service/src/main/java/ai/chronon/service/ConfigStore.java
+++ b/service/src/main/java/ai/chronon/service/ConfigStore.java
@@ -4,6 +4,7 @@ import io.vertx.config.ConfigRetriever;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,7 +51,7 @@ public class ConfigStore {
     public Map<String, String> getOnlineApiProps() {
         JsonObject apiProps = jsonConfig.getJsonObject(ONLINE_API_PROPS);
         if (apiProps == null) {
-            return Map.of();
+            return new HashMap<String, String>();
         }
 
         return apiProps.stream().collect(Collectors.toMap(

--- a/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
+++ b/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
@@ -11,11 +11,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Entry point for the Chronon webservice. We choose to use just 1 verticle for now as it allows us to
- * keep things simple and we don't need to scale / independently deploy different endpoint routes.
- * To run:
- * $ sbt "project service" clean assembly
- * $ java -jar service/target/scala-2.12/service-vertx_service-0.0.86-SNAPSHOT.jar run ai.chronon.service.WebServiceVerticle -Dserver.port=9000 -Donline.jar=/Users/piyush/workspace/airbnb-chronon/quickstart/mongo-online-impl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar -Donline.class=ai.chronon.quickstart.online.ChrononMongoOnlineImpl
+ * Entry point for the Chronon webservice. We wire up our API routes and configure and launch our HTTP service here.
+ * We choose to use just 1 verticle for now as it allows us to keep things simple and we don't need to scale /
+ * independently deploy different endpoint routes.
  */
 public class WebServiceVerticle extends AbstractVerticle {
     private static final Logger logger = LoggerFactory.getLogger(WebServiceVerticle.class);

--- a/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
+++ b/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
@@ -25,8 +25,7 @@ public class WebServiceVerticle extends AbstractVerticle {
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
         ConfigStore cfgStore = new ConfigStore(vertx);
-        ApiProvider apiProvider = new ApiProvider(cfgStore);
-        startHttpServer(cfgStore.getServerPort(), cfgStore.encodeConfig(), apiProvider.api, startPromise);
+        startHttpServer(cfgStore.getServerPort(), cfgStore.encodeConfig(), ApiProvider.buildApi(cfgStore), startPromise);
     }
 
     protected void startHttpServer(int port, String configJsonString, Api api, Promise<Void> startPromise) throws Exception {

--- a/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
+++ b/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
@@ -1,12 +1,8 @@
 package ai.chronon.service;
 
-import io.vertx.config.ConfigRetriever;
-import io.vertx.config.ConfigRetrieverOptions;
-import io.vertx.config.ConfigStoreOptions;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +22,7 @@ public class WebServiceVerticle extends AbstractVerticle {
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
         ConfigStore cfgStore = new ConfigStore(vertx);
+        ApiProvider apiProvider = new ApiProvider(cfgStore);
         startHttpServer(cfgStore.getServerPort(), cfgStore.encodeConfig(), startPromise);
     }
 
@@ -43,8 +40,6 @@ public class WebServiceVerticle extends AbstractVerticle {
                .putHeader("content-type", "application/json")
                .end(configJsonString);
         });
-
-        //Api myApi = loadApiImplementation();
 
         // Start HTTP server
         server = vertx.createHttpServer();
@@ -77,46 +72,4 @@ public class WebServiceVerticle extends AbstractVerticle {
             stopPromise.complete();
         }
     }
-
-//    private Api loadApiImplementation() throws Exception {
-//        String jarPath = System.getProperty("online.jar");
-//        String className = System.getProperty("online.class");
-//
-//        if (jarPath == null || className == null) {
-//            throw new IllegalArgumentException(
-//                    "Both 'online.jar' and 'online.class' system properties must be set. " +
-//                            "Current values - jar: " + jarPath + ", class: " + className
-//            );
-//        }
-//
-//        File jarFile = new File(jarPath);
-//        if (!jarFile.exists()) {
-//            throw new IllegalArgumentException("JAR file does not exist: " + jarPath);
-//        }
-//
-//        logger.info("Loading API implementation from JAR: {}, class: {}", jarPath, className);
-//
-//        // Create class loader for the API JAR
-//        URL jarUrl = jarFile.toURI().toURL();
-//        URLClassLoader apiClassLoader = new URLClassLoader(
-//                new URL[]{jarUrl},
-//                this.getClass().getClassLoader()
-//        );
-//
-//        // Load and instantiate the API implementation
-//        Class<?> apiClass = Class.forName(className, true, apiClassLoader);
-//        if (!Api.class.isAssignableFrom(apiClass)) {
-//            throw new IllegalArgumentException(
-//                    "Class " + className + " does not extend the Api abstract class"
-//            );
-//        }
-//
-//        Map<String, String> myMap = Map.of();
-//        scala.collection.immutable.Map<String, String> scalaPropsMap = ScalaVersionSpecificCollectionsConverter.convertJavaMapToScala(myMap);
-//
-//        Api apiInstance = (Api) apiClass.getConstructors()[0].newInstance(scalaPropsMap);
-//        logger.info("Successfully loaded API implementation: {}", className);
-//        return apiInstance;
-//    }
 }
-

--- a/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
+++ b/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
@@ -5,6 +5,7 @@ import ai.chronon.service.handlers.FeaturesRouter;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,11 @@ public class WebServiceVerticle extends AbstractVerticle {
         });
 
         // Start HTTP server
-        server = vertx.createHttpServer();
+        HttpServerOptions httpOptions =
+                new HttpServerOptions()
+                        .setTcpKeepAlive(true)
+                        .setIdleTimeout(60);
+        server = vertx.createHttpServer(httpOptions);
         server.requestHandler(router)
                 .listen(port)
                 .onSuccess(server -> {

--- a/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
+++ b/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
@@ -1,0 +1,122 @@
+package ai.chronon.service;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Entry point for the Chronon webservice. We choose to use just 1 verticle for now as it allows us to
+ * keep things simple and we don't need to scale / independently deploy different endpoint routes.
+ * To run:
+ * $ sbt "project service" clean assembly
+ * $ java -jar service/target/scala-2.12/service-vertx_service-0.0.86-SNAPSHOT.jar run ai.chronon.service.WebServiceVerticle -Dserver.port=9000 -Donline.jar=/Users/piyush/workspace/airbnb-chronon/quickstart/mongo-online-impl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar -Donline.class=ai.chronon.quickstart.online.ChrononMongoOnlineImpl
+ */
+public class WebServiceVerticle extends AbstractVerticle {
+    private static final Logger logger = LoggerFactory.getLogger(WebServiceVerticle.class);
+
+    private HttpServer server;
+
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+        ConfigStore cfgStore = new ConfigStore(vertx);
+        startHttpServer(cfgStore.getServerPort(), cfgStore.encodeConfig(), startPromise);
+    }
+
+    protected void startHttpServer(int port, String configJsonString, Promise<Void> startPromise) throws Exception {
+        Router router = Router.router(vertx);
+
+        // Define routes
+        router.get("/ping").handler(ctx -> {
+            ctx.json("Pong!");
+        });
+
+        // Add route to show current configuration
+        router.get("/config").handler(ctx -> {
+            ctx.response()
+               .putHeader("content-type", "application/json")
+               .end(configJsonString);
+        });
+
+        //Api myApi = loadApiImplementation();
+
+        // Start HTTP server
+        server = vertx.createHttpServer();
+        server.requestHandler(router)
+                .listen(port)
+                .onSuccess(server -> {
+                    logger.info("HTTP server started on port {}", server.actualPort());
+                    startPromise.complete();
+                })
+                .onFailure(err -> {
+                    logger.error("Failed to start HTTP server", err);
+                    startPromise.fail(err);
+                });
+    }
+
+    @Override
+    public void stop(Promise<Void> stopPromise) {
+        logger.info("Stopping HTTP server...");
+        if (server != null) {
+            server.close()
+                    .onSuccess(v -> {
+                        logger.info("HTTP server stopped successfully");
+                        stopPromise.complete();
+                    })
+                    .onFailure(err -> {
+                        logger.error("Failed to stop HTTP server", err);
+                        stopPromise.fail(err);
+                    });
+        } else {
+            stopPromise.complete();
+        }
+    }
+
+//    private Api loadApiImplementation() throws Exception {
+//        String jarPath = System.getProperty("online.jar");
+//        String className = System.getProperty("online.class");
+//
+//        if (jarPath == null || className == null) {
+//            throw new IllegalArgumentException(
+//                    "Both 'online.jar' and 'online.class' system properties must be set. " +
+//                            "Current values - jar: " + jarPath + ", class: " + className
+//            );
+//        }
+//
+//        File jarFile = new File(jarPath);
+//        if (!jarFile.exists()) {
+//            throw new IllegalArgumentException("JAR file does not exist: " + jarPath);
+//        }
+//
+//        logger.info("Loading API implementation from JAR: {}, class: {}", jarPath, className);
+//
+//        // Create class loader for the API JAR
+//        URL jarUrl = jarFile.toURI().toURL();
+//        URLClassLoader apiClassLoader = new URLClassLoader(
+//                new URL[]{jarUrl},
+//                this.getClass().getClassLoader()
+//        );
+//
+//        // Load and instantiate the API implementation
+//        Class<?> apiClass = Class.forName(className, true, apiClassLoader);
+//        if (!Api.class.isAssignableFrom(apiClass)) {
+//            throw new IllegalArgumentException(
+//                    "Class " + className + " does not extend the Api abstract class"
+//            );
+//        }
+//
+//        Map<String, String> myMap = Map.of();
+//        scala.collection.immutable.Map<String, String> scalaPropsMap = ScalaVersionSpecificCollectionsConverter.convertJavaMapToScala(myMap);
+//
+//        Api apiInstance = (Api) apiClass.getConstructors()[0].newInstance(scalaPropsMap);
+//        logger.info("Successfully loaded API implementation: {}", className);
+//        return apiInstance;
+//    }
+}
+

--- a/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
+++ b/service/src/main/java/ai/chronon/service/WebServiceVerticle.java
@@ -1,7 +1,7 @@
 package ai.chronon.service;
 
 import ai.chronon.online.Api;
-import ai.chronon.service.handlers.FeaturesHandler;
+import ai.chronon.service.handlers.FeaturesRouter;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
@@ -34,7 +34,7 @@ public class WebServiceVerticle extends AbstractVerticle {
         // Define routes
 
         // Set up sub-routes for the various feature retrieval apis
-        router.route("/v1/features/*").subRouter(FeaturesHandler.createFeaturesRoutes(vertx, api));
+        router.route("/v1/features/*").subRouter(FeaturesRouter.createFeaturesRoutes(vertx, api));
 
         // Health check route
         router.get("/ping").handler(ctx -> {

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
@@ -68,7 +68,7 @@ public class FeaturesHandler implements Handler<RoutingContext> {
     @Override
     public void handle(RoutingContext ctx) {
         String entityName = ctx.pathParam("name");
-        logger.info("Retrieving {} - {}", entityType.name(), entityName);
+        logger.debug("Retrieving {} - {}", entityType.name(), entityName);
         JTry<List<JavaRequest>> maybeRequest = parseJavaRequest(entityName, ctx.body());
         if (! maybeRequest.isSuccess()) {
             logger.error("Unable to parse request body", maybeRequest.getException());

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
@@ -15,6 +15,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -60,7 +61,7 @@ public class FeaturesHandler implements Handler<RoutingContext> {
         JTry<List<JavaRequest>> maybeRequest = parseJavaRequest(entityName, ctx.body());
         if (! maybeRequest.isSuccess()) {
             logger.error("Unable to parse request body", maybeRequest.getException());
-            List<String> errorMessages = List.of(maybeRequest.getException().getMessage());
+            List<String> errorMessages = Collections.singletonList(maybeRequest.getException().getMessage());
             ctx.response()
                     .setStatusCode(400)
                     .putHeader("content-type", "application/json")
@@ -98,7 +99,7 @@ public class FeaturesHandler implements Handler<RoutingContext> {
         });
 
         maybeFeatureResponses.onFailure(err -> {
-            List<String> failureMessages = List.of(err.getMessage());
+            List<String> failureMessages = Collections.singletonList(err.getMessage());
             ctx.response()
                     .setStatusCode(500)
                     .putHeader("content-type", "application/json")
@@ -111,7 +112,7 @@ public class FeaturesHandler implements Handler<RoutingContext> {
     }
 
     public static JTry<List<JavaRequest>> parseJavaRequest(String name, RequestBody body) {
-        TypeReference<List<Map<String, Object>>> ref = new TypeReference<>() { };
+        TypeReference<List<Map<String, Object>>> ref = new TypeReference<List<Map<String, Object>>>() { };
         try {
             List<Map<String, Object>> entityKeysList = objectMapper.readValue(body.asString(), ref);
             List<JavaRequest> requests = entityKeysList.stream().map(m -> new JavaRequest(name, m)).collect(Collectors.toList());

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
@@ -1,101 +1,109 @@
 package ai.chronon.service.handlers;
 
-import ai.chronon.online.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import ai.chronon.online.JTry;
+import ai.chronon.online.JavaFetcher;
+import ai.chronon.online.JavaRequest;
+import ai.chronon.online.JavaResponse;
+import ai.chronon.service.model.GetFeaturesResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
+import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RequestBody;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Map;
+
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static ai.chronon.online.JTry.failure;
+import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Failure;
+import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Success;
 
-public class FeaturesHandler {
+public class FeaturesHandler implements Handler<RoutingContext> {
+
+    public enum EntityType {
+        GroupBy,
+        Join
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(FeaturesHandler.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static Router createFeaturesRoutes(Vertx vertx, Api api) {
-        Router router = Router.router(vertx);
-        router.route().handler(BodyHandler.create());
-        JavaFetcher fetcher = api.buildJavaFetcher("feature-service", false);
+    private final EntityType entityType;
+    private final JavaFetcher fetcher;
 
-        router.post("/groupby/:groupByName").handler(ctx -> {
-            String groupByName = ctx.pathParam("groupByName");
-            logger.info("Retrieving groupBy - {}", groupByName);
-            JTry<JavaRequest> maybeRequest = parseJavaRequest(groupByName, ctx.body());
-            if (! maybeRequest.isSuccess()) {
-                logger.error("Unable to parse request body", maybeRequest.getException());
-                ctx.fail(400, maybeRequest.getException());
-            } else {
-                List<JavaRequest> requests = List.of(maybeRequest.getValue());
-                CompletableFuture<List<JavaResponse>> resultsJavaFuture = fetcher.fetchGroupBys(requests);
-                Future<List<JTry<String>>> map = Future.fromCompletionStage(resultsJavaFuture)
-                        .map(result -> result.stream().map(FeaturesHandler::responseToJson).collect(Collectors.toList()));
-                map.onSuccess(result -> {
-                    // collect any failures
-                   List<String> failureMessages = result.stream().filter(jt -> !jt.isSuccess()).map(jt -> jt.getException().getMessage()).collect(Collectors.toList());
-                   // fail the request if there are any failures
-                   if (! failureMessages.isEmpty()) {
-                       ctx.response()
-                               .setStatusCode(500)
-                               .putHeader("content-type", "application/json")
-                               .end(new JsonObject().put("errors", failureMessages).encode());
-                   } else {
-                       List<String> featureResults = result.stream().map(JTry::getValue).collect(Collectors.toList());
-                       ctx.response()
-                               .setStatusCode(200)
-                               .putHeader("content-type", "application/json")
-                               .end(new JsonObject().put("features", featureResults).encode());
-                   }
-                });
-                map.onFailure(err -> {
-                    List<String> failureMessages = List.of(err.getMessage());
-                    ctx.response()
-                            .setStatusCode(500)
-                            .putHeader("content-type", "application/json")
-                            .end(new JsonObject().put("errors", failureMessages).encode());
-                });
-            }
-        });
+    public FeaturesHandler(EntityType entityType, JavaFetcher fetcher) {
+        this.entityType = entityType;
+        this.fetcher = fetcher;
+    }
 
-        router.post("/join/:joinName").handler(ctx -> {
-            String joinName = ctx.pathParam("joinName");
-            logger.info("Retrieving join - {}", joinName);
+    @Override
+    public void handle(RoutingContext ctx) {
+        String entityName = ctx.pathParam("name");
+        logger.info("Retrieving {} - {}", entityType.name(), entityName);
+        JTry<List<JavaRequest>> maybeRequest = parseJavaRequest(entityName, ctx.body());
+        if (! maybeRequest.isSuccess()) {
+            logger.error("Unable to parse request body", maybeRequest.getException());
+            List<String> errorMessages = List.of(maybeRequest.getException().getMessage());
             ctx.response()
+                    .setStatusCode(400)
                     .putHeader("content-type", "application/json")
-                    .end("{\"status\": \"created\"}");
+                    .end(new JsonObject().put("errors", errorMessages).encode());
+            return;
+        }
+
+        List<JavaRequest> requests = maybeRequest.getValue();
+        CompletableFuture<List<JavaResponse>> resultsJavaFuture =
+                entityType.equals(EntityType.GroupBy) ? fetcher.fetchGroupBys(requests) : fetcher.fetchJoin(requests);
+        Future<List<JTry<Map<String, Object>>>> maybeFeatureResponses =
+                Future.fromCompletionStage(resultsJavaFuture)
+                      .map(result -> result.stream().map(FeaturesHandler::responseToMap)
+                      .collect(Collectors.toList()));
+
+        maybeFeatureResponses.onSuccess(resultList -> {
+            // as this is a bulkGet request, we might have some successful and some failed responses
+            // we return the responses in the same order as they come in and mark them as successful / failed based
+            // on the lookups
+            GetFeaturesResponse.Builder responseBuilder = GetFeaturesResponse.builder();
+            List<GetFeaturesResponse.Result> results = resultList.stream().map(tryObj -> {
+                if (tryObj.isSuccess()) {
+                    return GetFeaturesResponse.Result.builder().status(Success).features(tryObj.getValue()).build();
+                } else {
+                    return GetFeaturesResponse.Result.builder().status(Failure).error(tryObj.getException().getMessage()).build();
+                }
+            }).collect(Collectors.toList());
+            responseBuilder.results(results);
+
+            ctx.response()
+                        .setStatusCode(200)
+                        .putHeader("content-type", "application/json")
+                        .end(JsonObject.mapFrom(responseBuilder.build()).encode());
         });
 
-        return router;
+        maybeFeatureResponses.onFailure(err -> {
+            List<String> failureMessages = List.of(err.getMessage());
+            ctx.response()
+                    .setStatusCode(500)
+                    .putHeader("content-type", "application/json")
+                    .end(new JsonObject().put("errors", failureMessages).encode());
+        });
     }
 
-    public static JTry<String> responseToJson(JavaResponse response) {
-        if(response.values.isSuccess()) {
-            Map<String, Object> featureMap = response.values.getValue();
-            try {
-                return JTry.success(objectMapper.writeValueAsString(featureMap));
-            } catch (JsonProcessingException e) {
-                return JTry.failure(e);
-            }
-        } else {
-            return JTry.failure(response.values.getException());
-        }
+    public static JTry<Map<String, Object>> responseToMap(JavaResponse response) {
+        return response.values;
     }
 
-    public static JTry<JavaRequest> parseJavaRequest(String name, RequestBody body) {
-        TypeReference<Map<String, Object>> ref = new TypeReference<>() { };
+    public static JTry<List<JavaRequest>> parseJavaRequest(String name, RequestBody body) {
+        TypeReference<List<Map<String, Object>>> ref = new TypeReference<>() { };
         try {
-            Map<String, Object> entityKeysMap = objectMapper.readValue(body.asString(), ref);
-            return JTry.success(new JavaRequest(name, entityKeysMap));
+            List<Map<String, Object>> entityKeysList = objectMapper.readValue(body.asString(), ref);
+            List<JavaRequest> requests = entityKeysList.stream().map(m -> new JavaRequest(name, m)).collect(Collectors.toList());
+            return JTry.success(requests);
         } catch (Exception e) {
             return failure(e);
         }

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
@@ -1,0 +1,103 @@
+package ai.chronon.service.handlers;
+
+import ai.chronon.online.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Map;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static ai.chronon.online.JTry.failure;
+
+public class FeaturesHandler {
+    private static final Logger logger = LoggerFactory.getLogger(FeaturesHandler.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static Router createFeaturesRoutes(Vertx vertx, Api api) {
+        Router router = Router.router(vertx);
+        router.route().handler(BodyHandler.create());
+        JavaFetcher fetcher = api.buildJavaFetcher("feature-service", false);
+
+        router.post("/groupby/:groupByName").handler(ctx -> {
+            String groupByName = ctx.pathParam("groupByName");
+            logger.info("Retrieving groupBy - {}", groupByName);
+            JTry<JavaRequest> maybeRequest = parseJavaRequest(groupByName, ctx.body());
+            if (! maybeRequest.isSuccess()) {
+                logger.error("Unable to parse request body", maybeRequest.getException());
+                ctx.fail(400, maybeRequest.getException());
+            } else {
+                List<JavaRequest> requests = List.of(maybeRequest.getValue());
+                CompletableFuture<List<JavaResponse>> resultsJavaFuture = fetcher.fetchGroupBys(requests);
+                Future<List<JTry<String>>> map = Future.fromCompletionStage(resultsJavaFuture)
+                        .map(result -> result.stream().map(FeaturesHandler::responseToJson).collect(Collectors.toList()));
+                map.onSuccess(result -> {
+                    // collect any failures
+                   List<String> failureMessages = result.stream().filter(jt -> !jt.isSuccess()).map(jt -> jt.getException().getMessage()).collect(Collectors.toList());
+                   // fail the request if there are any failures
+                   if (! failureMessages.isEmpty()) {
+                       ctx.response()
+                               .setStatusCode(500)
+                               .putHeader("content-type", "application/json")
+                               .end(new JsonObject().put("errors", failureMessages).encode());
+                   } else {
+                       List<String> featureResults = result.stream().map(JTry::getValue).collect(Collectors.toList());
+                       ctx.response()
+                               .setStatusCode(200)
+                               .putHeader("content-type", "application/json")
+                               .end(new JsonObject().put("features", featureResults).encode());
+                   }
+                });
+                map.onFailure(err -> {
+                    List<String> failureMessages = List.of(err.getMessage());
+                    ctx.response()
+                            .setStatusCode(500)
+                            .putHeader("content-type", "application/json")
+                            .end(new JsonObject().put("errors", failureMessages).encode());
+                });
+            }
+        });
+
+        router.post("/join/:joinName").handler(ctx -> {
+            String joinName = ctx.pathParam("joinName");
+            logger.info("Retrieving join - {}", joinName);
+            ctx.response()
+                    .putHeader("content-type", "application/json")
+                    .end("{\"status\": \"created\"}");
+        });
+
+        return router;
+    }
+
+    public static JTry<String> responseToJson(JavaResponse response) {
+        if(response.values.isSuccess()) {
+            Map<String, Object> featureMap = response.values.getValue();
+            try {
+                return JTry.success(objectMapper.writeValueAsString(featureMap));
+            } catch (JsonProcessingException e) {
+                return JTry.failure(e);
+            }
+        } else {
+            return JTry.failure(response.values.getException());
+        }
+    }
+
+    public static JTry<JavaRequest> parseJavaRequest(String name, RequestBody body) {
+        TypeReference<Map<String, Object>> ref = new TypeReference<>() { };
+        try {
+            Map<String, Object> entityKeysMap = objectMapper.readValue(body.asString(), ref);
+            return JTry.success(new JavaRequest(name, entityKeysMap));
+        } catch (Exception e) {
+            return failure(e);
+        }
+    }
+}

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesHandler.java
@@ -20,10 +20,21 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static ai.chronon.online.JTry.failure;
 import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Failure;
 import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Success;
 
+/**
+ * Concrete implementation of the GetFeatures endpoints. Supports loading groupBys and joins.
+ * Some notes on this:
+ * We currently support bulkGet lookups against a single groupBy / join. Attempts to lookup n different GroupBys / Joins
+ * need to be split up into n different requests.
+ * A given bulkGet request might result in some successful lookups and some failed ones. We return a 4xx or 5xx response
+ * if the overall request fails (e.g. we're not able to parse the input json, Future failure due to Api returning an error)
+ * Individual failure responses will be marked as 'Failed' however the overall response status code will be successful (200)
+ * The response list maintains the same order as the incoming request list.
+ * As an example:
+ * { results: [ {"status": "Success", "features": ...}, {"status": "Failure", "error": ...} ] }
+ */
 public class FeaturesHandler implements Handler<RoutingContext> {
 
     public enum EntityType {
@@ -60,6 +71,7 @@ public class FeaturesHandler implements Handler<RoutingContext> {
         List<JavaRequest> requests = maybeRequest.getValue();
         CompletableFuture<List<JavaResponse>> resultsJavaFuture =
                 entityType.equals(EntityType.GroupBy) ? fetcher.fetchGroupBys(requests) : fetcher.fetchJoin(requests);
+        // wrap the Java future we get in a Vert.x Future to not block the worker thread
         Future<List<JTry<Map<String, Object>>>> maybeFeatureResponses =
                 Future.fromCompletionStage(resultsJavaFuture)
                       .map(result -> result.stream().map(FeaturesHandler::responseToMap)
@@ -105,7 +117,7 @@ public class FeaturesHandler implements Handler<RoutingContext> {
             List<JavaRequest> requests = entityKeysList.stream().map(m -> new JavaRequest(name, m)).collect(Collectors.toList());
             return JTry.success(requests);
         } catch (Exception e) {
-            return failure(e);
+            return JTry.failure(e);
         }
     }
 }

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesRouter.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesRouter.java
@@ -7,6 +7,8 @@ import io.vertx.ext.web.handler.BodyHandler;
 import static ai.chronon.service.handlers.FeaturesHandler.EntityType.GroupBy;
 import static ai.chronon.service.handlers.FeaturesHandler.EntityType.Join;
 
+// Configures the routes for our get features endpoints
+// We support bulkGets of groupBys and bulkGets of joins
 public class FeaturesRouter {
 
     public static Router createFeaturesRoutes(Vertx vertx, Api api) {

--- a/service/src/main/java/ai/chronon/service/handlers/FeaturesRouter.java
+++ b/service/src/main/java/ai/chronon/service/handlers/FeaturesRouter.java
@@ -1,0 +1,22 @@
+package ai.chronon.service.handlers;
+
+import ai.chronon.online.*;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+import static ai.chronon.service.handlers.FeaturesHandler.EntityType.GroupBy;
+import static ai.chronon.service.handlers.FeaturesHandler.EntityType.Join;
+
+public class FeaturesRouter {
+
+    public static Router createFeaturesRoutes(Vertx vertx, Api api) {
+        Router router = Router.router(vertx);
+        router.route().handler(BodyHandler.create());
+        JavaFetcher fetcher = api.buildJavaFetcher("feature-service", false);
+
+        router.post("/groupby/:name").handler(new FeaturesHandler(GroupBy, fetcher));
+        router.post("/join/:name").handler(new FeaturesHandler(Join, fetcher));
+
+        return router;
+    }
+}

--- a/service/src/main/java/ai/chronon/service/model/GetFeaturesResponse.java
+++ b/service/src/main/java/ai/chronon/service/model/GetFeaturesResponse.java
@@ -52,11 +52,13 @@ public class GetFeaturesResponse {
         }
 
         private final Status status;
+        private final Map<String, Object> entityKeys;
         private final Map<String, Object> features;
         private final String error;
 
         private Result(Builder builder) {
             this.status = builder.status;
+            this.entityKeys = builder.entityKeys;
             this.features = builder.features;
             this.error = builder.error;
         }
@@ -69,6 +71,10 @@ public class GetFeaturesResponse {
             return features;
         }
 
+        public Map<String, Object> getEntityKeys() {
+            return entityKeys;
+        }
+
         public String getError() {
             return error;
         }
@@ -79,6 +85,7 @@ public class GetFeaturesResponse {
 
         public static class Builder {
             private Status status;
+            private Map<String, Object> entityKeys;
             private Map<String, Object> features;
             private String error;
 
@@ -89,6 +96,11 @@ public class GetFeaturesResponse {
 
             public Builder features(Map<String, Object> features) {
                 this.features = features;
+                return this;
+            }
+
+            public Builder entityKeys(Map<String, Object> entityKeys) {
+                this.entityKeys = entityKeys;
                 return this;
             }
 

--- a/service/src/main/java/ai/chronon/service/model/GetFeaturesResponse.java
+++ b/service/src/main/java/ai/chronon/service/model/GetFeaturesResponse.java
@@ -1,0 +1,101 @@
+package ai.chronon.service.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetFeaturesResponse {
+    private final List<Result> results;
+
+    private GetFeaturesResponse(Builder builder) {
+        this.results = builder.results;
+    }
+
+    public List<Result> getResults() {
+        return results;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private List<Result> results = new ArrayList<>();
+
+        public Builder results(List<Result> results) {
+            this.results = results;
+            return this;
+        }
+
+        public Builder addResult(Result result) {
+            this.results.add(result);
+            return this;
+        }
+
+        public GetFeaturesResponse build() {
+            return new GetFeaturesResponse(this);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Result {
+        public enum Status {
+            Success,
+            Failure
+        }
+
+        private final Status status;
+        private final Map<String, Object> features;
+        private final String error;
+
+        private Result(Builder builder) {
+            this.status = builder.status;
+            this.features = builder.features;
+            this.error = builder.error;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public Map<String, Object> getFeatures() {
+            return features;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private Status status;
+            private Map<String, Object> features;
+            private String error;
+
+            public Builder status(Status status) {
+                this.status = status;
+                return this;
+            }
+
+            public Builder features(Map<String, Object> features) {
+                this.features = features;
+                return this;
+            }
+
+            public Builder error(String error) {
+                this.error = error;
+                return this;
+            }
+
+            public Result build() {
+                return new Result(this);
+            }
+        }
+    }
+}

--- a/service/src/main/java/ai/chronon/service/model/GetFeaturesResponse.java
+++ b/service/src/main/java/ai/chronon/service/model/GetFeaturesResponse.java
@@ -6,6 +6,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * PoJo capturing the response we return back as part of /v1/features/groupby and /v1/features/join endpoints
+ * when the individual bulkGet lookups were either all successful or partially successful.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GetFeaturesResponse {
     private final List<Result> results;

--- a/service/src/main/resources/example_config.json
+++ b/service/src/main/resources/example_config.json
@@ -1,0 +1,10 @@
+{
+  "online.jar": "./quickstart/mongo-online-impl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar",
+  "online.class": "ai.chronon.quickstart.online.ChrononMongoOnlineImpl",  
+  "online.api.props": {
+    "user": "admin",
+    "password": "admin",
+    "host": "localhost",
+    "port": "27017"
+  }
+}

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
         <!-- Use environment variable for log path -->
         <file>${LOG_PATH}/chronon-fs.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <FileNamePattern>${LOG_DIR}/chronon-fs.%d{yyyy-dd-MM}-%i.log</FileNamePattern>
+            <FileNamePattern>${LOG_PATH}/chronon-fs.%d{yyyy-dd-MM}-%i.log</FileNamePattern>
             <!-- each archived file, size max 100MB -->
             <maxFileSize>100MB</maxFileSize>
             <!-- total size of all archive files, if total size > 10GB, it will delete old archived file -->

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -1,12 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Property definition from environment variable with default -->
+    <property name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
+    <property name="LOG_PATH" value="${LOG_PATH:-/tmp/chronon/logs}"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%xException{10}</pattern>
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- Use environment variable for log path -->
+        <file>${LOG_PATH}/chronon-fs.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <FileNamePattern>${LOG_DIR}/chronon-fs.%d{yyyy-dd-MM}-%i.log</FileNamePattern>
+            <!-- each archived file, size max 100MB -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- total size of all archive files, if total size > 10GB, it will delete old archived file -->
+            <totalSizeCap>10GB</totalSizeCap>
+            <!-- 30 days to keep -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Wrap in async appender and tweak config a bit based on: https://dzone.com/articles/how-instantly-improve-your-0-->
+    <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE" />
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="STDOUT" />
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+    </appender>
+
+    <!-- Root logger using environment variable for level -->
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="ASYNCSTDOUT" />
+        <appender-ref ref="ASYNCFILE" />
     </root>
 </configuration>

--- a/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerJsonSerDeTest.java
+++ b/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerJsonSerDeTest.java
@@ -1,0 +1,57 @@
+package ai.chronon.service.handlers;
+
+import ai.chronon.online.JTry;
+import ai.chronon.online.JavaRequest;
+import io.vertx.ext.web.RequestBody;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FeaturesHandlerJsonSerDeTest {
+
+    @Test
+    public void testParsingOfSimpleJavaRequests() {
+        String mockRequest = "[{\"user\":\"user1\",\"zip\":10010}]";
+        RequestBody mockRequestBody = mock(RequestBody.class);
+        when(mockRequestBody.asString()).thenReturn(mockRequest);
+
+        String groupByName = "my_groupby.1";
+        JTry<List<JavaRequest>> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
+        assertTrue(maybeRequest.isSuccess());
+        List<JavaRequest> reqs = maybeRequest.getValue();
+        assertEquals(1, reqs.size());
+        JavaRequest req = reqs.get(0);
+        assertEquals(req.name, groupByName);
+        assertTrue(req.keys.containsKey("user") && req.keys.get("user").getClass().equals(String.class));
+        assertTrue(req.keys.containsKey("zip") && req.keys.get("zip").getClass().equals(Integer.class));
+    }
+
+    @Test
+    public void testParsingInvalidRequest() {
+        // mess up the colon after the zip field
+        String mockRequest = "[{\"user\":\"user1\",\"zip\"10010}]";
+        RequestBody mockRequestBody = mock(RequestBody.class);
+        when(mockRequestBody.asString()).thenReturn(mockRequest);
+
+        String groupByName = "my_groupby.1";
+        JTry<List<JavaRequest>> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
+        assertFalse(maybeRequest.isSuccess());
+        assertNotNull(maybeRequest.getException());
+    }
+
+    @Test
+    public void testParsingOneValidAndInvalidRequest() {
+        String mockRequest = "[{\"user\":\"user1\",\"zip\":10010}, {\"user\":\"user1\",\"zip\"10010}]";
+        RequestBody mockRequestBody = mock(RequestBody.class);
+        when(mockRequestBody.asString()).thenReturn(mockRequest);
+
+        String groupByName = "my_groupby.1";
+        JTry<List<JavaRequest>> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
+        assertFalse(maybeRequest.isSuccess());
+        assertNotNull(maybeRequest.getException());
+    }
+}

--- a/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerTest.java
+++ b/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerTest.java
@@ -72,7 +72,8 @@ public class FeaturesHandlerTest {
         String validRequestBody = "[{\"user_id\":\"123\"}]";
         when(requestBody.asString()).thenReturn(validRequestBody);
 
-        JavaRequest request = new JavaRequest(TEST_GROUP_BY, Collections.singletonMap("user_id", "123"));
+        Map<String, Object> keys = Collections.singletonMap("user_id", "123");
+        JavaRequest request = new JavaRequest(TEST_GROUP_BY, keys);
         Map<String, Object> featureMap = new HashMap<String, Object>() {{
             put("feature_1", 12);
             put("feature_2", 23.3);
@@ -99,7 +100,7 @@ public class FeaturesHandlerTest {
 
             // Verify response format
             JsonObject actualResponse = new JsonObject(responseCaptor.getValue());
-            GetFeaturesResponse.Result expectedResult = GetFeaturesResponse.Result.builder().status(Success).features(featureMap).build();
+            GetFeaturesResponse.Result expectedResult = GetFeaturesResponse.Result.builder().status(Success).entityKeys(keys).features(featureMap).build();
             validateSuccessfulResponse(actualResponse, Collections.singletonList(expectedResult), context);
             async.complete();
         });
@@ -169,8 +170,12 @@ public class FeaturesHandlerTest {
         String validRequestBody = "[{\"user_id\":\"123\"}, {\"user_id\":\"456\"}]";
         when(requestBody.asString()).thenReturn(validRequestBody);
 
-        JavaRequest request1 = new JavaRequest(TEST_GROUP_BY, Collections.singletonMap("user_id", "123"));
-        JavaRequest request2 = new JavaRequest(TEST_GROUP_BY, Collections.singletonMap("user_id", "456"));
+        Map<String, Object> keys1 = Collections.singletonMap("user_id", "123");
+        JavaRequest request1 = new JavaRequest(TEST_GROUP_BY, keys1);
+
+        Map<String, Object> keys2 = Collections.singletonMap("user_id", "456");
+        JavaRequest request2 = new JavaRequest(TEST_GROUP_BY, keys2);
+
         Map<String, Object> featureMap1 = new HashMap<String, Object>() {{
             put("feature_1", 12);
             put("feature_2", 23.3);
@@ -210,8 +215,8 @@ public class FeaturesHandlerTest {
 
             // Verify response format
             JsonObject actualResponse = new JsonObject(responseCaptor.getValue());
-            GetFeaturesResponse.Result expectedResult1 = GetFeaturesResponse.Result.builder().status(Success).features(featureMap1).build();
-            GetFeaturesResponse.Result expectedResult2 = GetFeaturesResponse.Result.builder().status(Success).features(featureMap2).build();
+            GetFeaturesResponse.Result expectedResult1 = GetFeaturesResponse.Result.builder().status(Success).entityKeys(keys1).features(featureMap1).build();
+            GetFeaturesResponse.Result expectedResult2 = GetFeaturesResponse.Result.builder().status(Success).entityKeys(keys2).features(featureMap2).build();
 
             List<GetFeaturesResponse.Result> expectedResultList = new ArrayList<GetFeaturesResponse.Result>() {{
                 add(expectedResult1);
@@ -230,8 +235,12 @@ public class FeaturesHandlerTest {
         String validRequestBody = "[{\"user_id\":\"123\"}, {\"user_id\":\"456\"}]";
         when(requestBody.asString()).thenReturn(validRequestBody);
 
-        JavaRequest request1 = new JavaRequest(TEST_GROUP_BY, Collections.singletonMap("user_id", "123"));
-        JavaRequest request2 = new JavaRequest(TEST_GROUP_BY, Collections.singletonMap("user_id", "456"));
+        Map<String, Object> keys1 = Collections.singletonMap("user_id", "123");
+        JavaRequest request1 = new JavaRequest(TEST_GROUP_BY, keys1);
+
+        Map<String, Object> keys2 = Collections.singletonMap("user_id", "456");
+        JavaRequest request2 = new JavaRequest(TEST_GROUP_BY, keys2);
+
         Map<String, Object> featureMap = new HashMap<String, Object>() {{
             put("feature_1", 12);
             put("feature_2", 23.3);
@@ -265,8 +274,8 @@ public class FeaturesHandlerTest {
 
             // Verify response format
             JsonObject actualResponse = new JsonObject(responseCaptor.getValue());
-            GetFeaturesResponse.Result expectedResult1 = GetFeaturesResponse.Result.builder().status(Success).features(featureMap).build();
-            GetFeaturesResponse.Result expectedResult2 = GetFeaturesResponse.Result.builder().status(Failure).error("some failure!").build();
+            GetFeaturesResponse.Result expectedResult1 = GetFeaturesResponse.Result.builder().status(Success).entityKeys(keys1).features(featureMap).build();
+            GetFeaturesResponse.Result expectedResult2 = GetFeaturesResponse.Result.builder().status(Failure).entityKeys(keys2).error("some failure!").build();
             List<GetFeaturesResponse.Result> expectedResultList = new ArrayList<GetFeaturesResponse.Result>() {{
                add(expectedResult1);
                add(expectedResult2);
@@ -293,6 +302,11 @@ public class FeaturesHandlerTest {
             Map<String, Object> resultMap = results.getJsonObject(i).getMap();
             context.assertTrue(resultMap.containsKey("status"));
             context.assertEquals(resultMap.get("status"), expectedResults.get(i).getStatus().name());
+
+            context.assertTrue(resultMap.containsKey("entityKeys"));
+            Map<String, Object> returnedKeys = (Map<String, Object>) resultMap.get("entityKeys");
+            context.assertEquals(expectedResults.get(i).getEntityKeys(), returnedKeys);
+
             if (expectedResults.get(i).getStatus().equals(Success)) {
                 context.assertTrue(resultMap.containsKey("features"));
                 Map<String, Object> returnedFeatureMap = (Map<String, Object>) resultMap.get("features");

--- a/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerTest.java
+++ b/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerTest.java
@@ -1,75 +1,274 @@
 package ai.chronon.service.handlers;
 
 import ai.chronon.online.JTry;
+import ai.chronon.online.JavaFetcher;
 import ai.chronon.online.JavaRequest;
 import ai.chronon.online.JavaResponse;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Objects;
+import ai.chronon.service.model.GetFeaturesResponse;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
+import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Failure;
+import static ai.chronon.service.model.GetFeaturesResponse.Result.Status.Success;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(VertxUnitRunner.class)
 public class FeaturesHandlerTest {
 
-    @Test
-    public void testParsingOfSimpleJavaRequests() {
-        String mockRequest = "{\"user\":\"user1\",\"zip\":10010}";
-        RequestBody mockRequestBody = mock(RequestBody.class);
-        when(mockRequestBody.asString()).thenReturn(mockRequest);
+    @Mock
+    private JavaFetcher mockFetcher;
 
-        String groupByName = "my_groupby.1";
-        JTry<JavaRequest> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
-        assertTrue(maybeRequest.isSuccess());
-        JavaRequest req = maybeRequest.getValue();
-        assertEquals(req.name, groupByName);
-        assertTrue(req.keys.containsKey("user") && req.keys.get("user").getClass().equals(String.class));
-        assertTrue(req.keys.containsKey("zip") && req.keys.get("zip").getClass().equals(Integer.class));
+    @Mock
+    private RoutingContext routingContext;
+
+    @Mock
+    private HttpServerResponse response;
+
+    @Mock
+    RequestBody requestBody;
+
+    private FeaturesHandler handler;
+    private Vertx vertx;
+
+    private static final String TEST_GROUP_BY = "test_groupby.v1";
+
+    @Before
+    public void setUp(TestContext context) {
+        MockitoAnnotations.openMocks(this);
+        vertx = Vertx.vertx();
+        handler = new FeaturesHandler(FeaturesHandler.EntityType.Join, mockFetcher);
+
+        // Set up common routing context behavior
+        when(routingContext.response()).thenReturn(response);
+        when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+        when(routingContext.body()).thenReturn(requestBody);
+        when(routingContext.pathParam("name")).thenReturn(TEST_GROUP_BY);
     }
 
     @Test
-    public void testParsingInvalidRequest() {
-        // mess up the colon after the zip field
-        String mockRequest = "{\"user\":\"user1\",\"zip\"10010}";
-        RequestBody mockRequestBody = mock(RequestBody.class);
-        when(mockRequestBody.asString()).thenReturn(mockRequest);
+    public void testSuccessfulSingleRequest(TestContext context) {
+        Async async = context.async();
 
-        String groupByName = "my_groupby.1";
-        JTry<JavaRequest> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
-        assertFalse(maybeRequest.isSuccess());
-        assertNotNull(maybeRequest.getException());
+        // Set up mocks
+        String validRequestBody = "[{\"user_id\":\"123\"}]";
+        when(requestBody.asString()).thenReturn(validRequestBody);
+
+        JavaRequest request = new JavaRequest(TEST_GROUP_BY, Map.of("user_id", "123"));
+        Map<String, Object> featureMap = Map.of("feature_1", 12, "feature_2", 23.3, "feature_3", "USD");
+        JTry<Map<String, Object>> values = JTry.success(featureMap);
+        JavaResponse mockResponse = new JavaResponse(request, values);
+
+        CompletableFuture<List<JavaResponse>> futureResponse =
+                CompletableFuture.completedFuture(List.of(mockResponse));
+        when(mockFetcher.fetchJoin(anyList())).thenReturn(futureResponse);
+
+        // Capture the response that will be sent
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+
+        // Trigger call
+        handler.handle(routingContext);
+
+        // Assert results
+        vertx.setTimer(1000, id -> {
+            verify(response).setStatusCode(200);
+            verify(response).putHeader("content-type", "application/json");
+            verify(response).end(responseCaptor.capture());
+
+            // Verify response format
+            JsonObject actualResponse = new JsonObject(responseCaptor.getValue());
+            GetFeaturesResponse.Result expectedResult = GetFeaturesResponse.Result.builder().status(Success).features(featureMap).build();
+            validateSuccessfulResponse(actualResponse, List.of(expectedResult), context);
+            async.complete();
+        });
     }
 
     @Test
-    public void testResponseToJson() throws Exception {
-        JavaRequest myReq = new JavaRequest("my_groupby.1", Map.of("key", "value"));
-        Map<String, Object> mockFeatureValues = Map.of("feature_1", 12, "feature_2", 34.4);
-        JavaResponse happyResponse = new JavaResponse(myReq, JTry.success(mockFeatureValues));
+    public void testRequestParseIssue(TestContext context) {
+        Async async = context.async();
 
-        JTry<String> jsonTry = FeaturesHandler.responseToJson(happyResponse);
-        assertTrue(jsonTry.isSuccess());
+        // Set up mocks
+        String invalidRequestBody = "[{\"user_id\"\"123\"}]";
+        when(requestBody.asString()).thenReturn(invalidRequestBody);
 
-        // test round trip to confirm values what the 'service' sent
-        String json = jsonTry.getValue();
-        ObjectMapper objectMapper = new ObjectMapper();
-        TypeReference<Map<String, Object>> ref = new TypeReference<>() { };
-        Map<String, Object> parsedFeatureValues = objectMapper.readValue(json, ref);
+        // Capture the response that will be sent
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
 
-        assertEquals(mockFeatureValues, parsedFeatureValues);
+        // Trigger call
+        handler.handle(routingContext);
+
+        // Assert results
+        vertx.setTimer(1000, id -> {
+            verify(response).setStatusCode(400);
+            verify(response).putHeader("content-type", "application/json");
+            verify(response).end(responseCaptor.capture());
+
+            // Verify response format
+            validateFailureResponse(responseCaptor.getValue(), context);
+            async.complete();
+        });
     }
 
     @Test
-    public void testFailureResponseToJson() throws Exception {
-        JavaRequest myReq = new JavaRequest("my_groupby.1", Map.of("key", "value"));
-        JavaResponse failureResponse = new JavaResponse(myReq, JTry.failure(new IllegalArgumentException("Something broke in Chronon")));
+    public void testFetcherFutureFailure(TestContext context) {
+        Async async = context.async();
 
-        JTry<String> jsonTry = FeaturesHandler.responseToJson(failureResponse);
-        assertFalse(jsonTry.isSuccess());
-        assertNotNull(jsonTry.getException());
+        // Set up mocks
+        String validRequestBody = "[{\"user_id\":\"123\"}]";
+        when(requestBody.asString()).thenReturn(validRequestBody);
+
+        CompletableFuture<List<JavaResponse>> futureResponse =
+                CompletableFuture.failedFuture(new RuntimeException("Error in KV store lookup"));
+        when(mockFetcher.fetchJoin(anyList())).thenReturn(futureResponse);
+
+        // Capture the response that will be sent
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+
+        // Trigger call
+        handler.handle(routingContext);
+
+        // Assert results
+        vertx.setTimer(1000, id -> {
+            verify(response).setStatusCode(500);
+            verify(response).putHeader("content-type", "application/json");
+            verify(response).end(responseCaptor.capture());
+
+            // Verify response format
+            validateFailureResponse(responseCaptor.getValue(), context);
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testSuccessfulMultipleRequests(TestContext context) {
+        Async async = context.async();
+
+        // Set up mocks
+        String validRequestBody = "[{\"user_id\":\"123\"}, {\"user_id\":\"456\"}]";
+        when(requestBody.asString()).thenReturn(validRequestBody);
+
+        JavaRequest request1 = new JavaRequest(TEST_GROUP_BY, Map.of("user_id", "123"));
+        JavaRequest request2 = new JavaRequest(TEST_GROUP_BY, Map.of("user_id", "456"));
+        Map<String, Object> featureMap1 = Map.of("feature_1", 12, "feature_2", 23.3, "feature_3", "USD");
+        Map<String, Object> featureMap2 = Map.of("feature_1", 24, "feature_2", 26.3, "feature_3", "CAD");
+
+        JTry<Map<String, Object>> values1 = JTry.success(featureMap1);
+        JTry<Map<String, Object>> values2 = JTry.success(featureMap2);
+        JavaResponse mockResponse1 = new JavaResponse(request1, values1);
+        JavaResponse mockResponse2 = new JavaResponse(request2, values2);
+
+        CompletableFuture<List<JavaResponse>> futureResponse =
+                CompletableFuture.completedFuture(List.of(mockResponse1, mockResponse2));
+        when(mockFetcher.fetchJoin(anyList())).thenReturn(futureResponse);
+
+        // Capture the response that will be sent
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+
+        // Trigger call
+        handler.handle(routingContext);
+
+        // Assert results
+        vertx.setTimer(1000, id -> {
+            verify(response).setStatusCode(200);
+            verify(response).putHeader("content-type", "application/json");
+            verify(response).end(responseCaptor.capture());
+
+            // Verify response format
+            JsonObject actualResponse = new JsonObject(responseCaptor.getValue());
+            GetFeaturesResponse.Result expectedResult1 = GetFeaturesResponse.Result.builder().status(Success).features(featureMap1).build();
+            GetFeaturesResponse.Result expectedResult2 = GetFeaturesResponse.Result.builder().status(Success).features(featureMap2).build();
+            validateSuccessfulResponse(actualResponse, List.of(expectedResult1, expectedResult2), context);
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testPartialSuccessfulRequests(TestContext context) {
+        Async async = context.async();
+
+        // Set up mocks
+        String validRequestBody = "[{\"user_id\":\"123\"}, {\"user_id\":\"456\"}]";
+        when(requestBody.asString()).thenReturn(validRequestBody);
+
+        JavaRequest request1 = new JavaRequest(TEST_GROUP_BY, Map.of("user_id", "123"));
+        JavaRequest request2 = new JavaRequest(TEST_GROUP_BY, Map.of("user_id", "456"));
+        Map<String, Object> featureMap1 = Map.of("feature_1", 12, "feature_2", 23.3, "feature_3", "USD");
+
+        JTry<Map<String, Object>> values1 = JTry.success(featureMap1);
+        JTry<Map<String, Object>> values2 = JTry.failure(new RuntimeException("some failure!"));
+        JavaResponse mockResponse1 = new JavaResponse(request1, values1);
+        JavaResponse mockResponse2 = new JavaResponse(request2, values2);
+
+        CompletableFuture<List<JavaResponse>> futureResponse =
+                CompletableFuture.completedFuture(List.of(mockResponse1, mockResponse2));
+        when(mockFetcher.fetchJoin(anyList())).thenReturn(futureResponse);
+
+        // Capture the response that will be sent
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+
+        // Trigger call
+        handler.handle(routingContext);
+
+        // Assert results
+        vertx.setTimer(1000, id -> {
+            verify(response).setStatusCode(200);
+            verify(response).putHeader("content-type", "application/json");
+            verify(response).end(responseCaptor.capture());
+
+            // Verify response format
+            JsonObject actualResponse = new JsonObject(responseCaptor.getValue());
+            GetFeaturesResponse.Result expectedResult1 = GetFeaturesResponse.Result.builder().status(Success).features(featureMap1).build();
+            GetFeaturesResponse.Result expectedResult2 = GetFeaturesResponse.Result.builder().status(Failure).error("some failure!").build();
+            validateSuccessfulResponse(actualResponse, List.of(expectedResult1, expectedResult2), context);
+            async.complete();;
+        });
+    }
+
+    private void validateFailureResponse(String jsonResponse, TestContext context) {
+        JsonObject actualResponse = new JsonObject(jsonResponse);
+        context.assertTrue(actualResponse.containsKey("errors"));
+
+        String failureString = actualResponse.getJsonArray("errors").getString(0);
+        context.assertNotNull(failureString);
+    }
+
+    private void validateSuccessfulResponse(JsonObject actualResponse, List<GetFeaturesResponse.Result> expectedResults, TestContext context) {
+        context.assertTrue(actualResponse.containsKey("results"));
+        context.assertEquals(actualResponse.getJsonArray("results").size(), expectedResults.size());
+
+        JsonArray results = actualResponse.getJsonArray("results");
+        for (int i = 0; i < expectedResults.size(); i++) {
+            Map<String, Object> resultMap = results.getJsonObject(i).getMap();
+            context.assertTrue(resultMap.containsKey("status"));
+            context.assertEquals(resultMap.get("status"), expectedResults.get(i).getStatus().name());
+            if (expectedResults.get(i).getStatus().equals(Success)) {
+                context.assertTrue(resultMap.containsKey("features"));
+                Map<String, Object> returnedFeatureMap = (Map<String, Object>) resultMap.get("features");
+                context.assertEquals(expectedResults.get(i).getFeatures(), returnedFeatureMap);
+            } else {
+                context.assertTrue(resultMap.containsKey("error"));
+                String returnedErrorMsg = (String) resultMap.get("error");
+                context.assertEquals(expectedResults.get(i).getError(), returnedErrorMsg);
+            }
+        }
     }
 }

--- a/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerTest.java
+++ b/service/src/test/java/ai/chronon/service/handlers/FeaturesHandlerTest.java
@@ -1,0 +1,75 @@
+package ai.chronon.service.handlers;
+
+import ai.chronon.online.JTry;
+import ai.chronon.online.JavaRequest;
+import ai.chronon.online.JavaResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Objects;
+import io.vertx.ext.web.RequestBody;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FeaturesHandlerTest {
+
+    @Test
+    public void testParsingOfSimpleJavaRequests() {
+        String mockRequest = "{\"user\":\"user1\",\"zip\":10010}";
+        RequestBody mockRequestBody = mock(RequestBody.class);
+        when(mockRequestBody.asString()).thenReturn(mockRequest);
+
+        String groupByName = "my_groupby.1";
+        JTry<JavaRequest> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
+        assertTrue(maybeRequest.isSuccess());
+        JavaRequest req = maybeRequest.getValue();
+        assertEquals(req.name, groupByName);
+        assertTrue(req.keys.containsKey("user") && req.keys.get("user").getClass().equals(String.class));
+        assertTrue(req.keys.containsKey("zip") && req.keys.get("zip").getClass().equals(Integer.class));
+    }
+
+    @Test
+    public void testParsingInvalidRequest() {
+        // mess up the colon after the zip field
+        String mockRequest = "{\"user\":\"user1\",\"zip\"10010}";
+        RequestBody mockRequestBody = mock(RequestBody.class);
+        when(mockRequestBody.asString()).thenReturn(mockRequest);
+
+        String groupByName = "my_groupby.1";
+        JTry<JavaRequest> maybeRequest = FeaturesHandler.parseJavaRequest(groupByName, mockRequestBody);
+        assertFalse(maybeRequest.isSuccess());
+        assertNotNull(maybeRequest.getException());
+    }
+
+    @Test
+    public void testResponseToJson() throws Exception {
+        JavaRequest myReq = new JavaRequest("my_groupby.1", Map.of("key", "value"));
+        Map<String, Object> mockFeatureValues = Map.of("feature_1", 12, "feature_2", 34.4);
+        JavaResponse happyResponse = new JavaResponse(myReq, JTry.success(mockFeatureValues));
+
+        JTry<String> jsonTry = FeaturesHandler.responseToJson(happyResponse);
+        assertTrue(jsonTry.isSuccess());
+
+        // test round trip to confirm values what the 'service' sent
+        String json = jsonTry.getValue();
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<Map<String, Object>> ref = new TypeReference<>() { };
+        Map<String, Object> parsedFeatureValues = objectMapper.readValue(json, ref);
+
+        assertEquals(mockFeatureValues, parsedFeatureValues);
+    }
+
+    @Test
+    public void testFailureResponseToJson() throws Exception {
+        JavaRequest myReq = new JavaRequest("my_groupby.1", Map.of("key", "value"));
+        JavaResponse failureResponse = new JavaResponse(myReq, JTry.failure(new IllegalArgumentException("Something broke in Chronon")));
+
+        JTry<String> jsonTry = FeaturesHandler.responseToJson(failureResponse);
+        assertFalse(jsonTry.isSuccess());
+        assertNotNull(jsonTry.getException());
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR adds a module to the project to spin up a service that wraps the Fetcher code and allows us to serve features. This module leverages the [Vert.x](https://vertx.io/) project. Vert.x is a high performance service toolkit that allows us to build http / grpc services - as the serving layer can be on the hot path for some use-cases, the high perf nature of Vert.x will hopefully be a good starting point. Vert.x core is Java based and given we have 3 Scala versions to support in the Chronon project, I've chosen the path of writing the service in Java rather than dealing with the interop and the multi-version compat story for now.

The service as such adds a couple of HTTP endpoints that allow us to serve groupBys and joins (each returning a json payload). We can extend things in the future with an equivalent set of grpc endpoints if needed. Endpoints look like:
```
/ping -> Health check
/config -> Returns the svc config
/v1/features/join/<joinName> -> Bulk get request for a given join
/v1/features/groupby/<groupByName> -> Bulk get request for a given group by
```

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Currently users getting going on the project have to take on the additional work of writing a feature serving layer of their own (or rely on a set of disparate clients calling and using the Fetcher libs directly). This makes it painful to set up and this burden is exacerbated for users that don't natively work on JVM languages. Hooking up the fetcher code in other languages is non-trivial as it requires rewriting a lot of the core fetcher logic and maintaining parity across as things change over time. Including a service module within the project aims to lower that barrier of entry as it allows users to package the service and have their non-JVM services hit it and get feature data over the wire.
 
## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [X] Integration tested

(Readme in the service module directory has some details / instructions on how you can spin up the project and test against the quickstart mongo api)

## Checklist
- [ ] Documentation update

## Reviewers
@caiocamatta-stripe @mickjermsurawong-openai
