### PR TITLE
Memoize reused time ranges

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Extensions.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Extensions.scala
@@ -64,6 +64,8 @@ object Extensions {
     val partitionRange: PartitionRange = PartitionRange(minPartition, maxPartition)
     val count: Long = partitionCounts.values.sum
 
+    lazy val timeRange: TimeRange = df.calculateTimeRange
+
     def prunePartitions(range: PartitionRange): Option[DfWithStats] = {
       println(
         s"Pruning down to new range $range, original range: $partitionRange." +
@@ -95,7 +97,7 @@ object Extensions {
 
     // This is safe to call on dataframes that are un-shuffled from their disk sources -
     // like tables read without shuffling with row level projections or filters.
-    def timeRange: TimeRange = {
+    def calculateTimeRange: TimeRange = {
       assert(
         df.schema(Constants.TimeColumn).dataType == LongType,
         s"Timestamp must be a Long type in milliseconds but found ${df.schema(Constants.TimeColumn).dataType}, if you are using a ts string, consider casting it with the UNIX_TIMESTAMP(ts)*1000 function."

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -283,7 +283,7 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
       .map { queriesUnfilteredDf.filter }
       .getOrElse(queriesUnfilteredDf.removeNulls(keyColumns))
 
-    val TimeRange(minQueryTs, maxQueryTs) = queryTimeRange.getOrElse(queriesDf.timeRange)
+    val TimeRange(minQueryTs, maxQueryTs) = queryTimeRange.getOrElse(queriesDf.calculateTimeRange)
     val hopsRdd = hopsAggregate(minQueryTs, resolution)
 
     def headStart(ts: Long): Long = TsUtils.round(ts, resolution.hopSizes.min)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -268,7 +268,7 @@ abstract class JoinBase(joinConf: api.Join,
     lazy val partitionRangeGroupBy = genGroupBy(unfilledRange)
 
     lazy val unfilledTimeRange = {
-      val timeRange = leftDf.timeRange
+      val timeRange = leftDfWithStats.get.timeRange
       logger.info(s"left unfilled time range: $timeRange")
       timeRange
     }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
* Memoize the calculation of timeRanges in DFWithStats.
  * Can't easily store state in implicit class DataframeOps
* Rename timeRange to calculateTimeRange to make clear there's work involved 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
When calculating the ts ranges for unfilled partitions, we often do the same work repeatedly.

Internally at Stripe this has resulted in multi-hour wallclock savings for certain apps.


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
Covered by existing tests. Been running in prod at Stripe for months.

## Checklist
- [ ] Documentation update

## Reviewers

