### PR TITLE
Remove the special handling for iceberg tables

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -333,6 +333,7 @@ class Analyzer(tableUtils: TableUtils,
       .unfilledRanges(joinConf.metaData.outputTable,
                       rangeToFill,
                       Some(Seq(joinConf.left.table)),
+                      inputTableToSubPartitionFiltersMap = Map(joinConf.left.table -> joinConf.left.subPartitionFilters),
                       inputTableToPartitionColumnsMap = joinConf.left.tableToPartitionColumn)
       .getOrElse(Seq.empty)
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -329,6 +329,7 @@ class Analyzer(tableUtils: TableUtils,
     val rangeToFill =
       JoinUtils.getRangesToFill(joinConf.left, tableUtils, endDate, historicalBackfill = joinConf.historicalBackfill)
     logger.info(s"Join range to fill $rangeToFill")
+
     val unfilledRanges = tableUtils
       .unfilledRanges(joinConf.metaData.outputTable,
                       rangeToFill,
@@ -357,7 +358,10 @@ class Analyzer(tableUtils: TableUtils,
       }
       // Run validation checks.
       keysWithError ++= runSchemaValidation(leftSchema, gbKeySchema, part.rightToLeft)
-      dataAvailabilityErrors ++= runDataAvailabilityCheck(joinConf.left.dataModel, part.groupBy, unfilledRanges)
+      val subPartitionFilters = part.groupBy.sources.toScala.map(
+        source => source.table -> source.subPartitionFilters
+      ).toMap
+      dataAvailabilityErrors ++= runDataAvailabilityCheck(joinConf.left.dataModel, part.groupBy, unfilledRanges, subPartitionFilters)
       noAccessTables ++= rightNoAccessTables
       // list any startPartition dates for conflict checks
       val gbStartPartition = part.groupBy.sources.toScala
@@ -513,7 +517,8 @@ class Analyzer(tableUtils: TableUtils,
   // return a list of (table, gb_name, expected_start) that don't have data available
   private def runDataAvailabilityCheck(leftDataModel: DataModel,
                                        groupBy: api.GroupBy,
-                                       unfilledRanges: Seq[PartitionRange]): List[(String, String, String)] = {
+                                       unfilledRanges: Seq[PartitionRange],
+                                       subPartitionsFilter: Map[String, Map[String, String]] = Map.empty) = {
     if (unfilledRanges.isEmpty) {
       logger.info("No unfilled ranges found.")
       List.empty
@@ -545,7 +550,7 @@ class Analyzer(tableUtils: TableUtils,
             val tableToPartitions = groupBy.sources.toScala.map { source =>
               val table = source.table
               logger.info(s"Checking table $table for data availability ...")
-              val partitions = tableUtils.partitions(table, partitionColOpt = source.partitionColumnOpt)
+              val partitions = tableUtils.partitions(table, subPartitionsFilter = subPartitionsFilter.getOrElse(table, Map.empty),partitionColOpt = source.partitionColumnOpt)
               val startOpt = if (partitions.isEmpty) None else Some(partitions.min)
               val endOpt = if (partitions.isEmpty) None else Some(partitions.max)
               (table, partitions, startOpt, endOpt)
@@ -557,7 +562,8 @@ class Analyzer(tableUtils: TableUtils,
               logger.info(s"""
                          |Join needs data older than what is available for GroupBy: ${groupBy.metaData.name}
                          |left-$leftDataModel, right-${groupBy.dataModel}, accuracy-${groupBy.inferredAccuracy}
-                         |expected earliest available data partition: $expectedStart""".stripMargin)
+                         |expected earliest available data partition: $expectedStart
+                         |actual earliest available data partition: $minPartition""".stripMargin)
               tableToPartitions.foreach {
                 case (table, _, startOpt, endOpt) =>
                   logger.info(

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -172,6 +172,7 @@ abstract class JoinBase(joinConf: api.Join,
           rightRange,
           Some(Seq(joinConf.left.table)),
           inputToOutputShift = shiftDays,
+          inputTableToSubPartitionFiltersMap = Map(joinConf.left.table -> joinConf.left.subPartitionFilters),
           inputTableToPartitionColumnsMap = joinConf.left.tableToPartitionColumn,
           // never skip hole during partTable's range determination logic because we don't want partTable
           // and joinTable to be out of sync. skipping behavior is already handled in the outer loop.
@@ -361,6 +362,7 @@ abstract class JoinBase(joinConf: api.Join,
          rangeToFill,
          Some(Seq(joinConf.left.table)),
          skipFirstHole = skipFirstHole,
+         inputTableToSubPartitionFiltersMap = Map(joinConf.left.table -> joinConf.left.subPartitionFilters),
          inputTableToPartitionColumnsMap = joinConf.left.tableToPartitionColumn
        )
        .getOrElse(Seq.empty))

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -23,6 +23,7 @@ import ai.chronon.api.{Constants, PartitionSpec, Query}
 import ai.chronon.api.Extensions._
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import ai.chronon.spark.Extensions.{DfStats, DfWithStats}
+import ai.chronon.spark.Hive.parseHivePartition
 import io.delta.tables.DeltaTable
 import jnr.ffi.annotations.Synchronized
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException
@@ -202,49 +203,18 @@ case object Hive extends Format {
 }
 
 case object Iceberg extends Format {
-  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
-      implicit sparkSession: SparkSession): Seq[String] = {
-    if (!supportSubPartitionsFilter && subPartitionsFilter.nonEmpty) {
-      throw new NotImplementedError(s"subPartitionsFilter is not supported on this format")
-    }
-
-    getIcebergPartitions(tableName, partitionColumn)
-  }
-
   override def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
-    throw new NotImplementedError(
-      "Multi-partitions retrieval is not supported on Iceberg tables yet." +
-        "For single partition retrieval, please use 'partition' method.")
-  }
-
-  private def getIcebergPartitions(tableName: String, partitionColumn: String)(implicit
-      sparkSession: SparkSession): Seq[String] = {
-    val partitionsDf = sparkSession.read.format("iceberg").load(s"$tableName.partitions")
-    val index = partitionsDf.schema.fieldIndex("partition")
-    if (partitionsDf.schema(index).dataType.asInstanceOf[StructType].fieldNames.contains("hr")) {
-      // Hour filter is currently buggy in iceberg. https://github.com/apache/iceberg/issues/4718
-      // so we collect and then filter.
-      partitionsDf
-        .select(s"partition.$partitionColumn", "partition.hr")
-        .collect()
-        .filter(_.get(1) == null)
-        .map(_.getString(0))
-        .toSeq
-    } else {
-      partitionsDf
-        .select(s"partition.$partitionColumn")
-        .collect()
-        .map(_.getString(0))
-        .toSeq
-    }
+    sparkSession.sqlContext
+      .sql(s"SHOW PARTITIONS $tableName")
+      .collect()
+      .map(row => parseHivePartition(row.getString(0)))
   }
 
   def createTableTypeString: String = "USING iceberg"
   def fileFormatString(format: String): String = ""
 
-  override def supportSubPartitionsFilter: Boolean = false
+  override def supportSubPartitionsFilter: Boolean = true
 }
-
 // The Delta Lake format is compatible with the Delta lake and Spark versions currently supported by the project.
 // Attempting to use newer Delta lake library versions (e.g. 3.2 which works with Spark 3.5) results in errors:
 // java.lang.NoSuchMethodError: 'org.apache.spark.sql.delta.Snapshot org.apache.spark.sql.delta.DeltaLog.update(boolean)'

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -205,14 +205,13 @@ case object Hive extends Format {
 case object Iceberg extends Format {
 
   override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
-    implicit sparkSession: SparkSession): Seq[String] = {
+      implicit sparkSession: SparkSession): Seq[String] = {
     if (!supportSubPartitionsFilter && subPartitionsFilter.nonEmpty) {
       throw new NotImplementedError(s"subPartitionsFilter is not supported on this format")
     }
 
     getIcebergPartitions(tableName, partitionColumn, subPartitionsFilter)
   }
-
 
   override def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
     sparkSession.sqlContext
@@ -221,11 +220,20 @@ case object Iceberg extends Format {
       .map(row => parseHivePartition(row.getString(0)))
   }
 
-  private def getIcebergPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(implicit
-                                                                               sparkSession: SparkSession): Seq[String] = {
+  private def getIcebergPartitions(tableName: String,
+                                   partitionColumn: String,
+                                   subPartitionsFilter: Map[String, String])(implicit
+      sparkSession: SparkSession): Seq[String] = {
     val partitionsDf = sparkSession.read.format("iceberg").load(s"$tableName.partitions")
     val index = partitionsDf.schema.fieldIndex("partition")
-    if (partitionsDf.schema(index).dataType.asInstanceOf[StructType].fieldNames.contains("hr") && subPartitionsFilter.isEmpty) {
+    if (
+      partitionsDf
+        .schema(index)
+        .dataType
+        .asInstanceOf[StructType]
+        .fieldNames
+        .contains("hr") && subPartitionsFilter.isEmpty
+    ) {
       // For iceberg tables with hr partition column but without sub-partition filter, only retain the records where hr=null.
       partitionsDf
         .select(s"partition.$partitionColumn", "partition.hr")


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We used to introduce a special handling for iceberg table with hr partition. This has blocked the users from using iceberg tables with hr partition as input because chronon is not able to detect corresponding partitions from the input table. 

The PR removes the special handling and enable the multiple partitions. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
Tested by integration test with iceberg hourly table. 

- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @pengyu-hou @pallavia7 @xiaohui-sun 
