### PR TITLE
Reuse extension method to collect query selects in DateRange

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -17,6 +17,7 @@
 package ai.chronon.spark
 
 import ai.chronon.aggregator.windowing.TsUtils
+import ai.chronon.api.Extensions.QueryOps
 import ai.chronon.api.{Constants, Query, QueryUtils}
 
 import scala.collection.JavaConverters._
@@ -103,7 +104,7 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
       whereClauses(partitionColumn) ++ queryOpt
         .flatMap(q => Option(q.wheres).map(_.asScala))
         .getOrElse(Seq.empty[String])
-    QueryUtils.build(selects = queryOpt.map { query => Option(query.selects).map(_.asScala.toMap).orNull }.orNull,
+    QueryUtils.build(selects = queryOpt.map(_.getQuerySelects).orNull,
                      from = table,
                      wheres = wheres,
                      fillIfAbsent = fillIfAbsent)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Reuses an existing extension method [`getQuerySelects`](https://github.com/airbnb/chronon/blob/89401221d0247aa126b1090adc77669fadfc3d8d/api/src/main/scala/ai/chronon/api/Extensions.scala#L1038) to collect query selects in `DataRange`.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Refactoring.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pengyu-hou @jbrooks-stripe 