### PR TITLE
add preAgg step in hopsAggregate

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -367,7 +367,8 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
     val keyBuilder: Row => KeyWithHash =
       FastHashing.generateKeyBuilder(keyColumns.toArray, inputDf.schema)
 
-    inputDf.rdd
+    tableUtils
+      .preAggRepartition(inputDf.rdd)
       .keyBy(keyBuilder)
       .mapValues(SparkConversions.toChrononRow(_, tsIndex))
       .aggregateByKey(zeroValue = hopsAggregator.init())(


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Apply `tableUtils.preAggRepartition` to repartition and increase parallelism on the inputDf before running later computation. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Handling under-partitioned input data. 

The same logic has already been applied to:
- snapshot entities case: [code](https://github.com/airbnb/chronon/blob/v0.0.99/spark/src/main/scala/ai/chronon/spark/GroupBy.scala#L128-L129)
- temporal events/entities case (in upload code path): [code](https://github.com/airbnb/chronon/blob/v0.0.99/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala#L83-L84)


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

tested for both group by batch upload and join part backfill cases, and got consistent behavior in performance improvements when input data is under partitioned. 

## Checklist
- [ ] Documentation update

## Reviewers

@airbnb/airbnb-chronon-maintainers 