### PR TITLE
Use builder pattern to build java fetcher and add new buildJavaFetcherWithExecutionContext

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -244,6 +244,7 @@ abstract class Api(userConf: Map[String, String]) extends Serializable {
       .callerName(callerName)
       .flagStore(flagStore)
       .disableErrorThrows(disableErrorThrows)
+      .debug(false)
       .build()
   }
 

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -44,7 +44,7 @@ object KVStore {
 // used for streaming writes, batch bulk uploads & fetching
 trait KVStore {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
-  implicit val executionContext: ExecutionContext = FlexibleExecutionContext.buildExecutionContext
+  implicit val executionContext: ExecutionContext = FlexibleExecutionContext.buildExecutionContext()
 
   def create(dataset: String): Unit
 
@@ -172,7 +172,7 @@ trait StreamBuilder {
 }
 
 object ExternalSourceHandler {
-  private[ExternalSourceHandler] val executor = FlexibleExecutionContext.buildExecutionContext
+  private[ExternalSourceHandler] val executor = FlexibleExecutionContext.buildExecutionContext()
 }
 
 // user facing class that needs to be implemented for external sources defined in a join

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -247,17 +247,9 @@ abstract class Api(userConf: Map[String, String]) extends Serializable {
       .build()
   }
 
-  final def buildJavaFetcherWithExecutionContext(callerName: String = null,
-                                                 disableErrorThrows: Boolean = false,
-                                                 debug: Boolean = false,
-                                                 executionContextOverride: ExecutionContext = null): JavaFetcher = {
+  final def javaFetcherBuilder(): JavaFetcher.Builder = {
     new JavaFetcher.Builder(genKvStore, Constants.ChrononMetadataKey, timeoutMillis, responseConsumer, externalRegistry)
-      .callerName(callerName)
-      .debug(debug)
       .flagStore(flagStore)
-      .disableErrorThrows(disableErrorThrows)
-      .executionContextOverride(executionContextOverride)
-      .build()
   }
 
   final def buildJavaFetcher(): JavaFetcher = buildJavaFetcher(callerName = null)

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -240,17 +240,27 @@ abstract class Api(userConf: Map[String, String]) extends Serializable {
                 disableErrorThrows = disableErrorThrows)
 
   final def buildJavaFetcher(callerName: String = null, disableErrorThrows: Boolean = false): JavaFetcher = {
-    new JavaFetcher(genKvStore,
-                    Constants.ChrononMetadataKey,
-                    timeoutMillis,
-                    responseConsumer,
-                    externalRegistry,
-                    callerName,
-                    flagStore,
-                    disableErrorThrows)
+    new JavaFetcher.Builder(genKvStore, Constants.ChrononMetadataKey, timeoutMillis, responseConsumer, externalRegistry)
+      .callerName(callerName)
+      .flagStore(flagStore)
+      .disableErrorThrows(disableErrorThrows)
+      .build()
   }
 
-  final def buildJavaFetcher(): JavaFetcher = buildJavaFetcher(null)
+  final def buildJavaFetcherWithExecutionContext(callerName: String = null,
+                                                 disableErrorThrows: Boolean = false,
+                                                 debug: Boolean = false,
+                                                 executionContextOverride: ExecutionContext = null): JavaFetcher = {
+    new JavaFetcher.Builder(genKvStore, Constants.ChrononMetadataKey, timeoutMillis, responseConsumer, externalRegistry)
+      .callerName(callerName)
+      .debug(debug)
+      .flagStore(flagStore)
+      .disableErrorThrows(disableErrorThrows)
+      .executionContextOverride(executionContextOverride)
+      .build()
+  }
+
+  final def buildJavaFetcher(): JavaFetcher = buildJavaFetcher(callerName = null)
 
   private def responseConsumer: Consumer[LoggableResponse] =
     new Consumer[LoggableResponse] {

--- a/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
+++ b/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, ThreadPoolExecut
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object FlexibleExecutionContext {
+  // users can also provide a custom execution context override in [MetadataStore]
   def buildExecutor(corePoolSize: Int = 20,
                     maxPoolSize: Int = 1000,
                     keepAliveTime: Int = 600,
@@ -28,6 +29,7 @@ object FlexibleExecutionContext {
     new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, keepAliveTimeUnit, workQueue)
   def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor())
 
+  // a helper method to tune execution context based on thread pool size
   def buildCustomExecutionContext(maxPoolSize: Int): ExecutionContextExecutor =
     ExecutionContext.fromExecutor(buildExecutor(maxPoolSize = maxPoolSize))
 }

--- a/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
+++ b/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
@@ -27,9 +27,18 @@ object FlexibleExecutionContext {
                     keepAliveTimeUnit: TimeUnit = TimeUnit.SECONDS,
                     workQueue: BlockingQueue[Runnable] = new ArrayBlockingQueue[Runnable](1000)): ThreadPoolExecutor =
     new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, keepAliveTimeUnit, workQueue)
-  def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor())
 
-  // a helper method to tune execution context based on thread pool size
-  def buildCustomExecutionContext(maxPoolSize: Int): ExecutionContextExecutor =
-    ExecutionContext.fromExecutor(buildExecutor(maxPoolSize = maxPoolSize))
+  // a helper method to tune execution context
+  def buildExecutionContext(
+      corePoolSize: Int = 20,
+      maxPoolSize: Int = 1000,
+      keepAliveTime: Int = 600,
+      keepAliveTimeUnit: TimeUnit = TimeUnit.SECONDS,
+      workQueue: BlockingQueue[Runnable] = new ArrayBlockingQueue[Runnable](1000)): ExecutionContextExecutor =
+    ExecutionContext.fromExecutor(
+      buildExecutor(corePoolSize = corePoolSize,
+                    maxPoolSize = maxPoolSize,
+                    keepAliveTime = keepAliveTime,
+                    keepAliveTimeUnit = keepAliveTimeUnit,
+                    workQueue = workQueue))
 }

--- a/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
+++ b/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
@@ -20,11 +20,14 @@ import java.util.concurrent.{ArrayBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object FlexibleExecutionContext {
-  def buildExecutor: ThreadPoolExecutor =
+  def buildExecutor(maxPoolSize: Int): ThreadPoolExecutor =
     new ThreadPoolExecutor(20, // corePoolSize
-                           1000, // maxPoolSize
+                           maxPoolSize, // maxPoolSize
                            600, // keepAliveTime
                            TimeUnit.SECONDS, // keep alive time units
                            new ArrayBlockingQueue[Runnable](1000))
-  def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor)
+  def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor(1000))
+
+  def buildCustomExecutionContext(maxPoolSize: Int): ExecutionContextExecutor =
+    ExecutionContext.fromExecutor(buildExecutor(maxPoolSize))
 }

--- a/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
+++ b/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
@@ -20,13 +20,13 @@ import java.util.concurrent.{ArrayBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object FlexibleExecutionContext {
-  def buildExecutor(maxPoolSize: Int): ThreadPoolExecutor =
+  def buildExecutor(maxPoolSize: Int = 1000): ThreadPoolExecutor =
     new ThreadPoolExecutor(20, // corePoolSize
                            maxPoolSize, // maxPoolSize
                            600, // keepAliveTime
                            TimeUnit.SECONDS, // keep alive time units
                            new ArrayBlockingQueue[Runnable](1000))
-  def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor(1000))
+  def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor())
 
   def buildCustomExecutionContext(maxPoolSize: Int): ExecutionContextExecutor =
     ExecutionContext.fromExecutor(buildExecutor(maxPoolSize))

--- a/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
+++ b/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala
@@ -16,18 +16,18 @@
 
 package ai.chronon.online
 
-import java.util.concurrent.{ArrayBlockingQueue, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, ThreadPoolExecutor, TimeUnit}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object FlexibleExecutionContext {
-  def buildExecutor(maxPoolSize: Int = 1000): ThreadPoolExecutor =
-    new ThreadPoolExecutor(20, // corePoolSize
-                           maxPoolSize, // maxPoolSize
-                           600, // keepAliveTime
-                           TimeUnit.SECONDS, // keep alive time units
-                           new ArrayBlockingQueue[Runnable](1000))
+  def buildExecutor(corePoolSize: Int = 20,
+                    maxPoolSize: Int = 1000,
+                    keepAliveTime: Int = 600,
+                    keepAliveTimeUnit: TimeUnit = TimeUnit.SECONDS,
+                    workQueue: BlockingQueue[Runnable] = new ArrayBlockingQueue[Runnable](1000)): ThreadPoolExecutor =
+    new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, keepAliveTimeUnit, workQueue)
   def buildExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(buildExecutor())
 
   def buildCustomExecutionContext(maxPoolSize: Int): ExecutionContextExecutor =
-    ExecutionContext.fromExecutor(buildExecutor(maxPoolSize))
+    ExecutionContext.fromExecutor(buildExecutor(maxPoolSize = maxPoolSize))
 }

--- a/online/src/main/scala/ai/chronon/online/MetadataStore.scala
+++ b/online/src/main/scala/ai/chronon/online/MetadataStore.scala
@@ -56,7 +56,7 @@ class MetadataStore(kvStore: KVStore,
   }
 
   implicit val executionContext: ExecutionContext =
-    Option(executionContextOverride).getOrElse(FlexibleExecutionContext.buildExecutionContext)
+    Option(executionContextOverride).getOrElse(FlexibleExecutionContext.buildExecutionContext())
 
   def getConf[T <: TBase[_, _]: Manifest](confPathOrName: String): Try[T] = {
     val clazz = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]

--- a/online/src/main/scala/ai/chronon/online/TTLCache.scala
+++ b/online/src/main/scala/ai/chronon/online/TTLCache.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function
 
 object TTLCache {
-  private[TTLCache] val executor = FlexibleExecutionContext.buildExecutor
+  private[TTLCache] val executor = FlexibleExecutionContext.buildExecutor()
 }
 // can continuously grow, only used for schemas
 // has two methods apply & refresh. Apply uses a longer ttl before updating than refresh


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR refactored the code to build java fetcher and expose parameters like `execution context` for thread pool tuning. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
In case the default [execution context](https://github.com/airbnb/chronon/blob/main/online/src/main/scala/ai/chronon/online/FlexibleExecutionContext.scala) does not meet performance demands, users can provide a custom one for performance tuning. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
