### PR TITLE
improve partial failure in join codec building logic 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -109,38 +109,49 @@ class Fetcher(val kvStore: KVStore,
   // run during initialization
   reportCallerNameFetcherVersion()
 
-  def buildJoinCodec(joinConf: Join): JoinCodec = {
+  def buildJoinCodec(joinConf: Join, refreshOnFail: Boolean): (JoinCodec, Boolean) = {
     val keyFields = new mutable.LinkedHashSet[StructField]
     val valueFields = new mutable.ListBuffer[StructField]
+    var hasPartialFailure = false
     // collect keyFields and valueFields from joinParts/GroupBys
     joinConf.joinPartOps.foreach { joinPart =>
       val servingInfoTry = getGroupByServingInfo(joinPart.groupBy.metaData.getName)
-      servingInfoTry
-        .map { servingInfo =>
-          val keySchema = servingInfo.keyCodec.chrononSchema.asInstanceOf[StructType]
-          joinPart.leftToRight
-            .mapValues(right => keySchema.fields.find(_.name == right).get.fieldType)
-            .foreach {
-              case (name, dType) =>
-                val keyField = StructField(name, dType)
-                keyFields.add(keyField)
-            }
-          val groupBySchemaBeforeDerivation: StructType = if (servingInfo.groupBy.aggregations == null) {
-            servingInfo.selectedChrononSchema
-          } else {
-            servingInfo.outputChrononSchema
+      if (servingInfoTry.isSuccess) {
+        val servingInfo = servingInfoTry.get
+        val keySchema = servingInfo.keyCodec.chrononSchema.asInstanceOf[StructType]
+        joinPart.leftToRight
+          .mapValues(right => keySchema.fields.find(_.name == right).get.fieldType)
+          .foreach {
+            case (name, dType) =>
+              val keyField = StructField(name, dType)
+              keyFields.add(keyField)
           }
-          val baseValueSchema: StructType = if (!servingInfo.groupBy.hasDerivations) {
-            groupBySchemaBeforeDerivation
-          } else {
-            val fields =
-              buildDerivedFields(servingInfo.groupBy.derivationsScala, keySchema, groupBySchemaBeforeDerivation)
-            StructType(s"groupby_derived_${servingInfo.groupBy.metaData.cleanName}", fields.toArray)
-          }
-          baseValueSchema.fields.foreach { sf =>
-            valueFields.append(joinPart.constructJoinPartSchema(sf))
-          }
+        val groupBySchemaBeforeDerivation: StructType = if (servingInfo.groupBy.aggregations == null) {
+          servingInfo.selectedChrononSchema
+        } else {
+          servingInfo.outputChrononSchema
         }
+        val baseValueSchema: StructType = if (!servingInfo.groupBy.hasDerivations) {
+          groupBySchemaBeforeDerivation
+        } else {
+          val fields =
+            buildDerivedFields(servingInfo.groupBy.derivationsScala, keySchema, groupBySchemaBeforeDerivation)
+          StructType(s"groupby_derived_${servingInfo.groupBy.metaData.cleanName}", fields.toArray)
+        }
+        baseValueSchema.fields.foreach { sf =>
+          valueFields.append(joinPart.constructJoinPartSchema(sf))
+        }
+      } else {
+        if (refreshOnFail) {
+          getGroupByServingInfo.refresh(joinPart.groupBy.metaData.getName)
+          hasPartialFailure = true
+        } else {
+          throw new Exception(
+            s"Failure to build join codec for join ${joinConf.metaData.name} due to bad groupBy serving info for ${joinPart.groupBy.metaData.name}",
+            servingInfoTry.failed.get)
+        }
+
+      }
     }
 
     // gather key schema and value schema from external sources.
@@ -169,15 +180,16 @@ class Fetcher(val kvStore: KVStore,
     val baseValueSchema = StructType(s"${joinName.sanitize}_value", valueFields.toArray)
     val joinCodec = JoinCodec(joinConf, keySchema, baseValueSchema)
     logControlEvent(joinCodec)
-    joinCodec
+    (joinCodec, hasPartialFailure)
   }
 
   // key and value schemas
-  lazy val getJoinCodecs = new TTLCache[String, Try[JoinCodec]](
+  lazy val getJoinCodecs = new TTLCache[String, Try[(JoinCodec, Boolean)]](
     { joinName: String =>
-      getJoinConf(joinName)
+      val startTimeMs = System.currentTimeMillis()
+      val result: Try[(JoinCodec, Boolean)] = getJoinConf(joinName)
         .map(_.join)
-        .map(buildJoinCodec)
+        .map(join => buildJoinCodec(join, refreshOnFail = true))
         .recoverWith {
           case th: Throwable =>
             Failure(
@@ -186,6 +198,13 @@ class Fetcher(val kvStore: KVStore,
                 th
               ))
         }
+      val context = Metrics.Context(Metrics.Environment.MetaDataFetching, join = joinName).withSuffix("join_codec")
+      if (result.isFailure) {
+        context.incrementException(result.failed.get)
+      } else {
+        context.distribution(Metrics.Name.LatencyMillis, System.currentTimeMillis() - startTimeMs)
+      }
+      result
     },
     { join: String => Metrics.Context(environment = "join.codec.fetch", join = join) })
 
@@ -227,7 +246,7 @@ class Fetcher(val kvStore: KVStore,
             val ctx = Metrics.Context(Environment.JoinFetching, join = joinName)
             val joinCodecTry = getJoinCodecs(internalResponse.request.name)
             joinCodecTry match {
-              case Success(joinCodec) =>
+              case Success((joinCodec, hasPartialFailure)) =>
                 ctx.distribution("derivation_codec.latency.millis", System.currentTimeMillis() - derivationStartTs)
                 // try to fix request mistype
                 val keySchemaMap: Map[String, DataType] = joinCodec.keySchema.fields.map { field =>
@@ -274,7 +293,12 @@ class Fetcher(val kvStore: KVStore,
                 val requestEndTs = System.currentTimeMillis()
                 ctx.distribution("derivation.latency.millis", requestEndTs - derivationStartTs)
                 ctx.distribution("overall.latency.millis", requestEndTs - ts)
-                ResponseWithContext(request, finalizedDerivedMap, baseMap)
+                val response = ResponseWithContext(request, finalizedDerivedMap, baseMap)
+                // Refresh joinCodec if it has partial failure
+                if (hasPartialFailure) {
+                  getJoinCodecs.refresh(joinName)
+                }
+                response
               case Failure(exception) =>
                 // more validation logic will be covered in compile.py to avoid this case
                 ctx.incrementException(exception)
@@ -332,83 +356,85 @@ class Fetcher(val kvStore: KVStore,
     val loggingTs = resp.request.atMillis.getOrElse(ts)
     val joinCodecTry = getJoinCodecs(resp.request.name)
 
-    val loggingTry: Try[Unit] = joinCodecTry.map(codec => {
-      val metaData = codec.conf.join.metaData
-      val samplePercent = if (metaData.isSetSamplePercent) metaData.getSamplePercent else 0
+    val loggingTry: Try[Unit] = joinCodecTry
+      .map(_._1)
+      .map(codec => {
+        val metaData = codec.conf.join.metaData
+        val samplePercent = if (metaData.isSetSamplePercent) metaData.getSamplePercent else 0
 
-      // Exit early if sample percent is 0
-      if (samplePercent == 0) {
-        return Response(resp.request, Success(resp.derivedValues))
-      }
-
-      val keyBytesTry: Try[Array[Byte]] = encode(loggingContext.map(_.withSuffix("encode_key")),
-                                                 codec.keySchema,
-                                                 codec.keyCodec,
-                                                 resp.request.keys,
-                                                 cast = true)
-      if (keyBytesTry.isFailure) {
-        loggingContext.foreach(_.withSuffix("encode_key").incrementException(keyBytesTry.failed.get))
-        throw keyBytesTry.failed.get
-      }
-      val keyBytes = keyBytesTry.get
-      val hash = if (samplePercent > 0) {
-        Math.abs(HashUtils.md5Long(keyBytes))
-      } else {
-        -1
-      }
-      val shouldPublishLog = (hash > 0) && ((hash % (100 * 1000)) <= (samplePercent * 1000))
-      if (shouldPublishLog || debug) {
-        val values = if (codec.conf.join.logFullValues) {
-          resp.combinedValues
-        } else {
-          resp.derivedValues
+        // Exit early if sample percent is 0
+        if (samplePercent == 0) {
+          return Response(resp.request, Success(resp.derivedValues))
         }
 
-        if (debug) {
-          logger.info(s"Logging ${resp.request.keys} : ${hash % 100000}: $samplePercent")
-          val gson = new Gson()
-          val valuesFormatted = values.map { case (k, v) => s"$k -> ${gson.toJson(v)}" }.mkString(", ")
-          logger.info(s"""Sampled join fetch
+        val keyBytesTry: Try[Array[Byte]] = encode(loggingContext.map(_.withSuffix("encode_key")),
+                                                   codec.keySchema,
+                                                   codec.keyCodec,
+                                                   resp.request.keys,
+                                                   cast = true)
+        if (keyBytesTry.isFailure) {
+          loggingContext.foreach(_.withSuffix("encode_key").incrementException(keyBytesTry.failed.get))
+          throw keyBytesTry.failed.get
+        }
+        val keyBytes = keyBytesTry.get
+        val hash = if (samplePercent > 0) {
+          Math.abs(HashUtils.md5Long(keyBytes))
+        } else {
+          -1
+        }
+        val shouldPublishLog = (hash > 0) && ((hash % (100 * 1000)) <= (samplePercent * 1000))
+        if (shouldPublishLog || debug) {
+          val values = if (codec.conf.join.logFullValues) {
+            resp.combinedValues
+          } else {
+            resp.derivedValues
+          }
+
+          if (debug) {
+            logger.info(s"Logging ${resp.request.keys} : ${hash % 100000}: $samplePercent")
+            val gson = new Gson()
+            val valuesFormatted = values.map { case (k, v) => s"$k -> ${gson.toJson(v)}" }.mkString(", ")
+            logger.info(s"""Sampled join fetch
                |Key Map: ${resp.request.keys}
                |Value Map: [${valuesFormatted}]
                |""".stripMargin)
-        }
+          }
 
-        val valueBytesTry: Try[Array[Byte]] =
-          encode(loggingContext.map(_.withSuffix("encode_value")), codec.valueSchema, codec.valueCodec, values)
-        if (valueBytesTry.isFailure) {
-          loggingContext.foreach(_.withSuffix("encode_value").incrementException(valueBytesTry.failed.get))
-          throw valueBytesTry.failed.get
-        }
-        val valueBytes = valueBytesTry.get
+          val valueBytesTry: Try[Array[Byte]] =
+            encode(loggingContext.map(_.withSuffix("encode_value")), codec.valueSchema, codec.valueCodec, values)
+          if (valueBytesTry.isFailure) {
+            loggingContext.foreach(_.withSuffix("encode_value").incrementException(valueBytesTry.failed.get))
+            throw valueBytesTry.failed.get
+          }
+          val valueBytes = valueBytesTry.get
 
-        val loggableResponse = LoggableResponse(
-          keyBytes,
-          valueBytes,
-          resp.request.name,
-          loggingTs,
-          codec.loggingSchemaHash
-        )
-        if (logFunc != null) {
-          logFunc.accept(loggableResponse)
-          loggingContext.foreach(context => context.increment("count"))
-          loggingContext.foreach(context =>
-            context.distribution("latency.millis", System.currentTimeMillis() - loggingStartTs))
-          loggingContext.foreach(context =>
-            context.distribution("overall.latency.millis", System.currentTimeMillis() - ts))
+          val loggableResponse = LoggableResponse(
+            keyBytes,
+            valueBytes,
+            resp.request.name,
+            loggingTs,
+            codec.loggingSchemaHash
+          )
+          if (logFunc != null) {
+            logFunc.accept(loggableResponse)
+            loggingContext.foreach(context => context.increment("count"))
+            loggingContext.foreach(context =>
+              context.distribution("latency.millis", System.currentTimeMillis() - loggingStartTs))
+            loggingContext.foreach(context =>
+              context.distribution("overall.latency.millis", System.currentTimeMillis() - ts))
 
-          if (debug) {
-            logger.info(s"Logged data with schema_hash ${codec.loggingSchemaHash}")
+            if (debug) {
+              logger.info(s"Logged data with schema_hash ${codec.loggingSchemaHash}")
+            }
           }
         }
-      }
-    })
+      })
     loggingTry.failed.map { exception =>
       // Publish logging failure metrics before codec refresh in case of another exception
       loggingContext.foreach(_.incrementException(exception)(logger))
 
       // to handle GroupByServingInfo staleness that results in encoding failure
-      val refreshedJoinCodec = getJoinCodecs.refresh(resp.request.name)
+      val refreshedJoinCodec = getJoinCodecs.refresh(resp.request.name).map(_._1)
       if (debug) {
         val rand = new Random
         val number = rand.nextDouble
@@ -429,6 +455,9 @@ class Fetcher(val kvStore: KVStore,
           }
         }
       }
+    }
+    if (joinCodecTry.isSuccess && joinCodecTry.get._2) {
+      getJoinCodecs.refresh(resp.request.name)
     }
     Response(resp.request, Success(resp.derivedValues))
   }

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -192,7 +192,13 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
     val leftSourceSchema: StructType = outputSchema(leftStreamSchema, enrichQuery(left.query)) // apply same thing
 
     // joinSchema = leftSourceSchema ++ joinCodec.valueSchema
-    val joinCodec: JoinCodec = apiImpl.buildFetcher(debug).buildJoinCodec(joinSource.getJoin)
+    val joinCodec: JoinCodec = apiImpl
+      .buildFetcher(debug)
+      .buildJoinCodec(
+        joinSource.getJoin,
+        refreshOnFail = false // immediately fails if the codec has partial error to avoid using stale codec
+      )
+      ._1
     val joinValueSchema: StructType = SparkConversions.fromChrononSchema(joinCodec.valueSchema)
     val joinSchema: StructType = StructType(leftSourceSchema ++ joinValueSchema)
     val joinSourceSchema: StructType = outputSchema(joinSchema, enrichQuery(joinSource.query))


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

`getJoinCodes` is used in several places (derivation, logging, chaining) in fetcher to construct the join schema. 

It builds the schema by looping over all join_parts, and call `getGroupByServingInfo` for each join_part. When `getGroupByServingInfo` fails for some GB, it currently ignores that joinPart, which leads to the a stale value of `JoinCodec` which gets cached for 2 hours without updating. If the failure of `getGroupByServingInfo` is transient, this cannot recover itself until 2 hours expires for the `JoinCodec`. 

This PR updates it such that if there is any partial failure (from `getGroupByServingInfo`) during `getJoinCodes`, the caller of it will always call `refresh` on it. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Reviewers

@pengyu-hou @yuli-han @xiaohui-sun 

