### PR TITLE
Fixing bazel py:api_test dependency paths on fresh build

### DIFF
--- a/.ijwb/.bazelproject
+++ b/.ijwb/.bazelproject
@@ -14,4 +14,3 @@ additional_languages:
   python
   scala
   java
-  python

--- a/.ijwb/.bazelproject
+++ b/.ijwb/.bazelproject
@@ -14,3 +14,4 @@ additional_languages:
   python
   scala
   java
+  python

--- a/api/py/BUILD.bazel
+++ b/api/py/BUILD.bazel
@@ -40,18 +40,21 @@ pytest_suite(
         ["test/**/*.py"],
         exclude = ["test/sample/**/*"],
     ),
-    data = glob(["test/sample/**/*"]),
+    data = glob(["test/sample/**/*",
+                 "test/lineage/**/*.sql"]),
     env = {
         "CHRONON_ROOT": "api/py/",
     },
     imports = [
         ".",
         "test/sample",
+        "chronon/api/thrift",
     ],
     deps = [
         "//api/py:api_py",
         "//api/thrift:api-models-py",
         requirement("thrift"),
         requirement("click"),
+        requirement("sqlglot")
     ],
 )

--- a/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
@@ -4,7 +4,7 @@
     "production": 0,
     "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
     "dependencies": [
-      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
     ],
     "tableProperties": {
       "sample_config_json": "{\"sample_key\": \"sample_value\"}",
@@ -17,7 +17,7 @@
   "sources": [
     {
       "events": {
-        "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill",
+        "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
         "query": {
           "selects": {
             "event": "event_expr",

--- a/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
@@ -6,7 +6,7 @@
     "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
-      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
     ],
     "tableProperties": {
       "source": "chronon"
@@ -39,7 +39,7 @@
           "production": 0,
           "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
           "dependencies": [
-            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
           "tableProperties": {
             "sample_config_json": "{\"sample_key\": \"sample_value\"}",
@@ -52,7 +52,7 @@
         "sources": [
           {
             "events": {
-              "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill",
+              "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
               "query": {
                 "selects": {
                   "event": "event_expr",

--- a/api/py/test/test_compile.py
+++ b/api/py/test/test_compile.py
@@ -19,7 +19,6 @@ Run the flow for materialize.
 import json
 import os
 import re
-
 import pytest
 from ai.chronon.api.ttypes import GroupBy, Join
 from ai.chronon.repo.compile import extract_and_convert

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click
 thrift==0.13
 pytest
 twine==6.1.0
-sqlglot
+sqlglot==25.17.0
 # To update dependency run: bazel run //:pip.update

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click
 thrift==0.13
 pytest
 twine==6.1.0
-
+sqlglot
 # To update dependency run: bazel run //:pip.update

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -243,9 +243,9 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via thrift
-sqlglot==26.16.0 \
-    --hash=sha256:253585bd6694bf376af100a306f71d8dae2e6b5be0b61df130a7c1d868d28487 \
-    --hash=sha256:7ecc3f7c73d714cad39a11a48c76db5e64466f93c793bf56ed8df6bb1210efb7
+sqlglot==25.17.0 \
+    --hash=sha256:8580475f4ee27032ad00b366b8a1967f3630f119a07ed6da92653adcba7ba731 \
+    --hash=sha256:91f3741f815a5e1d1dd157a428268af3eda43632dad56790d5c547be1c0491d0
     # via -r requirements.txt
 thrift==0.13.0 \
     --hash=sha256:9af1c86bf73433afc6010ed376a6c6aca2b54099cc0d61895f640870a9ae7d89

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -243,6 +243,10 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via thrift
+sqlglot==26.16.0 \
+    --hash=sha256:253585bd6694bf376af100a306f71d8dae2e6b5be0b61df130a7c1d868d28487 \
+    --hash=sha256:7ecc3f7c73d714cad39a11a48c76db5e64466f93c793bf56ed8df6bb1210efb7
+    # via -r requirements.txt
 thrift==0.13.0 \
     --hash=sha256:9af1c86bf73433afc6010ed376a6c6aca2b54099cc0d61895f640870a9ae7d89
     # via -r requirements.txt


### PR DESCRIPTION
## Summary
when following devnotes.md on a fresh machine, `bazel build //...` correctly builds, but the target `bazel test //api/py:api_test` will fail. This will fail for these reasons:

* The thrift packages will resolve to `chronon.api.thrift.ai.chronon.api.ttypes` until the "chronon/api/thrift" import is added. 
* After adding and rebuilding, the target succeeds the import, even if you test on an earlier commit. This leads me to believe the current set up is slightly non hermatic and relies on some setup in the sbt instructions for thrift/python path resolution. 
* There are a couple more path problems with sqlglot and the lineage folder, which are also resolved here.

## Why / Goal
Fresh containers should be able to run tests with only the bazel instructions. 

## Test Plan
- [N] Added Unit Tests
- [Y] Covered by existing CI
- [N] Integration tested

## Checklist
- [ N/A] Documentation update

## Reviewers

