### PR TITLE
Added option to disable Kryo serializer in SparkDriver invocation

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -289,7 +289,7 @@ def set_runtime_env(args):
                         conf_json = json.load(conf_file)
                     environment["conf_env"] = conf_json.get("metaData").get("modeToEnvMap", {}).get(effective_mode, {})
                     # Load additional args used on backfill.
-                    if custom_json(conf_json) and effective_mode in ["backfill", "backfill-left", "backfill-final"]:
+                    if custom_json(conf_json) and effective_mode in ["backfill", "backfill-left", "backfill-final", "upload"]:
                         environment["conf_env"]["CHRONON_CONFIG_ADDITIONAL_ARGS"] = " ".join(
                             custom_json(conf_json).get("additional_args", [])
                         )

--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -289,7 +289,9 @@ def set_runtime_env(args):
                         conf_json = json.load(conf_file)
                     environment["conf_env"] = conf_json.get("metaData").get("modeToEnvMap", {}).get(effective_mode, {})
                     # Load additional args used on backfill.
-                    if custom_json(conf_json) and effective_mode in ["backfill", "backfill-left", "backfill-final", "upload"]:
+                    if custom_json(conf_json) and effective_mode in {
+                      "backfill", "backfill-left", "backfill-final", "upload"
+                    }:
                         environment["conf_env"]["CHRONON_CONFIG_ADDITIONAL_ARGS"] = " ".join(
                             custom_json(conf_json).get("additional_args", [])
                         )

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -196,9 +196,8 @@ object Driver {
 
     val disableKryoSerializer: ScallopOption[Boolean] =
       opt[Boolean](required = false,
-        default = Some(false),
-        descr = "Disable Kryo to use JavaSerializer by default instead.")
-
+                   default = Some(false),
+                   descr = "Disable Kryo to use JavaSerializer by default instead.")
 
     lazy val sparkSession: SparkSession = buildSparkSession()
 
@@ -225,8 +224,7 @@ object Driver {
                                                      local = true,
                                                      localWarehouseLocation.toOption,
                                                      additionalConfig = extraDeltaConfigs,
-                                                     enforceKryoSerializer = !disableKryoSerializer.apply()
-        )
+                                                     enforceKryoSerializer = !disableKryoSerializer.apply())
         localTableMapping.foreach {
           case (table, filePath) =>
             val file = new File(filePath)
@@ -237,20 +235,22 @@ object Driver {
         val dir = new File(localDataPath())
         assert(dir.exists, s"Provided local data path: ${localDataPath()} doesn't exist")
         val localSession =
-          SparkSessionBuilder.build(subcommandName(),
-                                    local = true,
-                                    localWarehouseLocation = localWarehouseLocation.toOption,
-                                    additionalConfig = extraDeltaConfigs,
-                                    enforceKryoSerializer = !disableKryoSerializer.apply()
+          SparkSessionBuilder.build(
+            subcommandName(),
+            local = true,
+            localWarehouseLocation = localWarehouseLocation.toOption,
+            additionalConfig = extraDeltaConfigs,
+            enforceKryoSerializer = !disableKryoSerializer.apply()
           )
         LocalDataLoader.loadDataRecursively(dir, localSession)
         localSession
       } else {
         // We use the KryoSerializer for group bys and joins since we serialize the IRs.
         // But since staging query is fairly freeform, it's better to stick to the java serializer.
-        SparkSessionBuilder.build(subcommandName(),
-                                  enforceKryoSerializer = !subcommandName().contains("staging_query") && !disableKryoSerializer.apply(),
-                                  additionalConfig = extraDeltaConfigs)
+        SparkSessionBuilder.build(
+          subcommandName(),
+          enforceKryoSerializer = !subcommandName().contains("staging_query") && !disableKryoSerializer.apply(),
+          additionalConfig = extraDeltaConfigs)
       }
     }
 


### PR DESCRIPTION
## Summary
Currently, Spark Driver uses kryoserializer by default. Added an option to disable Kryo so that java serializer can be used. 

## Why / Goal
We came across oncall issue with certain UDFs not working with kryoserializer. Added option to disable Kryo, which in turn defaults to Java Serializer. 


## Test Plan
Integration Tested backfill and upload mode. 
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [+] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

