### PR TITLE
Add ; for proper sql syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ And then:
 spark-sql> SELECT user_id, quickstart_returns_v1_refund_amt_sum_30d, quickstart_purchases_v1_purchase_price_sum_14d, quickstart_users_v1_email_verified from default.quickstart_training_set_v1 limit 100;
 ```
 
-Note that this only selects a few columns. You can also run a `select * from default.quickstart_training_set_v1 limit 100` to see all columns, however, note that the table is quite wide and the results might not be very readable on your screen.
+Note that this only selects a few columns. You can also run a `select * from default.quickstart_training_set_v1 limit 100;` to see all columns, however, note that the table is quite wide and the results might not be very readable on your screen.
 
 To exit the sql shell you can run:
 

--- a/docs/source/getting_started/Tutorial.md
+++ b/docs/source/getting_started/Tutorial.md
@@ -197,7 +197,7 @@ And then:
 spark-sql> SELECT user_id, quickstart_returns_v1_refund_amt_sum_30d, quickstart_purchases_v1_purchase_price_sum_14d, quickstart_users_v1_email_verified from default.quickstart_training_set_v1 limit 100;
 ```
 
-Note that this only selects a few columns. You can also run a `select * from default.quickstart_training_set_v1 limit 100` to see all columns, however, note that the table is quite wide and the results might not be very readable on your screen.
+Note that this only selects a few columns. You can also run a `select * from default.quickstart_training_set_v1 limit 100;` to see all columns, however, note that the table is quite wide and the results might not be very readable on your screen.
 
 To exit the sql shell you can run:
 


### PR DESCRIPTION
## Summary
Was working thru the quickstart and noticed that one sql command was missing a `;`


## Why / Goal
Makes it easier for folks to copy/paste the code

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

