### PR TITLE
Improve analyzer to display final output schema 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -104,7 +104,7 @@ object MetadataExporter {
           val join = ThriftJsonCodec.fromJsonFile[api.Join](path, check = false)
           try {
             val joinAnalysis = analyzer.analyzeJoin(join, validateTablePermission = false)
-            val featureMetadata: Seq[Map[String, String]] = joinAnalysis._2.toSeq.map(_.asMap)
+            val featureMetadata: Seq[Map[String, String]] = joinAnalysis.finalOutputMetadata.toSeq.map(_.asMap)
             configData + { "features" -> featureMetadata }
           } catch {
             // Exception while analyzing join

--- a/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
@@ -92,7 +92,7 @@ class CompareJob(
   def validate(): Unit = {
     // Extract the schema of the Join, StagingQuery and the keys before calling this.
     val analyzer = new Analyzer(tableUtils, joinConf, startDate, endDate, enableHitter = false)
-    val joinChrononSchema = analyzer.analyzeJoin(joinConf, false)._1
+    val joinChrononSchema = analyzer.analyzeJoin(joinConf, false).finalOutputSchema
     val joinSchema = joinChrononSchema.map { case (k, v) => (k, SparkConversions.fromChrononType(v)) }.toMap
     val finalStagingQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, startDate, endDate, endDate)
     val stagingQuerySchema =

--- a/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
@@ -92,7 +92,8 @@ class CompareJob(
   def validate(): Unit = {
     // Extract the schema of the Join, StagingQuery and the keys before calling this.
     val analyzer = new Analyzer(tableUtils, joinConf, startDate, endDate, enableHitter = false)
-    val joinChrononSchema = analyzer.analyzeJoin(joinConf, false).finalOutputSchema
+    val analyzerResult = analyzer.analyzeJoin(joinConf, false)
+    val joinChrononSchema = analyzerResult.leftSchema ++ analyzerResult.finalOutputSchema
     val joinSchema = joinChrononSchema.map { case (k, v) => (k, SparkConversions.fromChrononType(v)) }.toMap
     val finalStagingQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, startDate, endDate, endDate)
     val stagingQuerySchema =

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -81,7 +81,11 @@ class AnalyzerTest {
 
     //run analyzer and validate output schema
     val analyzer = new Analyzer(tableUtils, joinConf, oneMonthAgo, today, enableHitter = true)
-    val analyzerSchema = analyzer.analyzeJoin(joinConf)._1.map { case (k, v) => s"${k} => ${v}" }.toList.sorted
+    val analyzerResult = analyzer.analyzeJoin(joinConf)
+    val analyzerSchema = (analyzerResult.leftSchema ++ analyzerResult.finalOutputSchema)
+      .map { case (k, v) => s"${k} => ${v}" }
+      .toList
+      .sorted
     val join = new Join(joinConf = joinConf, endPartition = oneMonthAgo, tableUtils)
     val computed = join.computeJoin()
     val expectedSchema = computed.schema.fields.map(field => s"${field.name} => ${field.dataType}").sorted

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -1258,9 +1258,10 @@ class JoinTest {
     )
 
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (_, aggregationsMetadata) =
-      new Analyzer(tableUtils, joinConfWithExternal, monthAgo, today).analyzeJoin(joinConfWithExternal, enableHitter = false)
-    aggregationsMetadata.foreach(agg => {assertTrue(agg.operation == "Derivation")})
+    val aggregationsMetadata = new Analyzer(tableUtils, joinConfWithExternal, monthAgo, today)
+      .analyzeJoin(joinConfWithExternal, enableHitter = false)
+      .finalOutputMetadata
+    aggregationsMetadata.foreach(agg => { assertTrue(agg.operation == "Derivation") })
     aggregationsMetadata.exists(_.name == "user_txn_count_30d")
     aggregationsMetadata.exists(_.name == "item")
   }
@@ -1294,9 +1295,10 @@ class JoinTest {
     )
 
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (_, aggregationsMetadata) =
-      new Analyzer(tableUtils, joinConfWithDerivationWithKey, monthAgo, today).analyzeJoin(joinConfWithDerivationWithKey, enableHitter = false)
-    aggregationsMetadata.foreach(agg => {assertTrue(agg.operation == "Derivation")})
+    val aggregationsMetadata = new Analyzer(tableUtils, joinConfWithDerivationWithKey, monthAgo, today)
+      .analyzeJoin(joinConfWithDerivationWithKey, enableHitter = false)
+      .finalOutputMetadata
+    aggregationsMetadata.foreach(agg => { assertTrue(agg.operation == "Derivation") })
     aggregationsMetadata.exists(_.name == f"${viewsGroupBy.metaData.name}_time_spent_ms_average")
     aggregationsMetadata.exists(_.name == f"${viewGroupByWithKepMapping.metaData.name}_time_spent_ms_average")
     aggregationsMetadata.exists(_.name == "item")


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->


Improve analyzer output to display more information: 
- `FINAL OUTPUT SCHEMA` is added to show the join's final output. In particular, if derivation is enabled, the result will be different from `RIGHT SIDE SCHEMA`
- `RIGHT SIDE SCHEMA` contains only intermediate join_parts result. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Update analyzer to handle joins with derivations. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

@pengyu-hou @yuli-han @Shiyinghaha 
@airbnb/airbnb-chronon-maintainers 