### PR TITLE
Fixing incorrect table names in run script and partition column

### DIFF
--- a/api/py/test/sample/scripts/run.sh
+++ b/api/py/test/sample/scripts/run.sh
@@ -44,7 +44,7 @@ run.py --mode backfill --conf production/joins/quickstart/training_set.v2
 # Run stats on the features
 run.py --mode stats-summary --conf production/joins/quickstart/training_set.v2
 # Upload to KV Store
-spark-submit --class ai.chronon.quickstart.online.Spark2MongoLoader --master local[*] /srv/onlineImpl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar default.quickstart_training_set_v2_logged_daily_stats_upload mongodb://admin:admin@mongodb:27017/?authSource=admin
+spark-submit --class ai.chronon.quickstart.online.Spark2MongoLoader --master local[*] /srv/onlineImpl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar default.quickstart_training_set_v2_daily_stats_upload mongodb://admin:admin@mongodb:27017/?authSource=admin
 # Fetch from KV Store
 run.py --mode fetch --type join-stats --name quickstart/training_set.v2 -k '{"startTs":"0","endTs":"180000000000000"}'
 
@@ -52,7 +52,7 @@ printf "\n => LOGSTATS \n\n"
 # Run Log stats
 run.py --mode log-summary --conf production/joins/quickstart/training_set.v2
 # Upload to KV Store
-spark-submit --class ai.chronon.quickstart.online.Spark2MongoLoader --master local[*] /srv/onlineImpl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar default.quickstart_training_set_v2_daily_stats_upload mongodb://admin:admin@mongodb:27017/?authSource=admin
+spark-submit --class ai.chronon.quickstart.online.Spark2MongoLoader --master local[*] /srv/onlineImpl/target/scala-2.12/mongo-online-impl-assembly-0.1.0-SNAPSHOT.jar default.quickstart_training_set_v2_logged_daily_stats_upload mongodb://admin:admin@mongodb:27017/?authSource=admin
 
 printf"\n => OOC \n\n"
 # Compute consistency metrics tables

--- a/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
@@ -70,7 +70,7 @@ class SummaryJob(session: SparkSession, joinConf: Join, endDate: String) extends
           val inputDf = tableUtils.sql(s"""
                |SELECT *
                |FROM $inputTable
-               |WHERE ds BETWEEN '${range.start}' AND '${range.end}'
+               |WHERE ${tableUtils.partitionColumn} BETWEEN '${range.start}' AND '${range.end}'
                |""".stripMargin)
           val stats = new StatsCompute(inputDf, joinConf.leftKeyCols, joinConf.metaData.nameToFilePath)
           val aggregator = StatsGenerator.buildAggregator(


### PR DESCRIPTION
## Summary

1. Stats and logstats names are replaced with right names
2. Summaryjob has hardcoded timepartition column 


## Why / Goal
Failing sample run script and summary job


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@piyush-zlai @pengyu-hou @caiocamatta-stripe 