### PR TITLE
select partition column only for table access check

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -441,7 +441,8 @@ case class TableUtils(sparkSession: SparkSession) {
       // retrieve one row from the table
       val partitionFilter = lastAvailablePartition(tableName).getOrElse(fallbackPartition)
       sparkSession
-        .sql(s"SELECT ${getPartitionColumn(partitionColOpt)} FROM $tableName where ${getPartitionColumn(partitionColOpt)}='$partitionFilter' LIMIT 1")
+        .sql(
+          s"SELECT ${getPartitionColumn(partitionColOpt)} FROM $tableName where ${getPartitionColumn(partitionColOpt)}='$partitionFilter' LIMIT 1")
         .collect()
       true
     } catch {

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -441,7 +441,7 @@ case class TableUtils(sparkSession: SparkSession) {
       // retrieve one row from the table
       val partitionFilter = lastAvailablePartition(tableName).getOrElse(fallbackPartition)
       sparkSession
-        .sql(s"SELECT * FROM $tableName where ${getPartitionColumn(partitionColOpt)}='$partitionFilter' LIMIT 1")
+        .sql(s"SELECT ${getPartitionColumn(partitionColOpt)} FROM $tableName where ${getPartitionColumn(partitionColOpt)}='$partitionFilter' LIMIT 1")
         .collect()
       true
     } catch {


### PR DESCRIPTION
## Summary
The current table access check is not granular to check access to specific columns. This change uses minimal columns to check table level access, leaving checking only necessary columns as a later task .

## Why / Goal
The current approach (select *) **unnecessarily fails jobs** which have general access to tables and to all necessary columns, but not to every (unused) columns in the table


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

