### PR TITLE
Exclude backfill start date for versioning in join jobs

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -907,20 +907,28 @@ object Extensions {
       join
     }
 
-    /*
-     * Compute variants of semantic_hash with different flags. A flag is stored on Hive metadata and used to
-     * indicate which version of semantic_hash logic to use.
-     */
-    def semanticHash(excludeTopic: Boolean): Map[String, String] = {
+    /**
+      * Compute variants of semantic_hash with different flags. A flag is stored on Hive metadata and used to
+      * indicate which version of semantic_hash logic to use.
+      * @param excludeTopic exclude streaming topic for any potential streaming topic migrations
+      * @param excludeBackfillStartDateInJoinPart exclude the backfill start date in the join part, it is intended to
+      *                                           trigger separate group by backfill jobs, and semantic hash is only
+      *                                           used in join for versioning check, therefore, exclude it for more
+      *                                           flexibility of group by backfill jobs
+      */
+    def semanticHash(excludeTopic: Boolean, excludeBackfillStartDateInJoinPart: Boolean = true): Map[String, String] = {
+      // WARN: deepCopy doesn't guarantee same semantic_hash will be produced due to reordering of map keys
+      // but the behavior is deterministic
+      val joinCopy = if (excludeTopic || excludeBackfillStartDateInJoinPart) join.deepCopy() else join
+
       if (excludeTopic) {
-        // WARN: deepCopy doesn't guarantee same semantic_hash will be produced due to reordering of map keys
-        // but the behavior is deterministic
-        val joinCopy = join.deepCopy()
         cleanTopic(joinCopy)
-        joinCopy.baseSemanticHash
-      } else {
-        baseSemanticHash
       }
+
+      if (excludeBackfillStartDateInJoinPart) {
+        joinCopy.getJoinParts.toScala.foreach(_.groupBy.unsetBackfillStartDate())
+      }
+      joinCopy.baseSemanticHash
     }
 
     /*


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
This PR will add a flag to exclude backfill start date in the join part in versioning check.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Exclude the backfill start date in the join part, it is intended to trigger separate group by backfill jobs, and semantic hash is only used in join for versioning check, therefore, exclude it for more flexibility of group by backfill jobs

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
