### PR TITLE
Update the join fetching exception metrics

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -622,8 +622,8 @@ class FetcherBase(kvStore: KVStore,
             val joinValuesTry = decomposedRequestsTry.map { groupByRequestsWithPrefix =>
               groupByRequestsWithPrefix.iterator.flatMap {
                 case Right(fetchException) => {
-                  val context = joinRequest.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching,
-                    joinRequest.name))
+                  val context =
+                    joinRequest.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching, joinRequest.name))
                   fetchException match {
                     case ex: KeyMissingException =>
                       context.increment("fetch_missing_key_failure.count")

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -589,7 +589,7 @@ class FetcherBase(kvStore: KVStore,
             Seq(Right(InvalidEntityException(request.name)))
           }
         }
-        request.copy(context = joinContext) -> decomposedTry
+        (request.copy(context = joinContext), decomposedTry)
       }
 
     val groupByRequests = joinDecomposed.flatMap {
@@ -597,17 +597,16 @@ class FetcherBase(kvStore: KVStore,
         val context = request.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching, request.name))
         gbTry match {
           case Failure(ex) => {
-            ex match {
-              case _: InvalidEntityException =>
-                context.increment("fetch_invalid_join_failure.count")
-              case _: KeyMissingException =>
-                context.increment("fetch_missing_key_failure.count")
-              case _: Exception =>
-                context.increment("fetch_join_failure.count")
-            }
-            Iterator.empty
+            case _: InvalidEntityException =>
+              context.increment("fetch_invalid_join_failure.count")
+            case _: KeyMissingException =>
+              context.increment("fetch_missing_key_failure.count")
+            case _: Exception =>
+              context.increment("fetch_join_failure.count")
           }
-          case Success(requests) => requests.iterator.flatMap(_.left.toOption).map(_.request)
+          case Success(requests) => {
+            requests.iterator.flatMap(_.left.toOption).map(_.request)
+          }
         }
     }
 
@@ -622,6 +621,14 @@ class FetcherBase(kvStore: KVStore,
             val joinValuesTry = decomposedRequestsTry.map { groupByRequestsWithPrefix =>
               groupByRequestsWithPrefix.iterator.flatMap {
                 case Right(fetchException) => {
+                  val context = joinRequest.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching,
+                    joinRequest.name))
+                  fetchException match {
+                    case ex: KeyMissingException =>
+                      context.increment("fetch_missing_key_failure.count")
+                    case ex: Exception =>
+                      context.incrementException(ex)
+                  }
                   Map(fetchException.getRequestName + "_exception" -> fetchException.getMessage)
                 }
                 case Left(PrefixedRequest(prefix, groupByRequest)) => {

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -597,7 +597,7 @@ class FetcherBase(kvStore: KVStore,
             Seq(Right(InvalidEntityException(request.name)))
           }
         }
-        (request.copy(context = joinContext), decomposedTry)
+        request.copy(context = joinContext) -> decomposedTry
       }
 
     val groupByRequests = joinDecomposed.flatMap {

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -608,6 +608,7 @@ class FetcherBase(kvStore: KVStore,
             Iterator.empty
           }
           case Success(requests) => requests.iterator.flatMap(_.left.toOption).map(_.request)
+        }
     }
 
     val groupByResponsesFuture = fetchGroupBys(groupByRequests)

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -593,16 +593,17 @@ class FetcherBase(kvStore: KVStore,
       }
 
     val groupByRequests = joinDecomposed.flatMap {
-      case (_, gbTry) =>
+      case (request, gbTry) =>
+        val context = request.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching, request.name))
         gbTry match {
           case Failure(ex) => {
             ex match {
               case _: InvalidEntityException =>
-                Metrics.Context(Metrics.Environment.JoinFetching).increment("fetch_invalid_join_failure.count")
+                context.increment("fetch_invalid_join_failure.count")
               case _: KeyMissingException =>
-                Metrics.Context(Metrics.Environment.JoinFetching).increment("fetch_missing_key_failure.count")
+                context.increment("fetch_missing_key_failure.count")
               case _: Exception =>
-                Metrics.Context(Metrics.Environment.JoinFetching).increment("fetch_join_failure.count")
+                context.increment("fetch_join_failure.count")
             }
             Iterator.empty
           }

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -597,17 +597,17 @@ class FetcherBase(kvStore: KVStore,
         val context = request.context.getOrElse(Metrics.Context(Metrics.Environment.JoinFetching, request.name))
         gbTry match {
           case Failure(ex) => {
-            case _: InvalidEntityException =>
-              context.increment("fetch_invalid_join_failure.count")
-            case _: KeyMissingException =>
-              context.increment("fetch_missing_key_failure.count")
-            case _: Exception =>
-              context.increment("fetch_join_failure.count")
+            ex match {
+              case _: InvalidEntityException =>
+                context.increment("fetch_invalid_join_failure.count")
+              case _: KeyMissingException =>
+                context.increment("fetch_missing_key_failure.count")
+              case _: Exception =>
+                context.increment("fetch_join_failure.count")
+            }
+            Iterator.empty
           }
-          case Success(requests) => {
-            requests.iterator.flatMap(_.left.toOption).map(_.request)
-          }
-        }
+          case Success(requests) => requests.iterator.flatMap(_.left.toOption).map(_.request)
     }
 
     val groupByResponsesFuture = fetchGroupBys(groupByRequests)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Currently the join fetching exception metrics are not recorded correctly. `Metrics.Context(Metrics.Environment.JoinFetching)` doesn't include the join name so the exception is not recorded on join level. 

The PR changes the behaviors for two types of exceptions:
1. InvalidEntityException is handled on join level, the PR updates the metric context to add join name.
2. MissingKeyException is handled on join part level, the PR updates the metric context to add join name(not group by name).

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
Testing the missing key exception:
`python3 ~/.local/bin/run.py --mode=fetch  --name zipline_test/iceberg_realtime.v0 -k '{"name":null}' -t join --chronon-jar ~/test/chronon-embedded.jar --online-jar ~/test/online-all.jar | tee ~/test/fetch.log`

Fetched result:
<img width="716" alt="image" src="https://github.com/user-attachments/assets/f25f2d13-8d11-44b0-91b7-5c6c3f553af4" />

metrics:
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/8d6e0218-86eb-4811-85f6-6d7979c90175" />


- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @pengyu-hou 
