### PR TITLE
Flink trigger as param to tiledjob

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -18,6 +18,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction
 import org.apache.flink.streaming.api.windowing.assigners.{TumblingEventTimeWindows, WindowAssigner}
 import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow
 import org.slf4j.LoggerFactory
 
@@ -112,8 +113,13 @@ class FlinkJob[T](eventSrc: FlinkSource[T],
     *  5. KV store writer - Writes the PutRequest objects to the KV store using the AsyncDataStream API
     *
     *  The window causes a split in the Flink DAG, so there are two nodes, (1+2) and (3+4+5).
+    *
+    * @param trigger - trigger used for window emission. Defaulted to AlwaysFireOnElementTrigger which fires on every element
+    *                An alternative is BufferedProcessingTimeTrigger which buffer writes so they happen at most every X milliseconds per GroupBy & key
     */
-  def runTiledGroupByJob(env: StreamExecutionEnvironment): DataStream[WriteResponse] = {
+  def runTiledGroupByJob(
+      env: StreamExecutionEnvironment,
+      trigger: Trigger[Map[String, Any], TimeWindow] = new AlwaysFireOnElementTrigger()): DataStream[WriteResponse] = {
     logger.info(
       f"Running Flink job for featureGroupName=${featureGroupName}, kafkaTopic=${kafkaTopic}. " +
         f"Tiling is enabled.")
@@ -139,10 +145,6 @@ class FlinkJob[T](eventSrc: FlinkSource[T],
     val window = TumblingEventTimeWindows
       .of(Time.milliseconds(tilingWindowSizeInMillis.get))
       .asInstanceOf[WindowAssigner[Map[String, Any], TimeWindow]]
-
-    // An alternative to AlwaysFireOnElementTrigger can be used: BufferedProcessingTimeTrigger.
-    // The latter will buffer writes so they happen at most every X milliseconds per GroupBy & key.
-    val trigger = new AlwaysFireOnElementTrigger()
 
     // We use Flink "Side Outputs" to track any late events that aren't computed.
     val tilingLateEventsTag = OutputTag[Map[String, Any]]("tiling-late-events")


### PR DESCRIPTION
## Summary
Currently the trigger used is `AlwaysFireOnElementTrigger` in runTiledGroupByJob. This is hardcoded and restricts use of using other custom triggers like BufferedProcessingTimeTrigger by passing to the job. Changes include making trigger as optional parameter, defaulting to AlwaysFireOnElement if not passed


## Why / Goal
Users can pass custom trigger as required to the Flink tiled jobs


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@piyush-zlai, @caiocamatta-stripe, @pengyu-hou 
