### PR TITLE
Fixing assert on backfillStartDate

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -677,8 +677,10 @@ object GroupBy {
                       overrideStartPartition: Option[String] = None,
                       skipFirstHole: Boolean = true): Unit = {
     assert(
-      groupByConf.backfillStartDate != null,
-      s"GroupBy:${groupByConf.metaData.name} has null backfillStartDate. This needs to be set for offline backfilling.")
+      groupByConf.backfillStartDate != null || overrideStartPartition != null,
+      s"GroupBy:${groupByConf.metaData.name} has null backfillStartDate or overrideStartPartition." +
+        s" This needs to be set for offline backfilling."
+    )
     groupByConf.setups.foreach(tableUtils.sql)
     val overrideStart = overrideStartPartition.getOrElse(groupByConf.backfillStartDate)
     val outputTable = groupByConf.metaData.outputTable


### PR DESCRIPTION
## Summary
Enable overrideStartPartition when backfillStartDate is not passed


## Why / Goal
This will help airflow DAG to run everyday without specifying it from Feature definition


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

