### PR TITLE
fix: combine default and step-specific settings

### DIFF
--- a/api/py/ai/chronon/repo/join_backfill.py
+++ b/api/py/ai/chronon/repo/join_backfill.py
@@ -106,7 +106,8 @@ class JoinBackfill:
         )
 
     def run_left_table(self, join_name: str):
-        settings = self.settings.get("left_table", self.settings["default"])
+        # Merge default settings and left_table settings
+        settings = {**self.settings["default"], **self.settings.get("left_table", {})}
         return (
             self.export_template(settings)
             + " && "
@@ -114,7 +115,8 @@ class JoinBackfill:
         )
 
     def run_final_join(self, join_name: str):
-        settings = self.settings.get("final_join", self.settings["default"])
+        # Merge default settings and final_join settings
+        settings = {**self.settings["default"], **self.settings.get("final_join", {})}
         return (
             self.export_template(settings)
             + " && "

--- a/api/py/ai/chronon/repo/join_backfill.py
+++ b/api/py/ai/chronon/repo/join_backfill.py
@@ -98,7 +98,8 @@ class JoinBackfill:
             "selected_join_parts": join_part,
             "use_cached_left": None,
         }
-        settings = self.settings.get(join_part, self.settings["default"])
+        # Merge default settings and join_part settings
+        settings = {**self.settings["default"], **self.settings.get(join_part, {})}
         return (
             self.export_template(settings)
             + " && "


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Combine default settings and step-specific settings in join backfill workflow. 

Example: user might input this, and the final step should use a combination what's in `final_table` and `default`, where `final_table` overrides `default`, but otherwise keeps everything from `default` 
```
{
    "default": {
        "spark_version": "3.1.1",
        "executor_memory": "4G",
        "driver_memory": "4G",
        "executor_cores": 2,
        "CHRONON_BACKFILL_BLOOMFILTER_THRESHOLD": 10000000, # Increase bloomfilter threshold for ad hoc runs
    },
    "final_table": {
        "executor_memory": "8G",
        "driver_memory": "8G",
        "SQL_ADAPTIVE_ENABLED": "false"
    }
}
```

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@yuli-han @donghanz 