### PR TITLE
Turn off sbt delta lake tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,36 +78,6 @@ jobs:
                   destination: spark_warehouse.tar.gz
                   when: on_fail
 
-    # run these separately as we need a isolated JVM to not have Spark session settings interfere with other runs
-    # long term goal is to refactor the current testing spark session builder and avoid adding new single test to CI
-    "Scala 13 -- Delta Lake Format Tests":
-      executor: docker_baseimg_executor
-      steps:
-        - checkout
-        - run:
-            name: Run Scala 13 tests for Delta Lake format
-            environment:
-              format_test: deltalake
-            shell: /bin/bash -leuxo pipefail
-            command: |
-              conda activate chronon_py
-              # Increase if we see OOM.
-              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
-              sbt '++ 2.13.6' "testOnly ai.chronon.spark.test.TableUtilsFormatTest"
-        - store_test_results:
-            path: /chronon/spark/target/test-reports
-        - store_test_results:
-            path: /chronon/aggregator/target/test-reports
-        - run:
-            name: Compress spark-warehouse
-            command: |
-              cd /tmp/ && tar -czvf spark-warehouse.tar.gz chronon/spark-warehouse
-            when: on_fail
-        - store_artifacts:
-            path: /tmp/spark-warehouse.tar.gz
-            destination: spark_warehouse.tar.gz
-            when: on_fail
-
     "Scala 11 -- Compile":
       executor: docker_baseimg_executor
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,6 @@ workflows:
             - "Scala 13 -- Tests":
                   requires:
                       - "Pull Docker Image"
-            - "Scala 13 -- Delta Lake Format Tests":
-                  requires:
-                    - "Pull Docker Image"
             - "Scalafmt Check":
                   requires:
                       - "Pull Docker Image"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Turn off delta lake tests in CI - We are seeing these tests flake out fairly often and they result in holding up the rest of our dev loops. We are exercising testing of the table utils path already (the Hive flow). We can explore enabling these on Spark 3.5 and when we're running tests on Bazel there. Isolation and Spark 3.5 are the only differences with our internal fork's setup that come to my mind and these tests have not been flaky on our end. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

