### PR TITLE
Fix bootstrap filter query on Iceberg tables 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -24,7 +24,7 @@ import ai.chronon.online.SparkConversions
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.JoinUtils._
 import org.apache.spark.sql
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions._
 import org.apache.spark.util.sketch.BloomFilter
 
@@ -48,17 +48,16 @@ import scala.util.{Failure, Success, Try}
 case class CoveringSet(hashes: Seq[String], rowCount: Long, isCovering: Boolean)
 
 object CoveringSet {
-  def toFilterExpression(coveringSets: Seq[CoveringSet]): String = {
-    val coveringSetHashExpression = "(" +
-      coveringSets
-        .map { coveringSet =>
-          val hashes = coveringSet.hashes.map("'" + _.trim + "'").mkString(", ")
-          s"array($hashes)"
-        }
-        .mkString(", ") +
-      ")"
+  def toFilterCondition(coveringSets: Seq[CoveringSet]): Column = {
+    val excludedConditions: Seq[Column] = coveringSets.map { coveringSet =>
+      val coveringSetLit = coveringSet.hashes.map(lit)
+      val coveringSetsArray = array(coveringSetLit: _*)          // A list of all acceptable coveringSets
+      col(Constants.MatchedHashes) === coveringSetsArray
+    }
 
-    s"( ${Constants.MatchedHashes} IS NULL ) OR ( ${Constants.MatchedHashes} NOT IN $coveringSetHashExpression )"
+    val disjunction = excludedConditions.reduceOption(_ || _).getOrElse(lit(false))
+
+    col(Constants.MatchedHashes).isNull || !disjunction
   }
 }
 
@@ -621,7 +620,7 @@ class Join(joinConf: api.Join,
       // this happens whether bootstrapParts is NULL for the JOIN and thus no metadata columns were created
       return Some(bootstrapDfWithStats)
     }
-    val filterExpr = CoveringSet.toFilterExpression(coveringSets)
+    val filterExpr = CoveringSet.toFilterCondition(coveringSets)
     logger.info(s"Using covering set filter: $filterExpr")
     val filteredDf = bootstrapDf.where(filterExpr)
     val filteredCount = filteredDf.count()


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Update bootstrap coveringSet filter logic to handle a limitation from Iceberg. 

Iceberg doesn't support Array literals to be used as filter values in its filter pushdown logic, and will run into an error like this:

```
`25/06/30 23:49:40 ERROR SparkSQLDriver: Failed in [SELECT *
FROM <namespace_name>.<table_name>
WHERE ds='2025-06-24'
AND ( matched_hashes IS NULL ) OR ( matched_hashes NOT IN (array('TbsUDYLyHu')) )]
java.lang.IllegalArgumentException: Cannot create expression literal from scala.collection.mutable.WrappedArray$ofRef: WrappedArray(TbsUDYLyHu)
        at org.apache.iceberg.expressions.Literals.from(Literals.java:86)
        at org.apache.iceberg.expressions.UnboundPredicate.<init>(UnboundPredicate.java:40)
        at org.apache.iceberg.expressions.Expressions.equal(Expressions.java:169)
        at org.apache.iceberg.spark.SparkFilters.handleEqual(SparkFilters.java:218)
        at org.apache.iceberg.spark.SparkFilters.convert(SparkFilters.java:141)
        at org.apache.iceberg.spark.SparkFilters.convert(SparkFilters.java:162)
        at org.apache.iceberg.spark.SparkFilters.convert(SparkFilters.java:183)
```

the problem is in the `( matched_hashes NOT IN (array('TbsUDYLyHu'))` part, where `array('TbsUDYLyHu')` is the array literal which we are trying to filter against, and Iceberg tables have issues working with it. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@airbnb/airbnb-chronon-maintainers 