### PR TITLE
add metrics for multi_get failures 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -430,6 +430,15 @@ class FetcherBase(kvStore: KVStore,
       kvStore.multiGet(allRequestsToFetch)
     } else {
       Future(Seq.empty[GetResponse])
+    }.recover {
+      case e: Throwable =>
+        // Capture exceptions from calling KvStore.multiGet
+        // requestMetaTry is a Failure when GBServingInfo failed to load, those are skipped because we don't fetch them.
+        groupByRequestToKvRequest.foreach {
+          case (_, requestMetaTry) =>
+            requestMetaTry.toOption.foreach(_.context.withSuffix("multi_get").incrementException(e))
+        }
+        throw e
     }
 
     kvResponseFuture
@@ -453,6 +462,7 @@ class FetcherBase(kvStore: KVStore,
               context.count("multi_get.batch.size", allRequestsToFetch.length)
               context.distribution("multi_get.bytes", totalResponseValueBytes)
               context.distribution("multi_get.response.length", kvResponses.length)
+              context.distribution("multi_get.response.success.length", kvResponses.count(_.values.isSuccess))
               context.distribution("multi_get.latency.millis", multiGetMillis)
 
               // pick the batch version with highest timestamp


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

`kvResponseFuture` is being reused and mapped all the way through fetchGroupBys -> FetcherBase.fetchJoins -> Fetcher.fetchJoins -> logResponse, with no instrumentation when it's a Failure. 


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Better observability 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Reviewers

@xiaohui-sun @pengyu-hou 