### PR TITLE
Set team name for inline modules

### DIFF
--- a/api/py/ai/chronon/repo/extract_objects.py
+++ b/api/py/ai/chronon/repo/extract_objects.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,20 +21,15 @@ import os
 from ai.chronon.logger import get_logger
 
 
-def from_folder(root_path: str,
-                full_path: str,
-                cls: type,
-                log_level=logging.INFO):
+def from_folder(root_path: str, full_path: str, cls: type, log_level=logging.INFO):
     """
     Recursively consumes a folder, and constructs a map
     Creates a map of object qualifier to
     """
-    if full_path.endswith('/'):
+    if full_path.endswith("/"):
         full_path = full_path[:-1]
 
-    python_files = glob.glob(
-        os.path.join(full_path, "**/*.py"),
-        recursive=True)
+    python_files = glob.glob(os.path.join(full_path, "**/*.py"), recursive=True)
     result = {}
     for f in python_files:
         try:
@@ -44,6 +38,13 @@ def from_folder(root_path: str,
             logging.error(f"Failed to extract: {f}")
             logging.exception(e)
     return result
+
+
+def import_module_set_all_teams(module):
+    for name, obj in list(module.__dict__.items()):
+        if hasattr(obj, "metaData") and hasattr(obj.metaData, "team"):
+            obj.metaData.team = module.__name__.split(".")[1]
+    return module
 
 
 def import_module_set_name(module, cls):
@@ -59,23 +60,22 @@ def import_module_set_name(module, cls):
     return module
 
 
-def from_file(root_path: str,
-              file_path: str,
-              cls: type,
-              log_level=logging.INFO):
+def from_file(root_path: str, file_path: str, cls: type, log_level=logging.INFO):
     logger = get_logger(log_level)
-    logger.debug(
-        "Loading objects of type {cls} from {file_path}".format(**locals()))
+    logger.debug("Loading objects of type {cls} from {file_path}".format(**locals()))
     # mod_qualifier includes team name and python script name without `.py`
     # this line takes the full file path as input, strips the root path on the left side
     # strips `.py` on the right side and finally replaces the slash sign to dot
     # eg: the output would be `team_name.python_script_name`
-    mod_qualifier = file_path[len(root_path.rstrip('/')) + 1:-3].replace("/", ".")
+    mod_qualifier = file_path[len(root_path.rstrip("/")) + 1 : -3].replace("/", ".")
     mod = importlib.import_module(mod_qualifier)
 
     # the key of result dict would be `team_name.python_script_name.[group_by_name|join_name|staging_query_name]`
     # real world case: psx.reservation_status.v1
     import_module_set_name(mod, cls)
+    # set team name for inline modules. E.g, a GroupBy could be declared within a Join module.
+    import_module_set_all_teams(mod)
+
     result = {}
 
     for obj in [o for o in mod.__dict__.values() if isinstance(o, cls)]:

--- a/api/py/ai/chronon/repo/extract_objects.py
+++ b/api/py/ai/chronon/repo/extract_objects.py
@@ -70,7 +70,7 @@ def from_file(root_path: str, file_path: str, cls: type, log_level=logging.INFO)
     mod = importlib.import_module(mod_qualifier)
 
     # get inline group_bys
-    inline_group_bys = [k for k in mod.__dict__.values() if isinstance(k, GroupBy)]
+    inline_group_bys = [k for k in mod.__dict__.values() if isinstance(k, GroupBy)] if cls == Join else None
 
     # the key of result dict would be `team_name.python_script_name.[group_by_name|join_name|staging_query_name]`
     # real world case: psx.reservation_status.v1

--- a/api/py/test/sample/joins/unit_test/user/sample_join_inline_group_by.py
+++ b/api/py/test/sample/joins/unit_test/user/sample_join_inline_group_by.py
@@ -1,0 +1,37 @@
+#     Copyright (C) 2023 The Chronon Authors.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from ai.chronon.group_by import Aggregation, GroupBy, Operation
+from ai.chronon.join import Join, JoinPart
+from sources import test_sources
+
+inline_group_by = GroupBy(
+    name="unit_test.user_inline_group_by",
+    sources=test_sources.event_source,
+    keys=["group_by_subject"],
+    aggregations=[
+        Aggregation(input_column="event", operation=Operation.SUM),
+    ],
+    online=True,
+)
+
+v1 = Join(
+    left=test_sources.event_source,
+    right_parts=[
+        JoinPart(
+            group_by=inline_group_by,
+            key_mapping={"subject": "group_by_subject"},
+        ),
+    ],
+)

--- a/api/py/test/sample/production/group_bys/unit_test/user_inline_group_by
+++ b/api/py/test/sample/production/group_bys/unit_test/user_inline_group_by
@@ -1,0 +1,42 @@
+{
+  "metaData": {
+    "name": "unit_test.user_inline_group_by",
+    "online": 1,
+    "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "offlineSchedule": "@daily"
+  },
+  "sources": [
+    {
+      "events": {
+        "table": "sample_namespace.sample_table_group_by",
+        "query": {
+          "selects": {
+            "event": "event_expr",
+            "group_by_subject": "group_by_expr"
+          },
+          "startPartition": "2021-04-09",
+          "timeColumn": "ts",
+          "setups": []
+        }
+      }
+    }
+  ],
+  "keyColumns": [
+    "group_by_subject"
+  ],
+  "aggregations": [
+    {
+      "inputColumn": "event",
+      "operation": 7,
+      "argMap": {}
+    }
+  ]
+}

--- a/api/py/test/sample/production/joins/unit_test/user.sample_join_inline_group_by.v1
+++ b/api/py/test/sample/production/joins/unit_test/user.sample_join_inline_group_by.v1
@@ -1,0 +1,78 @@
+{
+  "metaData": {
+    "name": "unit_test.user.sample_join_inline_group_by.v1",
+    "online": 0,
+    "production": 0,
+    "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
+    "dependencies": [
+      "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+    ],
+    "tableProperties": {
+      "source": "chronon"
+    },
+    "outputNamespace": "default",
+    "team": "unit_test",
+    "samplePercent": 100.0,
+    "offlineSchedule": "@daily"
+  },
+  "left": {
+    "events": {
+      "table": "sample_namespace.sample_table_group_by",
+      "query": {
+        "selects": {
+          "event": "event_expr",
+          "group_by_subject": "group_by_expr",
+          "ts": "ts"
+        },
+        "startPartition": "2021-04-09",
+        "timeColumn": "ts",
+        "setups": []
+      }
+    }
+  },
+  "joinParts": [
+    {
+      "groupBy": {
+        "metaData": {
+          "name": "unit_test.user_inline_group_by",
+          "online": 1,
+          "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
+          "dependencies": [
+            "{\"name\": \"wait_for_sample_namespace.sample_table_group_by_ds\", \"spec\": \"sample_namespace.sample_table_group_by/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+          ],
+          "team": "user",
+          "offlineSchedule": "@daily"
+        },
+        "sources": [
+          {
+            "events": {
+              "table": "sample_namespace.sample_table_group_by",
+              "query": {
+                "selects": {
+                  "event": "event_expr",
+                  "group_by_subject": "group_by_expr"
+                },
+                "startPartition": "2021-04-09",
+                "timeColumn": "ts",
+                "setups": []
+              }
+            }
+          }
+        ],
+        "keyColumns": [
+          "group_by_subject"
+        ],
+        "aggregations": [
+          {
+            "inputColumn": "event",
+            "operation": 7,
+            "argMap": {}
+          }
+        ]
+      },
+      "keyMapping": {
+        "subject": "group_by_subject"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adjust team name for inline modules.
For inline modules, like a GroupBy inside a Join, we need to set the correct team name for the GroupBy using the module name.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 
