### PR TITLE
[CI] Use 2xlarge for Scala 2.12 and 2.13 testing 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ executors:
         working_directory: /chronon
         docker:
             - image: houpy0829/chronon-ci:base--f87f50dc520f7a73894ae024eb78bd305d5b08e2
+    docker_baseimg_executor_xxlarge:
+      resource_class: xxlarge
+      working_directory: /chronon
+      docker:
+        - image: houpy0829/chronon-ci:base--f87f50dc520f7a73894ae024eb78bd305d5b08e2
 
 jobs:
     "Pull Docker Image":
@@ -27,7 +32,7 @@ jobs:
                     docker pull houpy0829/chronon-ci:base--f87f50dc520f7a73894ae024eb78bd305d5b08e2 || true
 
     "Scala 12 -- Spark 3 Tests":
-        executor: docker_baseimg_executor
+        executor: docker_baseimg_executor_xxlarge
         steps:
             - checkout
             - run:
@@ -53,7 +58,7 @@ jobs:
                   when: on_fail
 
     "Scala 13 -- Tests":
-        executor: docker_baseimg_executor
+        executor: docker_baseimg_executor_xxlarge
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         docker:
             - image: houpy0829/chronon-ci:base--f87f50dc520f7a73894ae024eb78bd305d5b08e2
     docker_baseimg_executor_xxlarge:
-      resource_class: xxlarge
+      resource_class: 2xlarge
       working_directory: /chronon
       docker:
         - image: houpy0829/chronon-ci:base--f87f50dc520f7a73894ae024eb78bd305d5b08e2


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/bb0c95e1-13aa-4b28-8bde-57ae692ea144" />
Based on the insights from CircleCi, the Scala 2.12 and 2.13 tests are bottlenecked by CPU sometimes. 

This PR creates an 2xlarge executor and it will be used for 2.12 and 2.13 tests to speed up.  

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
The goal is to improve developer experience. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
