### PR TITLE
Revert change on FetchGroupBys return value when key doesn't exist

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -539,7 +539,8 @@ class FetcherBase(kvStore: KVStore,
                 }
                 derivedMap
               } else {
-                groupByResponse.get
+                // When using fetchGroupBys and fetch key doesn't exist it should return Null.
+                groupByResponse.orNull
               }
             }
             Response(request, responseMapTry)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
The original change in [this PR](https://github.com/airbnb/chronon/pull/922/files#diff-9ea959844a5006c401298a8b18ac1b693a917a310345d563a10b76558127a297L490) changed the return value of fetchGroupBys when key doesn't exist.
Originally it returns Null, and after it returns an empty map.

This is an in-compatible change so we need to roll it back.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@airbnb/airbnb-chronon-maintainers 
