### PR TITLE
Support query-level custom partition column

### DIFF
--- a/api/py/ai/chronon/query.py
+++ b/api/py/ai/chronon/query.py
@@ -25,6 +25,7 @@ def Query(
     setups: List[str] = [],
     mutation_time_column: str = None,
     reversal_column: str = None,
+    partition_column: str = None,
 ) -> api.Query:
     """
     Create a query object that is used to scan data from various data sources.
@@ -68,7 +69,11 @@ def Query(
         inserts only have is_before = false (just the new value).
         deletes only have is_before = true (just the old value).
         This is not necessary for event sources.
-    :param reversal_column: str, optional (defaults to "is_before")
+    :type reversal_column: str, optional (defaults to "is_before")
+    :param partition_column: str, optional
+        Name of date partition column for the source table (not an expression derived from other columns)
+        Default value is "ds". This name does not concern the output table partitioning column.
+    :type partition_column: str, optional
     :return: A Query object that Chronon can use to scan just the necessary data efficiently.
     """
     return api.Query(
@@ -80,6 +85,7 @@ def Query(
         setups,
         mutation_time_column,
         reversal_column,
+        partition_column,
     )
 
 

--- a/api/src/main/scala/ai/chronon/api/Builders.scala
+++ b/api/src/main/scala/ai/chronon/api/Builders.scala
@@ -45,7 +45,8 @@ object Builders {
               timeColumn: String = null,
               setups: Seq[String] = null,
               mutationTimeColumn: String = null,
-              reversalColumn: String = null): Query = {
+              reversalColumn: String = null,
+              partitionColumn: String = null): Query = {
       val result = new Query()
       if (selects != null)
         result.setSelects(selects.toJava)
@@ -58,6 +59,7 @@ object Builders {
         result.setSetups(setups.toJava)
       result.setMutationTimeColumn(mutationTimeColumn)
       result.setReversalColumn(reversalColumn)
+      result.setPartitionColumn(partitionColumn)
       result
     }
   }

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -433,7 +433,6 @@ object Extensions {
       query.unsetStartPartition()
       newSource
     }
-
   }
 
   implicit class GroupByOps(groupBy: GroupBy) extends GroupBy(groupBy) {

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -643,12 +643,10 @@ object Extensions {
     }
 
     def getPartitionColumn: Option[String] = {
-      val partitionColumns = groupBy.sources.toScala.map(_.partitionColumnOpt).collect {
-        case Some(c) => c
-      }
+      val partitionColumns = groupBy.sources.toScala.flatMap(_.partitionColumnOpt).distinct
       if (partitionColumns.isEmpty) {
         None
-      } else if (partitionColumns.length == groupBy.sources.size()) {
+      } else if (partitionColumns.length == 1) {
         partitionColumns.headOption
       } else {
         throw new IllegalArgumentException(

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -336,7 +336,7 @@ object Extensions {
     def tableToPartitionColumn: Map[String, String] = {
       partitionColumnOpt match {
         case Some(col) => Map(table -> col)
-        case None => Map.empty
+        case None      => Map.empty
       }
     }
 

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -329,6 +329,17 @@ object Extensions {
       }
     }
 
+    def partitionColumnOpt: Option[String] = {
+      Option(source.query.partitionColumn)
+    }
+
+    def tableToPartitionColumn: Map[String, String] = {
+      partitionColumnOpt match {
+        case Some(col) => Map(table -> col)
+        case None => Map.empty
+      }
+    }
+
     lazy val rootTable: String = {
       if (source.isSetEntities) {
         source.getEntities.getSnapshotTable
@@ -630,7 +641,6 @@ object Extensions {
         case DataModel.Events   => Seq(s"$timeColumn is NOT NULL")
       }
     }
-
   }
 
   implicit class StringOps(string: String) {

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -644,14 +644,11 @@ object Extensions {
 
     def getPartitionColumn: Option[String] = {
       val partitionColumns = groupBy.sources.toScala.flatMap(_.partitionColumnOpt).distinct
-      if (partitionColumns.isEmpty) {
-        None
-      } else if (partitionColumns.length == 1) {
-        partitionColumns.headOption
-      } else {
-        throw new IllegalArgumentException(
-          s"Expect all queries from a given group-by to have the same partition column. All sources should have identical schemas and same partition column name. Found distinct partition columns $partitionColumns for group-by ${groupBy.metaData.name}")
-      }
+      require(
+        partitionColumns.length < 2,
+        s"Expect all queries from a given group-by to have the same partition column. All sources should have identical schemas and same partition column name. Found distinct partition columns $partitionColumns for group-by ${groupBy.metaData.name}"
+      )
+      partitionColumns.headOption
     }
   }
 

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -13,6 +13,7 @@ struct Query {
     6: optional list<string> setups = []
     7: optional string mutationTimeColumn
     8: optional string reversalColumn
+    9: optional string partitionColumn
 }
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
-import sbt.Keys.*
+import sbt.Keys._
 import sbt.Test
 
 import scala.io.StdIn
-import scala.sys.process.*
-import complete.DefaultParsers.*
-
-import scala.collection.Seq
+import scala.sys.process._
+import complete.DefaultParsers._
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.12"
@@ -16,8 +14,6 @@ lazy val spark3_2_1 = "3.2.1"
 lazy val spark3_5_3 = "3.5.3"
 lazy val tmp_warehouse = "/tmp/chronon/"
 
-ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
-ThisBuild / scalacOptions ++= Seq("-target:jvm-1.8")
 ThisBuild / organization := "ai.chronon"
 ThisBuild / organizationName := "chronon"
 ThisBuild / scalaVersion := scala212

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
-import sbt.Keys._
+import sbt.Keys.*
 import sbt.Test
 
 import scala.io.StdIn
-import scala.sys.process._
-import complete.DefaultParsers._
+import scala.sys.process.*
+import complete.DefaultParsers.*
+
+import scala.collection.Seq
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.12"
@@ -14,6 +16,8 @@ lazy val spark3_2_1 = "3.2.1"
 lazy val spark3_5_3 = "3.5.3"
 lazy val tmp_warehouse = "/tmp/chronon/"
 
+ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+ThisBuild / scalacOptions ++= Seq("-target:jvm-1.8")
 ThisBuild / organization := "ai.chronon"
 ThisBuild / organizationName := "chronon"
 ThisBuild / scalaVersion := scala212

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -297,7 +297,8 @@ class Analyzer(tableUtils: TableUtils,
       val leftDf: DataFrame = range.scanQueryDf(leftQuery,
                                                 joinConf.left.table,
                                                 fillIfAbsent = Map(partitionColumn -> null),
-                                                partitionColOpt = Some(partitionColumn))
+                                                partitionColOpt = Some(partitionColumn),
+                                                renamePartitionCol = true)
       (analysis, leftDf)
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -294,11 +294,10 @@ class Analyzer(tableUtils: TableUtils,
       val analysis = ""
       val leftQuery = joinConf.left.query
       val partitionColumn = tableUtils.getPartitionColumn(leftQuery)
-      val scanQuery = range.genScanQuery(leftQuery,
-                                         joinConf.left.table,
-                                         fillIfAbsent = Map(partitionColumn -> null),
-                                         partitionColumn = partitionColumn)
-      val leftDf: DataFrame = tableUtils.sqlWithDefaultPartitionColumn(scanQuery, partitionColumn)
+      val leftDf: DataFrame = range.scanQueryDf(leftQuery,
+                                                joinConf.left.table,
+                                                fillIfAbsent = Map(partitionColumn -> null),
+                                                partitionColOpt = Some(partitionColumn))
       (analysis, leftDf)
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -298,7 +298,7 @@ class Analyzer(tableUtils: TableUtils,
                                          joinConf.left.table,
                                          fillIfAbsent = Map(partitionColumn -> null),
                                          partitionColumn = partitionColumn)
-      val leftDf: DataFrame = tableUtils.sql(scanQuery)
+      val leftDf: DataFrame = tableUtils.sqlWithDefaultPartitionColumn(scanQuery, partitionColumn)
       (analysis, leftDf)
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -309,7 +309,7 @@ class Analyzer(tableUtils: TableUtils,
         }
       }.toSet
       val leftNoAccessTables =
-        runTablePermissionValidation(Set(joinConf.left.table), Option(joinConf.left.query.partitionColumn))
+        runTablePermissionValidation(Set(joinConf.left.table), joinConf.left.partitionColumnOpt)
       rightNoAccessTables ++ leftNoAccessTables
     } else Set.empty
 

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -85,13 +85,12 @@ object BootstrapInfo {
       .map(part => {
         // set computeDependency to False as we compute dependency upstream
         val gb = GroupBy.from(part.groupBy, range, tableUtils, computeDependency)
-        val partitionColumn = tableUtils.getPartitionColumn(part.groupBy.getPartitionColumn)
         val keySchema = SparkConversions
           .toChrononSchema(gb.keySchema)
           .map(field => StructField(part.rightToLeft(field._1), field._2))
 
         val keyAndPartitionFields =
-          gb.keySchema.fields ++ Seq(org.apache.spark.sql.types.StructField(partitionColumn, StringType))
+          gb.keySchema.fields ++ Seq(org.apache.spark.sql.types.StructField(tableUtils.partitionColumn, StringType))
         // todo: this change is only valid for offline use case
         // we need to revisit logic for the logging part to make sure the derived columns are also logged
         // to make bootstrap continue to work
@@ -203,7 +202,7 @@ object BootstrapInfo {
         val partitionColumn = tableUtils.getPartitionColumn(part.query)
         val bootstrapQuery =
           range.genScanQuery(part.query, part.table, Map(partitionColumn -> null), partitionColumn = partitionColumn)
-        val bootstrapDf = tableUtils.sql(bootstrapQuery).withColumnRenamed(partitionColumn, tableUtils.partitionColumn)
+        val bootstrapDf = tableUtils.sqlWithDefaultPartitionColumn(bootstrapQuery, partitionColumn)
         val schema = bootstrapDf.schema
         val missingKeys = part.keys(joinConf, tableUtils.partitionColumn).filterNot(schema.fieldNames.contains)
         collectException(

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -177,8 +177,7 @@ object BootstrapInfo {
       .foreach(part => {
         // practically there should only be one logBootstrapPart per Join, but nevertheless we will loop here
         val schema = tableUtils.getSchemaFromTable(part.table)
-        val partitionColumn = tableUtils.getPartitionColumn(part.query)
-        val missingKeys = part.keys(joinConf, partitionColumn).filterNot(schema.fieldNames.contains)
+        val missingKeys = part.keys(joinConf, tableUtils.partitionColumn).filterNot(schema.fieldNames.contains)
         collectException(
           assert(
             missingKeys.isEmpty,
@@ -199,12 +198,8 @@ object BootstrapInfo {
     val tableHashes = tableBootstrapParts
       .map(part => {
         val range = PartitionRange(part.startPartition, part.endPartition)(tableUtils)
-        val partitionColumn = tableUtils.getPartitionColumn(part.query)
         val (bootstrapQuery, bootstrapDf) =
-          range.scanQueryStringAndDf(part.query,
-                                     part.table,
-                                     fillIfAbsent = Map(partitionColumn -> null),
-                                     partitionColOpt = Some(partitionColumn))
+          range.scanQueryStringAndDf(part.query, part.table, fillIfAbsent = Map(tableUtils.partitionColumn -> null))
         val schema = bootstrapDf.schema
         val missingKeys = part.keys(joinConf, tableUtils.partitionColumn).filterNot(schema.fieldNames.contains)
         collectException(

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -200,9 +200,11 @@ object BootstrapInfo {
       .map(part => {
         val range = PartitionRange(part.startPartition, part.endPartition)(tableUtils)
         val partitionColumn = tableUtils.getPartitionColumn(part.query)
-        val bootstrapQuery =
-          range.genScanQuery(part.query, part.table, Map(partitionColumn -> null), partitionColumn = partitionColumn)
-        val bootstrapDf = tableUtils.sqlWithDefaultPartitionColumn(bootstrapQuery, partitionColumn)
+        val (bootstrapQuery, bootstrapDf) =
+          range.scanQueryStringAndDf(part.query,
+                                     part.table,
+                                     fillIfAbsent = Map(partitionColumn -> null),
+                                     partitionColOpt = Some(partitionColumn))
         val schema = bootstrapDf.schema
         val missingKeys = part.keys(joinConf, tableUtils.partitionColumn).filterNot(schema.fieldNames.contains)
         collectException(

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -198,6 +198,7 @@ object BootstrapInfo {
     val tableHashes = tableBootstrapParts
       .map(part => {
         val range = PartitionRange(part.startPartition, part.endPartition)(tableUtils)
+        // TODO: get query from
         val bootstrapQuery = range.genScanQuery(part.query, part.table, Map(tableUtils.partitionColumn -> null))
         val bootstrapDf = tableUtils.sql(bootstrapQuery)
         val schema = bootstrapDf.schema

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -100,7 +100,7 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
                    fillIfAbsent: Map[String, String] = Map.empty,
                    partitionColumn: String = tableUtils.partitionColumn): String = {
     val queryOpt = Option(query)
-    val partitionColumnName = queryOpt.map(_.getPartitionColumn).getOrElse(partitionColumn)
+    val partitionColumnName = queryOpt.flatMap(q => Option(q.getPartitionColumn)).getOrElse(partitionColumn)
     val wheres =
       whereClauses(partitionColumnName) ++ queryOpt
         .flatMap(q => Option(q.wheres).map(_.asScala))

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -118,7 +118,7 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
   private def genScanQuery(query: Query,
                            table: String,
                            fillIfAbsent: Map[String, String] = Map.empty,
-                           partitionColumn: String = tableUtils.partitionColumn): String = {
+                           partitionColumn: String): String = {
     // Because we allow query to specify custom partition column,
     // it is not safe to use this method independently without renaming the column
     // to the standard one. If you want to test gen query, use `scanQueryStringAndDf` instead.

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -100,7 +100,10 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
                    fillIfAbsent: Map[String, String] = Map.empty,
                    partitionColumn: String = tableUtils.partitionColumn): String = {
     val queryOpt = Option(query)
-    val partitionCol = queryOpt.flatMap(q => Option(q.getPartitionColumn)).getOrElse(partitionColumn)
+    val partitionCol = queryOpt match {
+      case Some(q) => Option(q.getPartitionColumn).getOrElse(partitionColumn)
+      case None    => partitionColumn
+    }
     val wheres =
       whereClauses(partitionCol) ++ queryOpt
         .flatMap(q => Option(q.wheres).map(_.asScala))

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -100,9 +100,9 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
                    fillIfAbsent: Map[String, String] = Map.empty,
                    partitionColumn: String = tableUtils.partitionColumn): String = {
     val queryOpt = Option(query)
-    val partitionColumnName = queryOpt.flatMap(q => Option(q.getPartitionColumn)).getOrElse(partitionColumn)
+    val partitionCol = queryOpt.flatMap(q => Option(q.getPartitionColumn)).getOrElse(partitionColumn)
     val wheres =
-      whereClauses(partitionColumnName) ++ queryOpt
+      whereClauses(partitionCol) ++ queryOpt
         .flatMap(q => Option(q.wheres).map(_.asScala))
         .getOrElse(Seq.empty[String])
     QueryUtils.build(selects = queryOpt.map(_.getQuerySelects).orNull,

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -100,8 +100,9 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
                    fillIfAbsent: Map[String, String] = Map.empty,
                    partitionColumn: String = tableUtils.partitionColumn): String = {
     val queryOpt = Option(query)
+    val partitionColumnName = queryOpt.map(_.getPartitionColumn).getOrElse(partitionColumn)
     val wheres =
-      whereClauses(partitionColumn) ++ queryOpt
+      whereClauses(partitionColumnName) ++ queryOpt
         .flatMap(q => Option(q.wheres).map(_.asScala))
         .getOrElse(Seq.empty[String])
     QueryUtils.build(selects = queryOpt.map(_.getQuerySelects).orNull,

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -612,7 +612,8 @@ object GroupBy {
       Some(getIntersectedRange(source, queryRange, tableUtils, window))
     } else None
 
-    var metaColumns: Map[String, String] = Map(tableUtils.partitionColumn -> null)
+    val partitionColumn = Option(source.query.partitionColumn).getOrElse(tableUtils.partitionColumn)
+    var metaColumns: Map[String, String] = Map(partitionColumn -> null)
     if (mutations) {
       metaColumns ++= Map(
         Constants.ReversalColumn -> source.query.reversalColumn,
@@ -626,7 +627,7 @@ object GroupBy {
         Some(Constants.TimeColumn -> source.query.timeColumn)
       } else {
         val dsBasedTimestamp = // 1 millisecond before ds + 1
-          s"(((UNIX_TIMESTAMP(${tableUtils.partitionColumn}, '${tableUtils.partitionSpec.format}') + 86400) * 1000) - 1)"
+          s"(((UNIX_TIMESTAMP($partitionColumn, '${tableUtils.partitionSpec.format}') + 86400) * 1000) - 1)"
 
         Some(Constants.TimeColumn -> Option(source.query.timeColumn).getOrElse(dsBasedTimestamp))
       }

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -562,7 +562,8 @@ class Join(joinConf: api.Join,
               var bootstrapDf = bootstrapRange.scanQueryDf(part.query,
                                                            part.table,
                                                            fillIfAbsent = Map(partitionColumn -> null),
-                                                           partitionColOpt = Some(partitionColumn))
+                                                           partitionColOpt = Some(partitionColumn),
+                                                           renamePartitionCol = true)
               // attach semantic_hash for either log or regular table bootstrap
               validateReservedColumns(bootstrapDf, part.table, Seq(Constants.BootstrapHash, Constants.MatchedHashes))
               if (bootstrapDf.columns.contains(Constants.SchemaHash)) {

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -559,8 +559,13 @@ class Join(joinConf: api.Join,
               logger.info(s"partition range of bootstrap table ${part.table} is beyond unfilled range")
               partialDf
             } else {
-              var bootstrapDf = tableUtils.sql(
-                bootstrapRange.genScanQuery(part.query, part.table, Map(tableUtils.partitionColumn -> null))
+              val partitionColumn = tableUtils.getPartitionColumn(part.query)
+              var bootstrapDf = tableUtils.sqlWithDefaultPartitionColumn(
+                bootstrapRange.genScanQuery(part.query,
+                                            part.table,
+                                            Map(partitionColumn -> null),
+                                            partitionColumn = partitionColumn),
+                existingPartitionColumn = partitionColumn
               )
 
               // attach semantic_hash for either log or regular table bootstrap

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -171,6 +171,7 @@ abstract class JoinBase(joinConf: api.Join,
           rightRange,
           Some(Seq(joinConf.left.table)),
           inputToOutputShift = shiftDays,
+          inputTableToPartitionColumnsMap=joinConf.left.tableToPartitionColumn,
           // never skip hole during partTable's range determination logic because we don't want partTable
           // and joinTable to be out of sync. skipping behavior is already handled in the outer loop.
           skipFirstHole = false
@@ -354,7 +355,9 @@ abstract class JoinBase(joinConf: api.Join,
 
     (rangeToFill,
      tableUtils
-       .unfilledRanges(outputTable, rangeToFill, Some(Seq(joinConf.left.table)), skipFirstHole = skipFirstHole)
+       .unfilledRanges(outputTable, rangeToFill, Some(Seq(joinConf.left.table)),
+         skipFirstHole = skipFirstHole,
+         inputTableToPartitionColumnsMap=joinConf.left.tableToPartitionColumn)
        .getOrElse(Seq.empty))
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -71,6 +71,7 @@ abstract class JoinBase(joinConf: api.Join,
     val partLeftKeys = joinPart.rightToLeft.values.toArray
 
     // compute join keys, besides the groupBy keys -  like ds, ts etc.,
+    // At dataframe, we already renamed various partition column names to the common default
     val additionalKeys: Seq[String] = {
       if (joinConf.left.dataModel == Entities) {
         Seq(tableUtils.partitionColumn)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -171,7 +171,7 @@ abstract class JoinBase(joinConf: api.Join,
           rightRange,
           Some(Seq(joinConf.left.table)),
           inputToOutputShift = shiftDays,
-          inputTableToPartitionColumnsMap=joinConf.left.tableToPartitionColumn,
+          inputTableToPartitionColumnsMap = joinConf.left.tableToPartitionColumn,
           // never skip hole during partTable's range determination logic because we don't want partTable
           // and joinTable to be out of sync. skipping behavior is already handled in the outer loop.
           skipFirstHole = false
@@ -355,9 +355,13 @@ abstract class JoinBase(joinConf: api.Join,
 
     (rangeToFill,
      tableUtils
-       .unfilledRanges(outputTable, rangeToFill, Some(Seq(joinConf.left.table)),
+       .unfilledRanges(
+         outputTable,
+         rangeToFill,
+         Some(Seq(joinConf.left.table)),
          skipFirstHole = skipFirstHole,
-         inputTableToPartitionColumnsMap=joinConf.left.tableToPartitionColumn)
+         inputTableToPartitionColumnsMap = joinConf.left.tableToPartitionColumn
+       )
        .getOrElse(Seq.empty))
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -218,7 +218,7 @@ abstract class JoinBase(joinConf: api.Join,
         throw e
     }
     if (tableUtils.tableExists(partTable)) {
-      Some(tableUtils.sql(rightRange.genScanQuery(query = null, partTable)))
+      Some(rightRange.scanQueryDf(query = null, partTable))
     } else {
       // Happens when everything is handled by bootstrap
       None
@@ -532,7 +532,7 @@ abstract class JoinBase(joinConf: api.Join,
     //  2 - User has entity table which is cumulative and only want to run backfill for the latest partition
     val (rangeToFill, unfilledRanges) = getUnfilledRange(overrideStartPartition, outputTable)
 
-    def finalResult: DataFrame = tableUtils.sql(rangeToFill.genScanQuery(null, outputTable))
+    def finalResult: DataFrame = rangeToFill.scanQueryDf(query = null, outputTable)
     if (unfilledRanges.isEmpty) {
       logger.info(s"\nThere is no data to compute based on end partition of ${rangeToFill.end}.\n\n Exiting..")
       if (selectedJoinParts.isDefined) {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -54,8 +54,6 @@ object JoinUtils {
                          joinConf.left.table,
                          fillIfAbsent = Map(partitionColumn -> null) ++ timeProjection,
                          partitionColumn = partitionColumn) + limit.map(num => s" LIMIT $num").getOrElse("")
-    // To support reading various partition column names but, rename it to "ds" later
-    // for downstream DataFrame operation in join
     val df = tableUtils.sqlWithDefaultPartitionColumn(scanQuery, partitionColumn)
     val skewFilter = joinConf.skewFilter()
     val result = skewFilter

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -54,7 +54,8 @@ object JoinUtils {
       joinConf.left.table,
       appendRawQueryString = limit.map(num => s" LIMIT $num").getOrElse(""),
       fillIfAbsent = Map(partitionColumn -> null) ++ timeProjection,
-      partitionColOpt = Some(partitionColumn)
+      partitionColOpt = Some(partitionColumn),
+      renamePartitionCol = true
     )
     val skewFilter = joinConf.skewFilter()
     val result = skewFilter

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -49,6 +49,7 @@ object JoinUtils {
     }
     val query = joinConf.left.query
     val partitionColumn = tableUtils.getPartitionColumn(query)
+
     val (scanQuery, df) = range.scanQueryStringAndDf(
       query,
       joinConf.left.table,
@@ -57,6 +58,7 @@ object JoinUtils {
       partitionColOpt = Some(partitionColumn),
       renamePartitionCol = true
     )
+
     val skewFilter = joinConf.skewFilter()
     val result = skewFilter
       .map(sf => {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -56,7 +56,7 @@ object JoinUtils {
                          partitionColumn = partitionColumn) + limit.map(num => s" LIMIT $num").getOrElse("")
     // To support reading various partition column names but, rename it to "ds" later
     // for downstream DataFrame operation in join
-    val df = tableUtils.sql(scanQuery).withColumnRenamed(partitionColumn, "ds")
+    val df = tableUtils.sqlWithDefaultPartitionColumn(scanQuery, partitionColumn)
     val skewFilter = joinConf.skewFilter()
     val result = skewFilter
       .map(sf => {

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -49,10 +49,9 @@ object JoinUtils {
     }
     val query = joinConf.left.query
     val partitionColumn = Option(query.partitionColumn).getOrElse(tableUtils.partitionColumn)
-    val scanQuery = range.genScanQuery(query,
-                                       joinConf.left.table,
-                                       fillIfAbsent = Map(partitionColumn -> null) ++ timeProjection) +
-      limit.map(num => s" LIMIT $num").getOrElse("")
+    val scanQuery =
+      range.genScanQuery(query, joinConf.left.table, fillIfAbsent = Map(partitionColumn -> null) ++ timeProjection) +
+        limit.map(num => s" LIMIT $num").getOrElse("")
     val df = tableUtils.sql(scanQuery).withColumnRenamed(partitionColumn, "ds")
     val skewFilter = joinConf.skewFilter()
     val result = skewFilter
@@ -111,7 +110,12 @@ object JoinUtils {
       Some(endPartition)
     }
     lazy val defaultLeftStart = Option(leftSource.query.startPartition)
-      .getOrElse(tableUtils.firstAvailablePartition(leftSource.table, leftSource.subPartitionFilters, Option(leftSource.query.getPartitionColumn)).get)
+      .getOrElse(
+        tableUtils
+          .firstAvailablePartition(leftSource.table,
+                                   leftSource.subPartitionFilters,
+                                   Option(leftSource.query.getPartitionColumn))
+          .get)
     val leftStart = overrideStart.getOrElse(defaultLeftStart)
     val leftEnd = Seq(Option(leftSource.query.endPartition), Some(endPartition)).flatten.min
     PartitionRange(leftStart, leftEnd)(tableUtils)

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -49,12 +49,13 @@ object JoinUtils {
     }
     val query = joinConf.left.query
     val partitionColumn = tableUtils.getPartitionColumn(query)
-    val scanQuery =
-      range.genScanQuery(query,
-                         joinConf.left.table,
-                         fillIfAbsent = Map(partitionColumn -> null) ++ timeProjection,
-                         partitionColumn = partitionColumn) + limit.map(num => s" LIMIT $num").getOrElse("")
-    val df = tableUtils.sqlWithDefaultPartitionColumn(scanQuery, partitionColumn)
+    val (scanQuery, df) = range.scanQueryStringAndDf(
+      query,
+      joinConf.left.table,
+      appendRawQueryString = limit.map(num => s" LIMIT $num").getOrElse(""),
+      fillIfAbsent = Map(partitionColumn -> null) ++ timeProjection,
+      partitionColOpt = Some(partitionColumn)
+    )
     val skewFilter = joinConf.skewFilter()
     val result = skewFilter
       .map(sf => {

--- a/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
@@ -119,7 +119,7 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
     val sanitizedLabelDs = labelDS.getOrElse(today)
     logger.info(s"Label join range to fill $leftRange")
-    def finalResult = tableUtils.sql(leftRange.genScanQuery(null, outputLabelTable))
+    def finalResult = leftRange.scanQueryDf(query = null, outputLabelTable)
 
     val leftFeatureRange = leftRange
     stepDays.foreach(metrics.gauge("step_days", _))
@@ -189,8 +189,7 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
                 s"${joinConf.metaData.name}/${labelJoinPart.groupBy.getMetaData.getName}")
             throw e
         }
-        tableUtils.sql(
-          labelOutputRange.genScanQuery(query = null, partTable, partitionColumn = Constants.LabelPartitionColumn))
+        labelOutputRange.scanQueryDf(query = null, partTable, partitionColOpt = Some(Constants.LabelPartitionColumn))
       }
     }
 

--- a/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
@@ -134,7 +134,7 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
           computeRange(leftDfInRange, range, sanitizedLabelDs)
             .save(outputLabelTable,
                   confTableProps,
-                  Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
+                  partitionColumns = Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
                   true)
           val elapsedMins = (System.currentTimeMillis() - startMillis) / (60 * 1000)
           metrics.gauge(Metrics.Name.LatencyMinutes, elapsedMins)

--- a/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
@@ -134,7 +134,7 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
           computeRange(leftDfInRange, range, sanitizedLabelDs)
             .save(outputLabelTable,
                   confTableProps,
-                  partitionColumns = Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
+                  Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
                   true)
           val elapsedMins = (System.currentTimeMillis() - startMillis) / (60 * 1000)
           metrics.gauge(Metrics.Name.LatencyMinutes, elapsedMins)

--- a/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
@@ -211,8 +211,7 @@ class LogFlattenerJob(session: SparkSession,
     val start = System.currentTimeMillis()
     val columnBeforeCount = columnCount()
     val rowCounts = unfilledRanges.map { unfilled =>
-      val rawTableScan = unfilled.genScanQuery(null, logTable)
-      val rawDf = tableUtils.sql(rawTableScan).where(col("name") === joinName)
+      val rawDf = unfilled.scanQueryDf(null, logTable).where(col("name") === joinName)
       val schemaHashes = rawDf.select(col(Constants.SchemaHash)).distinct().collect().map(_.getString(0)).toSeq
       val schemaStringsMap = fetchSchemas(schemaHashes)
 
@@ -231,7 +230,7 @@ class LogFlattenerJob(session: SparkSession,
 
       val inputRowCount = rawDf.count()
       // read from output table to avoid recomputation
-      val outputRowCount = tableUtils.sql(unfilled.genScanQuery(null, joinConf.metaData.loggedTable)).count()
+      val outputRowCount = unfilled.scanQueryDf(query = null, joinConf.metaData.loggedTable).count()
 
       (inputRowCount, outputRowCount)
     }

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -553,6 +553,12 @@ case class TableUtils(sparkSession: SparkSession) {
     }
   }
 
+  def sqlWithDefaultPartitionColumn(query: String, existingPartitionColumn: String): DataFrame = {
+    // To support joining table sources with various partition column name,
+    // we rename partition column back to the default
+    sql(query).withColumnRenamed(existingPartitionColumn, partitionColumn)
+  }
+
   def insertUnPartitioned(df: DataFrame,
                           tableName: String,
                           tableProperties: Map[String, String] = null,

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -616,7 +616,7 @@ case class TableUtils(sparkSession: SparkSession) {
   }
 
   def getPartitionColumn(q: Query): String = {
-    Option(q.partitionColumn).getOrElse(partitionColumn)
+    Option(q).map(_.partitionColumn).filter(_ != null).getOrElse(partitionColumn)
   }
 
   def getPartitionColumn(columnOpt: Option[String] = None): String = {

--- a/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
@@ -107,9 +107,8 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
       .getOrElse(Seq.empty)
     if (unfilledRanges.isEmpty) return null
     val allMetrics = unfilledRanges.map { unfilled =>
-      val comparisonDf = tableUtils.sql(unfilled.genScanQuery(null, joinConf.metaData.comparisonTable))
-      val loggedDf =
-        tableUtils.sql(unfilled.genScanQuery(null, joinConf.metaData.loggedTable)).drop(Constants.SchemaHash)
+      val comparisonDf = unfilled.scanQueryDf(null, joinConf.metaData.comparisonTable)
+      val loggedDf = unfilled.scanQueryDf(null, joinConf.metaData.loggedTable).drop(Constants.SchemaHash)
       // there could be external columns that are logged during online env, therefore they could not be used for computing OOC
       val loggedDfNoExternalCols = loggedDf.select(comparisonDf.columns.map(org.apache.spark.sql.functions.col): _*)
       logger.info("Starting compare job for stats")

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -23,7 +23,7 @@ import ai.chronon.spark.Extensions._
 import ai.chronon.spark.{Analyzer, Join, SparkSessionBuilder, TableUtils}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{col, lit}
-import org.junit.Assert.assertTrue
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, spy, verify, when}
@@ -423,6 +423,28 @@ class AnalyzerTest {
     //run analyzer and trigger assertion error when timestamps are all NULL
     val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
     analyzer.analyzeGroupBy(tableGroupBy)
+  }
+
+  @Test
+  def testGroupByAnalyzerInvalidTablePermissions(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = spy(TableUtils(spark))
+    when(tableUtils.checkTablePermission(any(), any(), any())).thenReturn(false)
+    val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    val tableGroupBy = Builders.GroupBy(
+      sources = Seq(getTestGBSourceWithTs(namespace=namespace)),
+      keyColumns = Seq("key"),
+      aggregations = Seq(
+        Builders.Aggregation(operation = Operation.SUM, inputColumn = "col1")
+      ),
+      metaData = Builders.MetaData(name = "group_by_analyzer_test.test_3", namespace = namespace),
+      accuracy = Accuracy.SNAPSHOT
+    )
+
+    val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
+    val (_, _, noAccessTables) = analyzer.analyzeGroupBy(tableGroupBy, validateTablePermission = true)
+    assertEquals(1, noAccessTables.size)
   }
 
   @Test(expected = classOf[java.lang.AssertionError])

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -345,7 +345,7 @@ class AnalyzerTest {
   def testJoinAnalyzerInvalidTablePermissions(): Unit = {
     val spark: SparkSession = SparkSessionBuilder.build("AnalyzerTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val tableUtils = spy(TableUtils(spark))
-    when(tableUtils.checkTablePermission(any(), any())).thenReturn(false)
+    when(tableUtils.checkTablePermission(any(), any(), any())).thenReturn(false)
     val namespace = "analyzer_test_ns" + "_" + Random.alphanumeric.take(6).mkString
     tableUtils.createDatabase(namespace)
     // left side

--- a/spark/src/test/scala/ai/chronon/spark/test/DataFrameGen.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/DataFrameGen.scala
@@ -32,9 +32,10 @@ import scala.collection.Seq
 // String types are nulled at row level and also at the set level (some strings are always absent)
 object DataFrameGen {
   //  The main api: that generates dataframes given certain properties of data
-  def gen(spark: SparkSession, columns: Seq[Column], count: Int): DataFrame = {
+  def gen(spark: SparkSession, columns: Seq[Column], count: Int, partitionColumnName: Option[String] = None): DataFrame = {
     val tableUtils = TableUtils(spark)
-    val RowsWithSchema(rows, schema) = CStream.gen(columns, count, tableUtils.partitionColumn, tableUtils.partitionSpec)
+    val partitionColumn = partitionColumnName.getOrElse(TableUtils(spark).partitionColumn)
+    val RowsWithSchema(rows, schema) = CStream.gen(columns, count, partitionColumn, tableUtils.partitionSpec)
     val genericRows = rows.map { row => new GenericRow(row.fieldsSeq.toArray) }.toArray
     val data: RDD[Row] = spark.sparkContext.parallelize(genericRows)
     val sparkSchema = SparkConversions.fromChrononSchema(schema)
@@ -42,16 +43,18 @@ object DataFrameGen {
   }
 
   //  The main api: that generates dataframes given certain properties of data
-  def events(spark: SparkSession, columns: Seq[Column], count: Int, partitions: Int): DataFrame = {
-    val generated = gen(spark, columns :+ Column(Constants.TimeColumn, LongType, partitions), count)
+  def events(spark: SparkSession, columns: Seq[Column], count: Int, partitions: Int, partitionColumn: Option[String] = None): DataFrame = {
+    val partitionCol = partitionColumn.getOrElse(TableUtils(spark).partitionColumn)
+    val generated = gen(spark, columns :+ Column(Constants.TimeColumn, LongType, partitions), count, Some(partitionCol))
     generated.withColumn(
-      TableUtils(spark).partitionColumn,
+      partitionCol,
       from_unixtime(generated.col(Constants.TimeColumn) / 1000, TableUtils(spark).partitionSpec.format))
   }
 
   //  Generates Entity data
-  def entities(spark: SparkSession, columns: Seq[Column], count: Int, partitions: Int): DataFrame = {
-    gen(spark, columns :+ Column(TableUtils(spark).partitionColumn, StringType, partitions), count)
+  def entities(spark: SparkSession, columns: Seq[Column], count: Int, partitions: Int, partitionColumnName: Option[String] = None): DataFrame = {
+    val partitionColumn = partitionColumnName.getOrElse(TableUtils(spark).partitionColumn)
+    gen(spark, columns :+ Column(partitionColumn, StringType, partitions), count, partitionColumnName)
   }
 
   /**
@@ -70,17 +73,19 @@ object DataFrameGen {
                 partitions: Int,
                 mutationProbability: Double,
                 mutationColumnIdx: Int,
-                keyColumnName: String): (DataFrame, DataFrame) = {
+                keyColumnName: String,
+                partitionColumnName: Option[String] = None): (DataFrame, DataFrame) = {
     val tableUtils = TableUtils(spark)
+    val partitionColumn = partitionColumnName.getOrElse(tableUtils.partitionColumn)
     val mutationColumn = columns(mutationColumnIdx)
     // Randomly generated some entity data, store them as inserts w/ mutation_ts = ts and partition = dsOf[ts].
-    val generated = gen(spark, columns :+ Column(Constants.TimeColumn, LongType, partitions), count)
+    val generated = gen(spark, columns :+ Column(Constants.TimeColumn, LongType, partitions), count, Some(partitionColumn))
       .withColumn("created_at", col(Constants.TimeColumn))
       .withColumn("updated_at", col(Constants.TimeColumn))
     val withInserts = generated
       .withColumn(Constants.ReversalColumn, lit(false))
       .withColumn(Constants.MutationTimeColumn, col(Constants.TimeColumn))
-      .withColumn(tableUtils.partitionColumn,
+      .withColumn(partitionColumn,
                   from_unixtime((generated.col(Constants.TimeColumn) / 1000), tableUtils.partitionSpec.format))
       .drop()
 
@@ -93,7 +98,7 @@ object DataFrameGen {
         Constants.MutationTimeColumn,
         randomLerp(
           col(Constants.MutationTimeColumn),
-          unix_timestamp(col(tableUtils.partitionColumn), tableUtils.partitionSpec.format) * 1000 + 86400 * 1000)
+          unix_timestamp(col(partitionColumn), tableUtils.partitionSpec.format) * 1000 + 86400 * 1000)
       )
     val realizedData = spark.sparkContext.parallelize(mutatedFromDf.rdd.collect())
     val realizedFrom = spark.createDataFrame(realizedData, mutatedFromDf.schema)
@@ -118,16 +123,16 @@ object DataFrameGen {
       .as("sd")
       .join(
         mutationsDf.filter(s"${Constants.ReversalColumn} = false").as("mt"),
-        col(s"${tableUtils.partitionColumn}") <= col(s"${tableUtils.partitionColumn}_s")
+        col(s"${partitionColumn}") <= col(s"${partitionColumn}_s")
       )
-      .select("mt.*", s"sd.${tableUtils.partitionColumn}_s")
-      .drop(tableUtils.partitionColumn, Constants.ReversalColumn)
-      .withColumnRenamed(s"${tableUtils.partitionColumn}_s", tableUtils.partitionColumn)
+      .select("mt.*", s"sd.${partitionColumn}_s")
+      .drop(partitionColumn, Constants.ReversalColumn)
+      .withColumnRenamed(s"${partitionColumn}_s", partitionColumn)
       .dropDuplicates()
 
     // Given expanded events aggregate data such that the snapshot data is consistent with the mutations from the day.
     val aggregator =
-      new SnapshotAggregator(expandedEventsDf.schema, mutationColumn.name, keyColumnName, tableUtils.partitionColumn)
+      new SnapshotAggregator(expandedEventsDf.schema, mutationColumn.name, keyColumnName, partitionColumn)
     val snapshotRdd = expandedEventsDf.rdd
       .keyBy(aggregator.aggregatorKey(_))
       .aggregateByKey(aggregator.init)(aggregator.update, aggregator.merge)

--- a/spark/src/test/scala/ai/chronon/spark/test/DataRangeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/DataRangeTest.scala
@@ -52,10 +52,10 @@ class DataRangeTest {
       table = testTable
     )
 
-    val result: String = partitionRange.genScanQuery(
+    val (scanQuery, _) = partitionRange.scanQueryStringAndDf(
       source.getEvents.query,
       testTable,
-      Seq(Constants.TimeColumn -> Option(source.getEvents.query).map(_.timeColumn).orNull).toMap
+      fillIfAbsent=Seq(Constants.TimeColumn -> Option(source.getEvents.query).map(_.timeColumn).orNull).toMap
     )
 
     val expected: String =
@@ -66,7 +66,7 @@ class DataRangeTest {
         |FROM date_range_test_namespace.test_gen_scan_query 
         |WHERE
         |  (ds >= '2024-03-01') AND (ds <= '2024-04-01') AND (col_1 = 'TEST')"""
-    assertEquals(expected.stripMargin, result.stripMargin)
+    assertEquals(expected.stripMargin, scanQuery.stripMargin)
   }
 
   @Test
@@ -94,12 +94,12 @@ class DataRangeTest {
       table = testTable
     )
 
-    val result: String = partitionRange.genScanQuery(
+    val (scanQuery, _) = partitionRange.scanQueryStringAndDf(
       source.getEvents.query,
       testTable,
-      Seq(Constants.TimeColumn -> Option(source.getEvents.query).map(_.timeColumn).orNull,
+      fillIfAbsent = Seq(Constants.TimeColumn -> Option(source.getEvents.query).map(_.timeColumn).orNull,
         customPartitionCol -> null).toMap,
-      partitionColumn = customPartitionCol
+      partitionColOpt = Some(customPartitionCol)
     )
 
     val expected: String =
@@ -111,7 +111,7 @@ class DataRangeTest {
         |FROM date_range_test_namespace_with_partition_column.test_gen_scan_query
         |WHERE
         |  ($customPartitionCol >= '2024-03-01') AND ($customPartitionCol <= '2024-04-01') AND (col_1 = 'TEST')"""
-    assertEquals(expected.stripMargin, result.stripMargin)
+    assertEquals(expected.stripMargin, scanQuery.stripMargin)
   }
 
   @Test

--- a/spark/src/test/scala/ai/chronon/spark/test/DataRangeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/DataRangeTest.scala
@@ -107,7 +107,7 @@ class DataRangeTest {
         |  `custom_partition_date`,
         |  col_1 as `col_1`,
         |  col_2 as `col_2`
-        |FROM date_range_test_namespace_with_partition_column.test_gen_scan_query
+        |FROM date_range_test_namespace_with_partition_column.test_gen_scan_query 
         |WHERE
         |  ($customPartitionCol >= '2024-03-01') AND ($customPartitionCol <= '2024-04-01') AND (col_1 = 'TEST')"""
     assertEquals(expected.stripMargin, scanQuery.stripMargin)

--- a/spark/src/test/scala/ai/chronon/spark/test/DataRangeTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/DataRangeTest.scala
@@ -40,7 +40,6 @@ class DataRangeTest {
     )
     DataFrameGen
       .events(spark, viewsSchema, count = 1000, partitions = 200)
-      .drop("ds")
       .save(testTable, partitionColumns = Seq())
     val partitionRange: PartitionRange = PartitionRange("2024-03-01", "2024-04-01")(tableUtils)
     val source: Source = Builders.Source.events(

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -72,6 +72,8 @@ class GroupByTest {
     assertEquals(0, diff.count())
   }
 
+
+
   @Test
   def testSnapshotEvents(): Unit = {
     lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
@@ -423,7 +425,7 @@ class GroupByTest {
              additionalAgg = aggs)
   }
 
-  private def createTestSource(windowSize: Int = 365, suffix: String = ""): (Source, String) = {
+  private def createTestSource(windowSize: Int = 365, suffix: String = "", partitionColOpt: Option[String] = None): (Source, String) = {
     lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     implicit val tableUtils = TableUtils(spark)
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
@@ -439,10 +441,16 @@ class GroupByTest {
     val sourceTable = s"$namespace.test_group_by_steps$suffix"
 
     tableUtils.createDatabase(namespace)
-    DataFrameGen.events(spark, sourceSchema, count = 1000, partitions = 200).save(sourceTable)
+    val genDf = DataFrameGen.events(spark, sourceSchema, count = 1000, partitions = 200, partitionColOpt=partitionColOpt)
+    partitionColOpt match {
+      case Some(partitionCol) => genDf.save(sourceTable, partitionColumns=Seq(partitionCol))
+      case None => genDf.save(sourceTable)
+    }
+
     val source = Builders.Source.events(
       query = Builders.Query(selects = Builders.Selects("ts", "item", "time_spent_ms", "price"),
-                             startPartition = startPartition),
+                             startPartition = startPartition,
+        partitionColumn=partitionColOpt.orNull),
       table = sourceTable
     )
     (source, endPartition)
@@ -687,11 +695,35 @@ class GroupByTest {
         )
       )
     )
-    backfill(name = "unit_test_group_by_descriptive_stats",
+    val outputTable = backfill(name = "unit_test_group_by_descriptive_stats",
              source = source,
              endPartition = endPartition,
              namespace = namespace,
              tableUtils = tableUtils,
              additionalAgg = aggs)
+    val expectedInputDf = spark.sql(f"select count(*), ds from $outputTable group by ds")
+    expectedInputDf.show()
+  }
+
+  @Test
+  def testGroupByWithQueryPartitionColumn(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val queryPartitionColumn = "new_date_col"
+    val (source, endPartition) = createTestSource(suffix = "_different_names", partitionColOpt = Some(queryPartitionColumn))
+    val tableUtils = TableUtils(spark)
+    val namespace = "test_different_names"
+
+    val outputTable = backfill(name = "unit_test_different_names",
+      source = source,
+      endPartition = endPartition,
+      namespace = namespace,
+      tableUtils = tableUtils)
+
+    // Resulting table has "ds" column
+    val expectedInputDf = spark.sql(f"select count(*) as cnt, ds from $outputTable group by ds")
+    assert(expectedInputDf.count() > 10, "Expected more than 10 rows in the result")
+    expectedInputDf.select("cnt").as[Long](Encoders.scalaLong).collect().foreach { count =>
+      assert(count > 0, s"Found a count value that is not greater than zero: $count")
+    }
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -707,11 +707,11 @@ class GroupByTest {
   def testGroupByWithQueryPartitionColumn(): Unit = {
     lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
     val queryPartitionColumn = "new_date_col"
-    val (source, endPartition) = createTestSource(suffix = "_different_names", partitionColOpt = Some(queryPartitionColumn))
+    val (source, endPartition) = createTestSource(suffix = "_custom_p_cols", partitionColOpt = Some(queryPartitionColumn))
     val tableUtils = TableUtils(spark)
-    val namespace = "test_different_names"
+    val namespace = "test_custom_p_cols"
 
-    val outputTable = backfill(name = "unit_test_different_names",
+    val outputTable = backfill(name = "unit_test_custom_p_cols",
       source = source,
       endPartition = endPartition,
       namespace = namespace,

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -72,8 +72,6 @@ class GroupByTest {
     assertEquals(0, diff.count())
   }
 
-
-
   @Test
   def testSnapshotEvents(): Unit = {
     lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -292,7 +292,7 @@ class GroupByTest {
     val namespace = "test_analyzer_testGroupByAnalyzer"
     val groupByConf = getSampleGroupBy("unit_analyze_test_item_views", source, namespace)
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (aggregationsMetadata, _) =
+    val (aggregationsMetadata, _, _) =
       new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)
     val outputTable = backfill(name = "unit_analyze_test_item_views",
                                source = source,
@@ -329,7 +329,7 @@ class GroupByTest {
                                                          new Window(60, TimeUnit.DAYS))
     )
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (aggregationsMetadata, _) =
+    val (aggregationsMetadata, _, _) =
       new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)
 
     print(aggregationsMetadata)
@@ -352,7 +352,7 @@ class GroupByTest {
     val derivation = Builders.Derivation(name = "*", expression = "*")
     val groupByConf = getSampleGroupBy("unit_analyze_test_item_views", source, namespace, Seq.empty, derivations = Seq(derivation))
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (aggregationsMetadata, _) =
+    val (aggregationsMetadata, _, _) =
       new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)
     val outputTable = backfill(name = "unit_analyze_test_item_views",
       source = source,

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -720,7 +720,8 @@ class JoinTest {
       PartitionRange("2021-02-23", "2021-05-03")(tableUtils),
       tableUtils,
       None,
-      viewsGroupByCumulative.inferredAccuracy
+      viewsGroupByCumulative.inferredAccuracy,
+      tableUtils.partitionColumn
     )
     // Only checking that the date logic is correct in the query
     assert(renderedCumulative.contains(s"(ds >= '${today}') AND (ds <= '${today}')"))
@@ -734,7 +735,8 @@ class JoinTest {
       PartitionRange("2021-01-01", "2021-01-01")(tableUtils),
       tableUtils,
       None,
-      viewsGroupByCumulative.inferredAccuracy
+      viewsGroupByCumulative.inferredAccuracy,
+      tableUtils.partitionColumn
     )
     println(renderedIncremental)
     assert(renderedIncremental.contains(s"(ds >= '2021-01-01') AND (ds <= '2021-01-01')"))

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -1740,13 +1740,13 @@ class JoinTest {
     println(s"join start = $start")
     val expected = tableUtils.sql(s"""
                                      |WITH
-                                     |   users AS (SELECT user, ds from $usersTable where ds >= '$start' and ds <= '$end'),
+                                     |   users AS (SELECT user, $userPartitionColumn as ds from $usersTable where $userPartitionColumn >= '$start' and $userPartitionColumn <= '$end'),
                                      |   grouped_names AS (
                                      |      SELECT user,
                                      |             name as unit_test_user_names_name,
-                                     |             ds
+                                     |             $namePartitionColumn as ds
                                      |      FROM $namesTable
-                                     |      WHERE ds >= '$yearAgo' and ds <= '$dayAndMonthBefore')
+                                     |      WHERE $namePartitionColumn >= '$yearAgo' and $namePartitionColumn <= '$dayAndMonthBefore')
                                      |   SELECT users.user,
                                      |        grouped_names.unit_test_user_names_name,
                                      |        users.ds
@@ -1760,7 +1760,7 @@ class JoinTest {
     println("showing query result")
     expected.show()
     println(
-      s"Left side count: ${spark.sql(s"SELECT user, ds from $namesTable where ds >= '$start' and ds <= '$end'").count()}")
+      s"Left side count: ${spark.sql(s"SELECT user, $namePartitionColumn as ds from $namesTable where $namePartitionColumn >= '$start' and $namePartitionColumn <= '$end'").count()}")
     println(s"Actual count: ${computed.count()}")
     println(s"Expected count: ${expected.count()}")
     val diff = Comparison.sideBySide(computed, expected, List("user", "ds"))

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -1682,4 +1682,93 @@ class JoinTest {
     aggregationsMetadata.exists(_.name == f"${viewGroupByWithKepMapping.metaData.name}_time_spent_ms_average")
     aggregationsMetadata.exists(_.name == "item")
   }
+
+  @Test
+  def testJoinDifferentPartitionColumns(): Unit = {
+    val spark: SparkSession = SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val tableUtils = TableUtils(spark)
+    val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+    // Left side entities, right side entities no agg
+    // Also testing specific select statement (rather than select *)
+    val namesSchema = List(
+      Column("user", api.StringType, 1000),
+      Column("name", api.StringType, 500)
+    )
+    val namePartitionColumn = "name_date"
+    val namesTable = s"$namespace.names"
+    DataFrameGen.entities(spark, namesSchema, 1000, partitions = 400, partitionColumnName = Some(namePartitionColumn)).save(namesTable, partitionColumns = Seq(namePartitionColumn))
+
+    val namesSource = Builders.Source.entities(
+      query =
+        Builders.Query(selects = Builders.Selects("name"), startPartition = yearAgo, endPartition = dayAndMonthBefore, partitionColumn = namePartitionColumn),
+      snapshotTable = namesTable
+    )
+
+    val namesGroupBy = Builders.GroupBy(
+      sources = Seq(namesSource),
+      keyColumns = Seq("user"),
+      aggregations = null,
+      metaData = Builders.MetaData(name = "unit_test.user_names", team = "chronon")
+    )
+
+    DataFrameGen
+      .entities(spark, namesSchema, 1000, partitions = 400, partitionColumnName = Some(namePartitionColumn))
+      .groupBy("user", namePartitionColumn)
+      .agg(Map("name" -> "max"))
+      .save(namesTable, partitionColumns = Seq(namePartitionColumn))
+
+    // left side
+    val userPartitionColumn = "user_date"
+    val userSchema = List(Column("user", api.StringType, 100))
+    val usersTable = s"$namespace.users"
+    DataFrameGen.entities(spark, userSchema, 1000, partitions = 400, partitionColumnName = Some(userPartitionColumn))
+      .dropDuplicates()
+      .save(usersTable, partitionColumns = Seq(userPartitionColumn))
+
+    val start = tableUtils.partitionSpec.minus(today, new Window(60, TimeUnit.DAYS))
+    val end = tableUtils.partitionSpec.minus(today, new Window(15, TimeUnit.DAYS))
+    val joinConf = Builders.Join(
+      left = Builders.Source.entities(Builders.Query(selects = Map("user" -> "user"), startPartition = start, partitionColumn = userPartitionColumn),
+        snapshotTable = usersTable),
+      joinParts = Seq(Builders.JoinPart(groupBy = namesGroupBy)),
+      metaData = Builders.MetaData(name = "test.user_features", namespace = namespace, team = "chronon")
+    )
+
+    val runner = new Join(joinConf, end, tableUtils)
+    val computed = runner.computeJoin(Some(7))
+    println(s"join start = $start")
+    val expected = tableUtils.sql(s"""
+                                     |WITH
+                                     |   users AS (SELECT user, ds from $usersTable where ds >= '$start' and ds <= '$end'),
+                                     |   grouped_names AS (
+                                     |      SELECT user,
+                                     |             name as unit_test_user_names_name,
+                                     |             ds
+                                     |      FROM $namesTable
+                                     |      WHERE ds >= '$yearAgo' and ds <= '$dayAndMonthBefore')
+                                     |   SELECT users.user,
+                                     |        grouped_names.unit_test_user_names_name,
+                                     |        users.ds
+                                     | FROM users left outer join grouped_names
+                                     | ON users.user = grouped_names.user
+                                     | AND users.ds = grouped_names.ds
+    """.stripMargin)
+
+    println("showing join result")
+    computed.show()
+    println("showing query result")
+    expected.show()
+    println(
+      s"Left side count: ${spark.sql(s"SELECT user, ds from $namesTable where ds >= '$start' and ds <= '$end'").count()}")
+    println(s"Actual count: ${computed.count()}")
+    println(s"Expected count: ${expected.count()}")
+    val diff = Comparison.sideBySide(computed, expected, List("user", "ds"))
+    if (diff.count() > 0) {
+      println(s"Diff count: ${diff.count()}")
+      println(s"diff result rows")
+      diff.show()
+    }
+    assertEquals(diff.count(), 0)
+  }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -1697,7 +1697,7 @@ class JoinTest {
     )
     val namePartitionColumn = "name_date"
     val namesTable = s"$namespace.names"
-    DataFrameGen.entities(spark, namesSchema, 1000, partitions = 400, partitionColumnName = Some(namePartitionColumn)).save(namesTable, partitionColumns = Seq(namePartitionColumn))
+    DataFrameGen.entities(spark, namesSchema, 1000, partitions = 400, partitionColOpt = Some(namePartitionColumn)).save(namesTable, partitionColumns = Seq(namePartitionColumn))
 
     val namesSource = Builders.Source.entities(
       query =
@@ -1713,7 +1713,7 @@ class JoinTest {
     )
 
     DataFrameGen
-      .entities(spark, namesSchema, 1000, partitions = 400, partitionColumnName = Some(namePartitionColumn))
+      .entities(spark, namesSchema, 1000, partitions = 400, partitionColOpt = Some(namePartitionColumn))
       .groupBy("user", namePartitionColumn)
       .agg(Map("name" -> "max"))
       .save(namesTable, partitionColumns = Seq(namePartitionColumn))
@@ -1722,7 +1722,7 @@ class JoinTest {
     val userPartitionColumn = "user_date"
     val userSchema = List(Column("user", api.StringType, 100))
     val usersTable = s"$namespace.users"
-    DataFrameGen.entities(spark, userSchema, 1000, partitions = 400, partitionColumnName = Some(userPartitionColumn))
+    DataFrameGen.entities(spark, userSchema, 1000, partitions = 400, partitionColOpt = Some(userPartitionColumn))
       .dropDuplicates()
       .save(usersTable, partitionColumns = Seq(userPartitionColumn))
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Support partition column at query so that joining multiple group by sources of different partition column name would work
- This PR updates thrift schema, and adds new optional param to pass in optional column
- Partition column is used in reading source data, and also for partition-level operations

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- Currently partition column is fixed as `ds` or configured at `spark.chronon.partition.column`
- In join job, with groupby with source table having different date partition column, we currently has no support

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI


## Checklist
- [ ] Documentation update

## Reviewers

