### PR TITLE
Fix type hints for enums in ttypes

### DIFF
--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -33,12 +33,12 @@ LOGGER = logging.getLogger()
 
 
 def collector(
-    op: ttypes.Operation,
-) -> Callable[[ttypes.Operation], Tuple[ttypes.Operation, Dict[str, str]]]:
+    op: int,
+) -> Callable[[int], Tuple[int, Dict[str, str]]]:
     return lambda k: (op, {"k": str(k)})
 
 
-def generic_collector(op: ttypes.Operation, required, **kwargs):
+def generic_collector(op: int, required, **kwargs):
     def _collector(*args, **other_args):
         arguments = kwargs.copy() if kwargs else {}
         for idx, arg in enumerate(required):
@@ -123,8 +123,8 @@ def op_to_str(operation: OperationType):
 
 # See docs/Aggregations.md
 def Aggregation(
-    input_column: str = None,
-    operation: Union[ttypes.Operation, Tuple[ttypes.Operation, Dict[str, str]]] = None,
+    input_column: Optional[str] = None,
+    operation: Optional[Union[int, Tuple[int, Dict[str, str]]]] = None,
     windows: Optional[List[ttypes.Window]] = None,
     buckets: Optional[List[str]] = None,
     tags: Optional[Dict[str, str]] = None,
@@ -154,12 +154,14 @@ def Aggregation(
     arg_map = {}
     if isinstance(operation, tuple):
         operation, arg_map = operation[0], operation[1]
+    assert utils.is_valid_ttype_enum_value(operation, ttypes.Operation), f"Invalid operation: {operation}"
     agg = ttypes.Aggregation(input_column, operation, arg_map, windows, buckets)
     agg.tags = tags
     return agg
 
 
-def Window(length: int, timeUnit: ttypes.TimeUnit) -> ttypes.Window:
+def Window(length: int, timeUnit: int) -> ttypes.Window:
+    assert utils.is_valid_ttype_enum_value(timeUnit, ttypes.TimeUnit), f"Invalid timeUnit: {timeUnit}"
     return ttypes.Window(length, timeUnit)
 
 
@@ -342,7 +344,7 @@ def GroupBy(
     env: Optional[Dict[str, Dict[str, str]]] = None,
     table_properties: Optional[Dict[str, str]] = None,
     output_namespace: Optional[str] = None,
-    accuracy: Optional[ttypes.Accuracy] = None,
+    accuracy: Optional[int] = None,
     lag: int = 0,
     offline_schedule: str = "@daily",
     name: Optional[str] = None,
@@ -471,6 +473,8 @@ def GroupBy(
         A GroupBy object containing specified aggregations.
     """
     assert sources, "Sources are not specified"
+    if accuracy is not None:
+        assert utils.is_valid_ttype_enum_value(accuracy, ttypes.Accuracy), f"Invalid accuracy: {accuracy}"
 
     agg_inputs = []
     if aggregations is not None:

--- a/api/py/ai/chronon/utils.py
+++ b/api/py/ai/chronon/utils.py
@@ -23,7 +23,7 @@ import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass, fields
 from enum import Enum
-from typing import Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import ai.chronon.api.ttypes as api
 import ai.chronon.repo.extract_objects as eo
@@ -575,3 +575,8 @@ def get_config_path(join_name: str) -> str:
     assert "." in join_name, f"Invalid join name: {join_name}"
     team_name, config_name = join_name.split(".", 1)
     return f"production/joins/{team_name}/{config_name}"
+
+def is_valid_ttype_enum_value(value: int, enum_type: Any) -> bool:
+    """Validates that an integer value is valid for a Thrift enum type."""
+    assert hasattr(enum_type, '_VALUES_TO_NAMES'), f"enum_type {enum_type} is not a valid Thrift enum type"
+    return value in enum_type._VALUES_TO_NAMES


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Changes type hints for enum values to `int`s instead of the class type.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Current type hints for enum values are incorrect because of the way Thrift compiles them in Python. E.g. for `ttypes.Accuracy`:

```python
class Accuracy(object):
    TEMPORAL = 0
    SNAPSHOT = 1
```

So a parameter defined as `def my_func(accuracy: ttypes.Accuracy = ttyps.Accuracy.TEMPORAL)` ends up being an incorrect assignment because `TEMPORAL` is just an int.

To improve usability with IDEs and lint tools, along the same lines as #969.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

