### PR TITLE
[BugFix][Airflow] Scheduled join/groupbys should be airflow execution date 

### DIFF
--- a/airflow/helpers.py
+++ b/airflow/helpers.py
@@ -233,6 +233,12 @@ def get_extra_args(mode, conf_type, common_env, conf):
         args.update({
             "online-jar-fetch": os.path.join(constants.CHRONON_PATH, "scripts/fetch_online_staging_jar.py"),
         })
+    if conf_type in ("joins", "group_bys"):
+        # Default in run.py is ds=today for adhoc runs,
+        # but use deterministic date from airflow execution date in Airflow schedule
+        args.update({
+            "ds": "{{ ds }}",
+        })
     return args
 
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Currently, when scheduling join/groupbys the end-date will wall-clock date airflow run:
https://github.com/airbnb/chronon/blob/efdb0dba0ffe76204d8e0d1ad211265b8da88c0d/api/py/ai/chronon/repo/run.py#L533-L539
- This PR passes `ds` from airflow to be its execution date

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- When running groupby upload, when data partition of source of date T lands on early T+1  for airflow execution T,
we wants the end date to be of that airflow execution T by {{ ds }}, not the current default wall-clock date of T+1

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
```
>> print(ChrononOperator(
    conf_path="joins/quickstart/example_checkout_features.v1",
    mode="backfill",
    repo="test/repo",
    conf_type=conf_type,
    extra_args=get_extra_args(mode="backfill", conf_type=conf_type, common_env={}, conf={"metaData": {"team": "foo"}}),
    task_id="foo",
    params={"production": True, "team": "mickj", "name": "test"},
).bash_command)

python3 run.py --version=0.0.20 --mode=backfill --conf=test/repo/joins/quickstart/example_checkout_features.v1 --ds {{ ds }} 

```

## Checklist
- [ ] Documentation update

## Reviewers

