### PR TITLE
fix: reuse batch response max timestamp immediately 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -265,7 +265,10 @@ class FetcherBase(kvStore: KVStore,
     *
     * @param oldServingInfo The previous serving information before fetching the latest KV store data.
     * @param batchResponses the latest batch responses (either a fresh KV store response or a cached batch ir).
-    * @return the GroupByServingInfoParsed containing the latest serving information.
+    * @return A tuple that contains:
+    *  - the GroupByServingInfoParsed containing the latest serving information.
+    *  - the maximum ts from the batch IR responses. It will be later used for filtering the streaming rows after
+    *    this ts to avoid any potential duplicate records between the batch IR and streaming rows.
     */
   private[online] def getServingInfo(oldServingInfo: GroupByServingInfoParsed,
                                      batchResponses: BatchResponses): (GroupByServingInfoParsed, Option[Long]) = {

--- a/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherBaseTest.scala
@@ -159,7 +159,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
     val batchTimedValuesSuccess = Success(Seq(TimedValue(Array(1.toByte), 2000L)))
     val kvStoreBatchResponses = BatchResponses(batchTimedValuesSuccess)
 
-    val result = fetcherBase.getServingInfo(oldServingInfo, kvStoreBatchResponses)
+    val (result, _) = fetcherBase.getServingInfo(oldServingInfo, kvStoreBatchResponses)
 
     // updateServingInfo is called
     result shouldEqual updatedServingInfo
@@ -183,7 +183,7 @@ class FetcherBaseTest extends MockitoSugar with Matchers with MockitoHelper {
     doReturn(groupByOpsMock).when(oldServingInfo).groupByOps
 
     val cachedBatchResponses = BatchResponses(mock[FinalBatchIr])
-    val result = fetcherBase.getServingInfo(oldServingInfo, cachedBatchResponses)
+    val (result, _) = fetcherBase.getServingInfo(oldServingInfo, cachedBatchResponses)
 
     // FetcherBase.updateServingInfo is not called, but getGroupByServingInfo.refresh() is.
     result shouldEqual oldServingInfo


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

This change will immediately use the batch response's max timestamp in the lambda aggregation to exclude streaming rows that are before the timestamp, without waiting for groupBy serving info to get refreshed. 

Only the uncached flow is updated for now, because the (cached) batchIr objects currently don't include the timestamp, and change to this is left out of scope. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

When batch response's latest timestamp is later than GroupByServingInfo's end ts (which indicates staleness of GroupByServingInfo's staleness), the TTL cache is updated asynchronously, and occasionally can fail. In the meantime, the initial request will keep using stale end ts, causing the aggregation results to be wrong as extra streaming rows that should've been excluded is included. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

wip
## Checklist
- [ ] Documentation update

## Reviewers


@pengyu-hou @yuli-han 