### PR TITLE
Enable derivation name duplicate with key

### DIFF
--- a/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
@@ -62,20 +62,11 @@ v1 = Join(
 v2 = Join(
     left=test_sources.staging_entities,
     right_parts=[JoinPart(group_by=sample_group_by.v1)],
-    online_external_parts=[
-        ExternalPart(
-            ExternalSource(
-                name="test_external_source",
-                team="chronon",
-                key_fields=[("key", DataType.LONG)],
-                value_fields=[("ext_place_id", DataType.STRING)],
-            )
-        )
-    ],
+    online_external_parts=[ExternalPart(ContextualSource(fields=[("place_id", DataType.STRING)]))],
     table_properties={"config_json": """{"sample_key": "sample_value"}"""},
     derivations=[
         Derivation(name="*", expression="*"),
-        Derivation(name="place_id", expression="ext_test_external_source_ext_place_id"),
+        Derivation(name="place_id", expression="ext_contextual_place_id"),
     ],
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
@@ -16,17 +16,17 @@ Sample Join
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from group_bys.sample_team import sample_group_by
-from sources import test_sources
-
 from ai.chronon.join import (
-    Join,
-    JoinPart,
+    ContextualSource,
+    DataType,
+    Derivation,
     ExternalPart,
     ExternalSource,
-    DataType,
-    ContextualSource
+    Join,
+    JoinPart,
 )
+from group_bys.sample_team import sample_group_by
+from sources import test_sources
 
 v1 = Join(
     left=test_sources.staging_entities,
@@ -36,14 +36,12 @@ v1 = Join(
             ExternalSource(
                 name="test_external_source",
                 team="chronon",
-                key_fields=[
-                    ("key", DataType.LONG)
-                ],
+                key_fields=[("key", DataType.LONG)],
                 value_fields=[
                     ("value_str", DataType.STRING),
                     ("value_long", DataType.LONG),
-                    ("value_bool", DataType.BOOLEAN)
-                ]
+                    ("value_bool", DataType.BOOLEAN),
+                ],
             )
         ),
         ExternalPart(
@@ -52,12 +50,28 @@ v1 = Join(
                     ("context_str", DataType.STRING),
                     ("context_long", DataType.LONG),
                 ],
-                team="chronon"
+                team="chronon",
+            )
+        ),
+    ],
+    table_properties={"config_json": """{"sample_key": "sample_value"}"""},
+    output_namespace="sample_namespace",
+)
+
+v2 = Join(
+    left=test_sources.staging_entities,
+    right_parts=[JoinPart(group_by=sample_group_by.v1)],
+    online_external_parts=[
+        ExternalPart(
+            ExternalSource(
+                name="test_external_source",
+                team="chronon",
+                key_fields=[("key", DataType.LONG)],
+                value_fields=[("ext_place_id", DataType.STRING)],
             )
         )
     ],
-    table_properties={
-        "config_json": """{"sample_key": "sample_value"}"""
-    },
-    output_namespace="sample_namespace"
+    table_properties={"config_json": """{"sample_key": "sample_value"}"""},
+    derivations=[Derivation(name="*", expression="*"), Derivation(name="place_id", expression="ext_place_id")],
+    output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
+++ b/api/py/test/sample/joins/sample_team/sample_join_external_parts.py
@@ -58,6 +58,7 @@ v1 = Join(
     output_namespace="sample_namespace",
 )
 
+# sample join with derivations on external column to pass key fields
 v2 = Join(
     left=test_sources.staging_entities,
     right_parts=[JoinPart(group_by=sample_group_by.v1)],
@@ -72,6 +73,9 @@ v2 = Join(
         )
     ],
     table_properties={"config_json": """{"sample_key": "sample_value"}"""},
-    derivations=[Derivation(name="*", expression="*"), Derivation(name="place_id", expression="ext_place_id")],
+    derivations=[
+        Derivation(name="*", expression="*"),
+        Derivation(name="place_id", expression="ext_test_external_source_ext_place_id"),
+    ],
     output_namespace="sample_namespace",
 )

--- a/api/py/test/sample/production/joins/sample_team/sample_join_external_parts.v2
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_external_parts.v2
@@ -1,0 +1,131 @@
+{
+  "metaData": {
+    "name": "sample_team.sample_join_external_parts.v2",
+    "online": 0,
+    "production": 0,
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "config_json": "{\"sample_key\": \"sample_value\"}"
+    },
+    "outputNamespace": "sample_namespace",
+    "team": "sample_team",
+    "samplePercent": 100.0,
+    "offlineSchedule": "@daily"
+  },
+  "left": {
+    "entities": {
+      "snapshotTable": "sample_namespace.sample_team_sample_staging_query_v1",
+      "query": {
+        "selects": {
+          "impressed_unique_count_1d": "impressed_unique_count_1d",
+          "viewed_unique_count_1d": "viewed_unique_count_1d",
+          "s2CellId": "s2CellId",
+          "place_id": "place_id"
+        },
+        "startPartition": "2021-03-01",
+        "setups": []
+      }
+    }
+  },
+  "joinParts": [
+    {
+      "groupBy": {
+        "metaData": {
+          "name": "sample_team.sample_group_by.v1",
+          "production": 0,
+          "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+          "dependencies": [
+            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}"
+          ],
+          "tableProperties": {
+            "sample_config_json": "{\"sample_key\": \"sample_value\"}",
+            "description": "sample description"
+          },
+          "outputNamespace": "sample_namespace",
+          "team": "sample_team",
+          "offlineSchedule": "@daily"
+        },
+        "sources": [
+          {
+            "entities": {
+              "snapshotTable": "sample_namespace.sample_team_sample_staging_query_v1",
+              "query": {
+                "selects": {
+                  "impressed_unique_count_1d": "impressed_unique_count_1d",
+                  "viewed_unique_count_1d": "viewed_unique_count_1d",
+                  "s2CellId": "s2CellId",
+                  "place_id": "place_id"
+                },
+                "startPartition": "2021-03-01",
+                "setups": []
+              }
+            }
+          }
+        ],
+        "keyColumns": [
+          "s2CellId",
+          "place_id"
+        ],
+        "aggregations": [
+          {
+            "inputColumn": "impressed_unique_count_1d",
+            "operation": 7,
+            "argMap": {}
+          },
+          {
+            "inputColumn": "viewed_unique_count_1d",
+            "operation": 7,
+            "argMap": {}
+          }
+        ]
+      }
+    }
+  ],
+  "onlineExternalParts": [
+    {
+      "source": {
+        "metadata": {
+          "name": "test_external_source",
+          "team": "chronon"
+        },
+        "keySchema": {
+          "kind": 13,
+          "params": [
+            {
+              "name": "key",
+              "dataType": {
+                "kind": 4
+              }
+            }
+          ],
+          "name": "ext_test_external_source_keys"
+        },
+        "valueSchema": {
+          "kind": 13,
+          "params": [
+            {
+              "name": "ext_place_id",
+              "dataType": {
+                "kind": 7
+              }
+            }
+          ],
+          "name": "ext_test_external_source_values"
+        }
+      }
+    }
+  ],
+  "derivations": [
+    {
+      "name": "*",
+      "expression": "*"
+    },
+    {
+      "name": "place_id",
+      "expression": "ext_test_external_source_ext_place_id"
+    }
+  ]
+}

--- a/api/py/test/test_validator.py
+++ b/api/py/test/test_validator.py
@@ -159,8 +159,9 @@ def test_validate_group_by_deprecation_date(zvalidator):
     assert len(errors) == 1
 
 
+# Derive from external column to key should be enabled in validator
 def test_validate_derivation_on_keys(zvalidator):
-    from sample.join.sample_team.sample_join_external_parts import v2
+    from sample.joins.sample_team.sample_join_external_parts import v2
 
     errors = zvalidator._validate_join(v2)
     assert len(errors) == 0

--- a/api/py/test/test_validator.py
+++ b/api/py/test/test_validator.py
@@ -164,4 +164,4 @@ def test_validate_derivation_on_keys(zvalidator):
     from sample.joins.sample_team.sample_join_external_parts import v2
 
     errors = zvalidator._validate_join(v2)
-    assert len(errors) == 0
+    assert len(errors) == 0, f"Failed on: {errors}"

--- a/api/py/test/test_validator.py
+++ b/api/py/test/test_validator.py
@@ -157,3 +157,10 @@ def test_validate_group_by_deprecation_date(zvalidator):
     assert len(errors) == 0
     errors = zvalidator._validate_group_by(v1_incorrect_deprecation_format)
     assert len(errors) == 1
+
+
+def test_validate_derivation_on_keys(zvalidator):
+    from sample.join.sample_team.sample_join_external_parts import v2
+
+    errors = zvalidator._validate_join(v2)
+    assert len(errors) == 0


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Currently building a derivation with name=key name is disabled by validator. But there are Airbnb users using this to introduce key to their response body. So introduce this PR to remove the validation on derivation name = key name. 


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

Testing by local tests on compiler

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @pengyu-hou @donghanz 
