### PR TITLE
[Metadata-Upload]Support passing configurable arguments dataset and batchSize for metadata upload job

### DIFF
--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -262,7 +262,7 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
       }
     }.toSeq
     val putsBatches = puts.grouped(batchSize).toSeq
-    logger.info(s"Putting ${puts.size} configs to KV Store, dataset=$datasetName")
+    logger.info(s"Putting ${puts.size} configs to KV Store, dataset=$datasetName, batchSize=$batchSize")
     val futures = putsBatches.map(batch => kvStore.multiPut(batch))
     Future.sequence(futures).map(_.flatten)
   }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -772,15 +772,27 @@ object Driver {
     class Args extends Subcommand("metadata-upload") with OnlineSubcommand {
       val confPath: ScallopOption[String] =
         opt[String](required = true, descr = "Path to the Chronon config file or directory")
+      val endPointName: ScallopOption[String] =
+        opt[String](required = false, descr = "Name of the endpoint to upload the metadata to")
+      val batchSize: ScallopOption[Int] =
+        opt[Int](required = false, descr = "Batch size for uploading metadata", default = Some(50))
     }
 
     def run(args: Args): Unit = {
-      val acceptedEndPoints = List(MetadataEndPoint.ConfByKeyEndPointName, MetadataEndPoint.NameByTeamEndPointName)
+      if (args.endPointName.isDefined) {
+        val acceptedEndPoints = List(args.endPointName())
+      } else {
+        val acceptedEndPoints = List(MetadataEndPoint.ConfByKeyEndPointName, MetadataEndPoint.NameByTeamEndPointName)
+      }
       val dirWalker = new MetadataDirWalker(args.confPath(), acceptedEndPoints)
       val kvMap: Map[String, Map[String, List[String]]] = dirWalker.run
       implicit val ec: ExecutionContext = ExecutionContext.global
       val putRequestsSeq: Seq[Future[scala.collection.Seq[Boolean]]] = kvMap.toSeq.map {
-        case (endPoint, kvMap) => args.metaDataStore.put(kvMap, endPoint)
+        case (endPoint, kvMap) => args.metaDataStore.put(
+          kVPairs = kvMap,
+          datasetName = endPoint,
+          batchSize = args.batchSize() if args.batchSize.isDefined else args.metaDataStore.CONF_BATCH_SIZE
+        )
       }
       val res = putRequestsSeq.flatMap(putRequests => Await.result(putRequests, 1.hour))
       logger.info(

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -788,15 +788,16 @@ object Driver {
       val kvMap: Map[String, Map[String, List[String]]] = dirWalker.run
       implicit val ec: ExecutionContext = ExecutionContext.global
       val putRequestsSeq: Seq[Future[scala.collection.Seq[Boolean]]] = kvMap.toSeq.map {
-        case (endPoint, kvMap) => if (args.batchSize.isDefined) {
+        case (endPoint, kvMap) =>
+          if (args.batchSize.isDefined) {
             args.metaDataStore.put(
-                kVPairs = kvMap,
-                datasetName = endPoint,
-                batchSize = args.batchSize()
+              kVPairs = kvMap,
+              datasetName = endPoint,
+              batchSize = args.batchSize()
             )
-        } else {
+          } else {
             args.metaDataStore.put(kVPairs = kvMap, datasetName = endPoint)
-        }
+          }
       }
       val res = putRequestsSeq.flatMap(putRequests => Await.result(putRequests, 1.hour))
       logger.info(


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Support passing configurable arguments dataset and batchSize for metadata upload job.
Currently the metadata upload job will upload the confByKey and confListByTeam metadata to k-v store with the default batch size 50 in a single job. This PR is to add two passing parameter, endPointName and batchSize. So that users can run different endpoint with different batch size based on the data volume. 

Sample usage:
`python3 ~/.local/bin/run.py --mode=metadata-upload  --conf production/group_bys/zipline_test/ --end-point-name ZIPLINE_METADATA --batch-size 10 --chronon-jar ~/test/chronon-embedded.jar --online-jar ~/test/online-all.jar | tee ~/test/metadata_upload.log`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @hzding621 
