### PR TITLE
Support Hive views as source inputs

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -74,7 +74,8 @@ trait Format {
   }
 
   // Return a sequence for partitions where each partition entry consists of a Map of partition keys to values
-  def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]]
+  def partitions(tableName: String, partitionColumns: Seq[String])(implicit
+      sparkSession: SparkSession): Seq[Map[String, String]]
 
   // Help specify the appropriate table type to use in the Spark create table DDL query
   def createTableTypeString: String
@@ -206,7 +207,8 @@ case object Hive extends Format {
       .toMap
   }
 
-  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit
+      sparkSession: SparkSession): Seq[Map[String, String]] = {
     // data is structured as a Df with single composite partition key column. Every row is a partition with the
     // column values filled out as a formatted key=value pair
     // Eg. df schema = (partitions: String)
@@ -234,7 +236,8 @@ case object Iceberg extends Format {
     getIcebergPartitions(tableName, partitionColumn, subPartitionsFilter)
   }
 
-  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit
+      sparkSession: SparkSession): Seq[Map[String, String]] = {
     sparkSession.sqlContext
       .sql(s"SHOW PARTITIONS $tableName")
       .collect()
@@ -282,7 +285,8 @@ case object DeltaLake extends Format {
       implicit sparkSession: SparkSession): Seq[String] =
     super.primaryPartitions(tableName, partitionColumn, subPartitionsFilter)
 
-  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit
+      sparkSession: SparkSession): Seq[Map[String, String]] = {
     // delta lake doesn't support the `SHOW PARTITIONS <tableName>` syntax - https://github.com/delta-io/delta/issues/996
     // there's alternative ways to retrieve partitions using the DeltaLog abstraction which is what we have to lean into
     // below
@@ -304,10 +308,11 @@ case object DeltaLake extends Format {
 
 case object View extends Format {
   override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
-    implicit sparkSession: SparkSession): Seq[String] =
+      implicit sparkSession: SparkSession): Seq[String] =
     super.primaryPartitions(tableName, partitionColumn, subPartitionsFilter)
 
-  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit
+      sparkSession: SparkSession): Seq[Map[String, String]] = {
     val partitionColumnsStr = partitionColumns.mkString("`,`")
     sparkSession.sqlContext
       .sql(s"SELECT DISTINCT `$partitionColumnsStr` FROM $tableName")
@@ -320,7 +325,6 @@ case object View extends Format {
 
   override def supportSubPartitionsFilter: Boolean = true
 }
-
 
 case class TableUtils(sparkSession: SparkSession) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)

--- a/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/TableUtils.scala
@@ -59,7 +59,7 @@ trait Format {
       throw new NotImplementedError(s"subPartitionsFilter is not supported on this format")
     }
 
-    val partitionSeq = partitions(tableName)(sparkSession)
+    val partitionSeq = partitions(tableName, partitionColumn +: subPartitionsFilter.keys.toSeq)(sparkSession)
     partitionSeq.flatMap { partitionMap =>
       if (
         subPartitionsFilter.forall {
@@ -74,7 +74,7 @@ trait Format {
   }
 
   // Return a sequence for partitions where each partition entry consists of a Map of partition keys to values
-  def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]]
+  def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]]
 
   // Help specify the appropriate table type to use in the Spark create table DDL query
   def createTableTypeString: String
@@ -110,6 +110,8 @@ case class DefaultFormatProvider(sparkSession: SparkSession) extends FormatProvi
       Iceberg
     } else if (isDeltaTable(tableName)) {
       DeltaLake
+    } else if (isView(tableName)) {
+      View
     } else {
       Hive
     }
@@ -138,6 +140,25 @@ case class DefaultFormatProvider(sparkSession: SparkSession) extends FormatProvi
       case _ =>
         // the describe detail calls fails for Delta Lake tables
         logger.info(s"Delta check: Unable to read the format of the table $tableName using DESCRIBE DETAIL")
+        false
+    }
+  }
+
+  private def isView(tableName: String): Boolean = {
+    Try {
+      val describeResult = sparkSession.sql(s"DESCRIBE TABLE EXTENDED $tableName")
+      describeResult
+        .filter(lower(col("col_name")) === "type")
+        .select("data_type")
+        .collect()
+        .headOption
+        .exists(row => row.getString(0).toLowerCase.contains("view"))
+    } match {
+      case Success(isView) =>
+        logger.info(s"View check: Table: $tableName is view: $isView")
+        isView
+      case _ =>
+        logger.info(s"View check: Unable to check if the table $tableName is a view using DESCRIBE TABLE EXTENDED")
         false
     }
   }
@@ -185,7 +206,7 @@ case object Hive extends Format {
       .toMap
   }
 
-  override def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
     // data is structured as a Df with single composite partition key column. Every row is a partition with the
     // column values filled out as a formatted key=value pair
     // Eg. df schema = (partitions: String)
@@ -213,7 +234,7 @@ case object Iceberg extends Format {
     getIcebergPartitions(tableName, partitionColumn, subPartitionsFilter)
   }
 
-  override def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
     sparkSession.sqlContext
       .sql(s"SHOW PARTITIONS $tableName")
       .collect()
@@ -261,7 +282,7 @@ case object DeltaLake extends Format {
       implicit sparkSession: SparkSession): Seq[String] =
     super.primaryPartitions(tableName, partitionColumn, subPartitionsFilter)
 
-  override def partitions(tableName: String)(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
     // delta lake doesn't support the `SHOW PARTITIONS <tableName>` syntax - https://github.com/delta-io/delta/issues/996
     // there's alternative ways to retrieve partitions using the DeltaLog abstraction which is what we have to lean into
     // below
@@ -280,6 +301,26 @@ case object DeltaLake extends Format {
 
   override def supportSubPartitionsFilter: Boolean = true
 }
+
+case object View extends Format {
+  override def primaryPartitions(tableName: String, partitionColumn: String, subPartitionsFilter: Map[String, String])(
+    implicit sparkSession: SparkSession): Seq[String] =
+    super.primaryPartitions(tableName, partitionColumn, subPartitionsFilter)
+
+  override def partitions(tableName: String, partitionColumns: Seq[String])(implicit sparkSession: SparkSession): Seq[Map[String, String]] = {
+    val partitionColumnsStr = partitionColumns.mkString("`,`")
+    sparkSession.sqlContext
+      .sql(s"SELECT DISTINCT `$partitionColumnsStr` FROM $tableName")
+      .collect()
+      .map(row => row.schema.fieldNames.zip(row.toSeq.map(_.toString)).toMap)
+  }
+
+  def createTableTypeString: String = ""
+  def fileFormatString(format: String): String = ""
+
+  override def supportSubPartitionsFilter: Boolean = true
+}
+
 
 case class TableUtils(sparkSession: SparkSession) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -381,7 +422,7 @@ case class TableUtils(sparkSession: SparkSession) {
   def allPartitions(tableName: String, partitionColumnsFilter: Seq[String] = Seq.empty): Seq[Map[String, String]] = {
     if (!tableExists(tableName)) return Seq.empty[Map[String, String]]
     val format = tableReadFormat(tableName)
-    val partitionSeq = format.partitions(tableName)(sparkSession)
+    val partitionSeq = format.partitions(tableName, partitionColumnsFilter)(sparkSession)
     if (partitionColumnsFilter.isEmpty) {
       partitionSeq
     } else {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Users should be able to put a view name in the "table" section to use as input.


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
It is more flexible for users to use a view as Chronon input source.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
@hzding621 @pengyu-hou 
