### PR TITLE
fix: improve bootstrap failure error message

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -161,9 +161,9 @@ class Join(joinConf: api.Join,
           if (hashes.exists(hash => !bootstrapInfo.hashToSchema.contains(hash))) {
             logger.error(s"""Bootstrap table contains out-of-date metadata and should be cleaned up.
                  |This is most likely caused by bootstrap table not properly archived during schema evolution. The semantic_hash may have been manually cleared to skip this.
-                 |Please remove old data from bootstrap table for this partition range.
+                 |Please manually archive the old bootstrap table and re-run.
                  |
-                 |${leftRange.partitions.map(ds => s"ALTER TABLE ${bootstrapTable} DROP IF EXISTS PARTITION (ds='${ds}')").mkString("\n")}
+                 |ALTER TABLE ${bootstrapTable} RENAME TO ${bootstrapTable}_<timestamp_suffix>;
                  |""".stripMargin)
             throw new IllegalStateException("Bootstrap table contains out-of-date metadata and should be cleaned up.")
           }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

improve error message when join job fails to parse `matched_hash` from bootstrap table, likely because bootstrap table is out dated, not cleaned up because user unset and skipped semantic_hash. 

instead of automatic recovery, for now just print a message to ask user to manually clean up the bootstrap table to be more safe.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

improve error message readability


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pallavia7 