### PR TITLE
Make fetcher thread pool separate and pluggable 

### DIFF
--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -24,6 +24,7 @@ import scala.collection.Iterator;
 import scala.collection.Seq;
 import scala.Option;
 import scala.collection.mutable.ArrayBuffer;
+import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 
 import java.util.ArrayList;
@@ -36,15 +37,15 @@ public class JavaFetcher {
     Fetcher fetcher;
 
     public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry, String callerName, Boolean disableErrorThrows) {
-        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, null, disableErrorThrows);
+        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, null, disableErrorThrows, null);
     }
 
     public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
-        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, null, null, false);
+        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, null, null, false, null);
     }
 
     public JavaFetcher(KVStore kvStore, String metaDataSet, Long timeoutMillis, Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry, String callerName, FlagStore flagStore, Boolean disableErrorThrows) {
-        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, flagStore, disableErrorThrows);
+        this.fetcher = new Fetcher(kvStore, metaDataSet, timeoutMillis, logFunc, false, registry, callerName, flagStore, disableErrorThrows, null);
     }
 
     /* user builder pattern to create JavaFetcher
@@ -64,7 +65,8 @@ public class JavaFetcher {
                 builder.registry,
                 builder.callerName,
                 builder.flagStore,
-                builder.disableErrorThrows);
+                builder.disableErrorThrows,
+                builder.executionContextOverride);
     }
 
     public static class Builder {
@@ -77,6 +79,7 @@ public class JavaFetcher {
         private Boolean debug;
         private FlagStore flagStore;
         private Boolean disableErrorThrows;
+        private ExecutionContext executionContextOverride;
 
         public Builder(KVStore kvStore, String metaDataSet, Long timeoutMillis,
                        Consumer<LoggableResponse> logFunc, ExternalSourceRegistry registry) {
@@ -104,6 +107,11 @@ public class JavaFetcher {
 
         public Builder debug(Boolean debug) {
             this.debug = debug;
+            return this;
+        }
+
+        public Builder executionContextOverride(ExecutionContext executionContextOverride) {
+            this.executionContextOverride = executionContextOverride;
             return this;
         }
 

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -35,7 +35,7 @@ import java.util.function.Consumer
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, mutable}
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Random, Success, Try}
 
 object Fetcher {
@@ -85,8 +85,15 @@ class Fetcher(val kvStore: KVStore,
               val externalSourceRegistry: ExternalSourceRegistry = null,
               callerName: String = null,
               flagStore: FlagStore = null,
-              disableErrorThrows: Boolean = false)
-    extends FetcherBase(kvStore, metaDataSet, timeoutMillis, debug, flagStore, disableErrorThrows) {
+              disableErrorThrows: Boolean = false,
+              executionContextOverride: ExecutionContext = null)
+    extends FetcherBase(kvStore,
+                        metaDataSet,
+                        timeoutMillis,
+                        debug,
+                        flagStore,
+                        disableErrorThrows,
+                        executionContextOverride) {
   private def reportCallerNameFetcherVersion(): Unit = {
     val message = s"CallerName: ${Option(callerName).getOrElse("N/A")}, FetcherVersion: ${BuildInfo.version}"
     val ctx = Metrics.Context(Environment.Fetcher)

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -32,7 +32,7 @@ import com.google.gson.Gson
 import java.util
 import scala.collection.JavaConverters._
 import scala.collection.Seq
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 // Does internal facing fetching
@@ -44,8 +44,9 @@ class FetcherBase(kvStore: KVStore,
                   timeoutMillis: Long = 10000,
                   debug: Boolean = false,
                   flagStore: FlagStore = null,
-                  disableErrorThrows: Boolean = false)
-    extends MetadataStore(kvStore, metaDataSet, timeoutMillis)
+                  disableErrorThrows: Boolean = false,
+                  executionContextOverride: ExecutionContext = null)
+    extends MetadataStore(kvStore, metaDataSet, timeoutMillis, executionContextOverride)
     with FetcherCache {
   import FetcherBase._
 

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -37,7 +37,10 @@ import scala.util.{Failure, Success, Try}
 // [timestamp -> {metric name -> metric value}]
 case class DataMetrics(series: Seq[(Long, SortedMap[String, Any])])
 
-class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, timeoutMillis: Long) {
+class MetadataStore(kvStore: KVStore,
+                    val dataset: String = ChrononMetadataKey,
+                    timeoutMillis: Long,
+                    executionContextOverride: ExecutionContext = null) {
   @transient implicit lazy val logger = LoggerFactory.getLogger(getClass)
   private var partitionSpec = PartitionSpec(format = "yyyy-MM-dd", spanMillis = WindowUtils.Day.millis)
   private val CONF_BATCH_SIZE = 50
@@ -52,7 +55,8 @@ class MetadataStore(kvStore: KVStore, val dataset: String = ChrononMetadataKey, 
     partitionSpec = PartitionSpec(format = format, spanMillis = partitionSpec.spanMillis)
   }
 
-  implicit val executionContext: ExecutionContext = kvStore.executionContext
+  implicit val executionContext: ExecutionContext =
+    Option(executionContextOverride).getOrElse(FlexibleExecutionContext.buildExecutionContext)
 
   def getConf[T <: TBase[_, _]: Manifest](confPathOrName: String): Try[T] = {
     val clazz = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Currently Fetcher and KVStore share the same execution context:  

```
// MetadataStore.scala
implicit val executionContext: ExecutionContext = kvStore.executionContext
```

This could lead to potential deadlock if when TTLCache (e.g. called by Fetcher => getGroupByServingInfo) is trying to initiate kvStore requests to refresh cache but the thread pool is already exhausted. 

This PR 
* updates executionContext in MetadataStore (which FetcherBase/Fetcher extends) to a separate one
* allows pass in from Fetcher initialization so can be customized by users. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pengyu-hou @pkundurthy 
cc @sup @nikhil-zlai thx both for the help investigating this

