### PR TITLE
small improvements to streaming metrics 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -64,9 +64,9 @@ object Fetcher {
     var exceptions = 0
     var nulls = 0
     responseMap.foreach {
-      case (_, v) =>
+      case (k, v) =>
         if (v == null) nulls += 1
-        else if (v.isInstanceOf[Throwable]) exceptions += 1
+        else if (v.isInstanceOf[Throwable] || k.endsWith("_exception")) exceptions += 1
     }
     context.distribution(Metrics.Name.FetchNulls, nulls)
     context.distribution(Metrics.Name.FetchExceptions, exceptions)

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -220,6 +220,7 @@ class FetcherBase(kvStore: KVStore,
           logger.info(s"""
                          |batch ir: ${gson.toJson(batchIr)}
                          |streamingRows: ${gson.toJson(streamingRows)}
+                         |streamingRowsCount: ${streamingRows.length}
                          |batchEnd in millis: ${servingInfo.batchEndTsMillis}
                          |queryTime in millis: $queryTimeMs
                          |""".stripMargin)

--- a/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
@@ -130,8 +130,8 @@ class GroupBy(inputStream: DataFrame,
           .filter(_ != null)
           .map(SparkConversions.toSparkRow(_, streamDecoder.schema, GenericRowHandler.func).asInstanceOf[Row])
       }(streamSchemaEncoder)
-      .map {
-        row => {
+      .map { row =>
+        {
           // Report flattened row count metric
           ingressContext.withSuffix("flatten").increment(Metrics.Name.RowCount)
           row

--- a/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
@@ -115,6 +115,7 @@ class GroupBy(inputStream: DataFrame,
         mutation != null && (!(mutation.before != null && mutation.after != null) || !(mutation.before sameElements mutation.after)))
 
     val streamSchema = SparkConversions.fromChrononSchema(streamDecoder.schema)
+    val streamSchemaEncoder = EncoderUtil(streamSchema)
     logger.info(s"""
         | group by serving info: $groupByServingInfo
         | Streaming source: $streamingSource
@@ -128,7 +129,14 @@ class GroupBy(inputStream: DataFrame,
         Seq(mutation.after, mutation.before)
           .filter(_ != null)
           .map(SparkConversions.toSparkRow(_, streamDecoder.schema, GenericRowHandler.func).asInstanceOf[Row])
-      }(EncoderUtil(streamSchema))
+      }(streamSchemaEncoder)
+      .map {
+        row => {
+          // Report flattened row count metric
+          ingressContext.withSuffix("flatten").increment(Metrics.Name.RowCount)
+          row
+        }
+      }(streamSchemaEncoder)
 
     des.createOrReplaceTempView(streamingTable)
 

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -22,7 +22,7 @@ import ai.chronon.api._
 import ai.chronon.online.Fetcher.Request
 import ai.chronon.online.KVStore.PutRequest
 import ai.chronon.online._
-import ai.chronon.spark.{GenericRowHandler, TableUtils, EncoderUtil}
+import ai.chronon.spark.{EncoderUtil, GenericRowHandler, TableUtils}
 import com.google.gson.Gson
 import org.apache.spark.api.java.function.{MapPartitionsFunction, VoidFunction2}
 import org.apache.spark.sql.streaming.{DataStreamWriter, Trigger}
@@ -37,6 +37,7 @@ import java.{lang, util}
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.util.ScalaJavaConversions.{IteratorOps, JIteratorOps, ListOps, MapOps}
+import scala.util.{Failure, Success}
 
 // micro batching destroys and re-creates these objects repeatedly through ForeachBatchWriter and MapFunction
 // this allows for re-use
@@ -247,6 +248,7 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
         (mutation != null) && (!bothNull || !bothSame)
       }
     val streamSchema = SparkConversions.fromChrononSchema(streamDecoder.schema)
+    val streamSchemaEncoder = EncoderUtil(streamSchema)
     logger.info(s"""
          | streaming source: ${groupByConf.streamingSource.get}
          | streaming dataset: ${groupByConf.streamingDataset}
@@ -258,7 +260,14 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
         Seq(mutation.after, mutation.before)
           .filter(_ != null)
           .map(SparkConversions.toSparkRow(_, streamDecoder.schema, GenericRowHandler.func).asInstanceOf[Row])
-      }(EncoderUtil(streamSchema))
+      }(streamSchemaEncoder)
+      .map {
+        row => {
+          // Report flattened row count metric
+          ingressContext.withSuffix("flatten").increment(Metrics.Name.RowCount)
+          row
+        }
+      }(streamSchemaEncoder)
     dataStream.copy(df = des)
   }
 
@@ -385,7 +394,16 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
           }
 
           if (debug && shouldSample) {
-            requests.foreach(request => logger.info(s"request: ${request.keys}, ts: ${request.atMillis}"))
+            var logMessage = s"\nShowing all ${requests.length} requests:\n"
+            requests.zipWithIndex.foreach {
+              case (request, index) =>
+                logMessage +=
+                  s"""request ${index}
+                     |payload: ${request.keys}
+                     |ts: ${request.atMillis}
+                     |""".stripMargin
+            }
+            logger.info(logMessage)
           }
 
           val responsesFuture = fetcher.fetchJoin(requests = requests.toSeq)
@@ -394,10 +412,18 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
           val responses = Await.result(responsesFuture, 5.second)
 
           if (debug && shouldSample) {
-            logger.info(s"responses/request size: ${responses.size}/${requests.size}\n  responses: ${responses}")
-            responses.foreach(response =>
-              logger.info(
-                s"request: ${response.request.keys}, ts: ${response.request.atMillis}, values: ${response.values}"))
+            logger.info(s"Request count: ${requests.length} Response count: ${responses.length}")
+            var logMessage = s"\n Showing all ${responses.length} responses:\n"
+            responses.zipWithIndex.foreach {
+              case (response, index) =>
+                logMessage +=
+                  s"""response ${index}
+                     |ts: ${response.request.atMillis}
+                     |request payload: ${response.request.keys}
+                     |response payload: ${response.values}
+                     |""".stripMargin
+            }
+            logger.info(logMessage)
           }
           responses.iterator.map { response =>
             val responseMap = response.values.get
@@ -437,8 +463,24 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
             logger.info(s" Final df size to write: ${data.length}")
             logger.info(s" Size of putRequests to kv store- ${putRequests.length}")
           } else {
-            putRequests.foreach(request => emitRequestMetric(request, context.withSuffix("egress")))
-            kvStore.multiPut(putRequests)
+            val egressCtx = context.withSuffix("egress")
+            putRequests.foreach(request => emitRequestMetric(request, egressCtx))
+
+            // Report kvStore metrics
+            val kvContext = egressCtx.withSuffix("put")
+            kvStore
+              .multiPut(putRequests)
+              .andThen {
+                case Success(results) =>
+                  results.foreach { result =>
+                    if (result) {
+                      kvContext.increment("success")
+                    } else {
+                      kvContext.increment("failure")
+                    }
+                  }
+                case Failure(exception) => kvContext.incrementException(exception)
+              }(kvStore.executionContext)
           }
         }
       }

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -261,8 +261,8 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
           .filter(_ != null)
           .map(SparkConversions.toSparkRow(_, streamDecoder.schema, GenericRowHandler.func).asInstanceOf[Row])
       }(streamSchemaEncoder)
-      .map {
-        row => {
+      .map { row =>
+        {
           // Report flattened row count metric
           ingressContext.withSuffix("flatten").increment(Metrics.Name.RowCount)
           row


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Publish metrics in streaming:
- ingress row count after flattening out mutations 
- report kvStore multiPut return status (currently it returns boolean flags)

A healthy streaming job should satisfy the invariant that `egress.put.success == ingress.flattened.row.count`

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Improve instrumentation

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pengyu-hou @xiaohui-sun 