### PR TITLE
Set refreshIntervalMillis=8ms for metadata's force update

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -309,7 +309,7 @@ class FetcherBase(kvStore: KVStore,
                      |ahead of schema timestamp of ${groupByServingInfo.batchEndTsMillis}.
                      |Forcing an update of schema.""".stripMargin)
       getGroupByServingInfo
-        .force(name)
+        .refresh(name)
         .recover {
           case ex: Throwable =>
             logger.error(s"Couldn't update GroupByServingInfo of $name. Proceeding with the old one.", ex)

--- a/online/src/main/scala/ai/chronon/online/TTLCache.scala
+++ b/online/src/main/scala/ai/chronon/online/TTLCache.scala
@@ -93,5 +93,4 @@ class TTLCache[I, O](f: I => O,
   def apply(i: I): O = asyncUpdateOnExpiry(i, ttlMillis)
   // manually refresh entry with a lower interval
   def refresh(i: I): O = asyncUpdateOnExpiry(i, refreshIntervalMillis)
-  def force(i: I): O = asyncUpdateOnExpiry(i, refreshIntervalMillis)
 }

--- a/online/src/main/scala/ai/chronon/online/TTLCache.scala
+++ b/online/src/main/scala/ai/chronon/online/TTLCache.scala
@@ -93,5 +93,5 @@ class TTLCache[I, O](f: I => O,
   def apply(i: I): O = asyncUpdateOnExpiry(i, ttlMillis)
   // manually refresh entry with a lower interval
   def refresh(i: I): O = asyncUpdateOnExpiry(i, refreshIntervalMillis)
-  def force(i: I): O = asyncUpdateOnExpiry(i, 0)
+  def force(i: I): O = asyncUpdateOnExpiry(i, refreshIntervalMillis)
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
We are seeing potentially thread pool exhaustion during forcing update of GB serving info's metadata. Set a refresh limit to reduce the potential load.  

Next steps: 
- we will monitor the effectiveness of this PR. If not, we will implement an exponential backoff version 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
The PR will make the online fetching more robust.  

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
