### PR TITLE
Update spark app name for all join backfill stages

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -344,8 +344,8 @@ object Driver {
       lazy val joinConf: api.Join = parseConf[api.Join](confPath())
       override def subcommandName() =
         if (selectedJoinParts.isDefined) {
-          val parts = selectedJoinParts().mkString("_")
-          s"join_${joinConf.metaData.name}_${parts}"
+          val parts = selectedJoinParts().mkString(",")
+          s"join_${joinConf.metaData.name}_jp_${parts}"
         } else {
           s"join_${joinConf.metaData.name}"
         }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -342,7 +342,12 @@ object Driver {
           default = Some(false),
           descr = "Whether or not to use the cached bootstrap table as the source - used in parallelized join flow.")
       lazy val joinConf: api.Join = parseConf[api.Join](confPath())
-      override def subcommandName() = s"join_${joinConf.metaData.name}"
+      override def subcommandName() = if (selectedJoinParts.isDefined) {
+        val parts = selectedJoinParts().mkString("_")
+        s"join_${joinConf.metaData.name}_${parts}"
+      } else {
+        s"join_${joinConf.metaData.name}"
+      }
     }
 
     def run(args: Args): Unit = {

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -342,12 +342,13 @@ object Driver {
           default = Some(false),
           descr = "Whether or not to use the cached bootstrap table as the source - used in parallelized join flow.")
       lazy val joinConf: api.Join = parseConf[api.Join](confPath())
-      override def subcommandName() = if (selectedJoinParts.isDefined) {
-        val parts = selectedJoinParts().mkString("_")
-        s"join_${joinConf.metaData.name}_${parts}"
-      } else {
-        s"join_${joinConf.metaData.name}"
-      }
+      override def subcommandName() =
+        if (selectedJoinParts.isDefined) {
+          val parts = selectedJoinParts().mkString("_")
+          s"join_${joinConf.metaData.name}_${parts}"
+        } else {
+          s"join_${joinConf.metaData.name}"
+        }
     }
 
     def run(args: Args): Unit = {

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -398,7 +398,7 @@ object Driver {
         with LocalExportTableAbility
         with ResultValidationAbility {
       lazy val joinConf: api.Join = parseConf[api.Join](confPath())
-      override def subcommandName() = s"join_left_${joinConf.metaData.name}"
+      override def subcommandName() = s"join_${joinConf.metaData.name}_left"
     }
 
     def run(args: Args): Unit = {
@@ -422,7 +422,7 @@ object Driver {
         with LocalExportTableAbility
         with ResultValidationAbility {
       lazy val joinConf: api.Join = parseConf[api.Join](confPath())
-      override def subcommandName() = s"join_final_${joinConf.metaData.name}"
+      override def subcommandName() = s"join_${joinConf.metaData.name}_final"
     }
 
     def run(args: Args): Unit = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->


1. If `selectedJoinParts` mode (where we only run a subset of join_parts), add join_parts as suffix to spark application name for easier monitoring. 
2. Update spark application name for left and final stage to match the format for easier prefix-matching

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

For easier monitoring and analysis. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pallavia7 