### PR TITLE
CircleCi - tune the CI testing with base executor with doubled memory 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
                   when: on_fail
 
     "Scala 13 -- Tests":
-        executor: docker_baseimg_executor_xxlarge
+        executor: docker_baseimg_executor
         steps:
             - checkout
             - run:
@@ -67,7 +67,7 @@ jobs:
                   command: |
                       conda activate chronon_py
                       # Increase if we see OOM.
-                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=8G -Xmx8G -Xms4G"
                       sbt "++ 2.13.6 test"
             - store_test_results:
                   path: /chronon/spark/target/test-reports


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
<img width="1737" alt="image" src="https://github.com/user-attachments/assets/9e1387d9-8e78-449e-b67c-9882996b357e" />
After switching to 2x executor, the CI jobs are still bottlenecked at CPU usage. This PR will test out if bumping memory would help. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
