### PR TITLE
Python wrappers for source objects

### DIFF
--- a/api/py/test/lineage/test_parse_group_by.py
+++ b/api/py/test/lineage/test_parse_group_by.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 from ai.chronon import group_by
+from ai.chronon import source
 from ai.chronon.api import ttypes
 from ai.chronon.group_by import Accuracy, Derivation
 from ai.chronon.lineage.lineage_metadata import ConfigType, TableType
@@ -25,7 +26,7 @@ from helper import compare_lineages
 
 class TestParseGroupBy(unittest.TestCase):
     def setUp(self):
-        gb_event_source = ttypes.EventSource(
+        gb_event_source = source.EventSource(
             table="source.gb_table",
             topic=None,
             query=ttypes.Query(
@@ -35,7 +36,7 @@ class TestParseGroupBy(unittest.TestCase):
             ),
         )
 
-        gb_event_source1 = ttypes.EventSource(
+        gb_event_source1 = source.EventSource(
             table="source.gb_table1",
             topic=None,
             query=ttypes.Query(

--- a/api/py/test/lineage/test_parse_join.py
+++ b/api/py/test/lineage/test_parse_join.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 from ai.chronon import group_by
+from ai.chronon import source
 from ai.chronon.api import ttypes
 from ai.chronon.api import ttypes as api
 from ai.chronon.group_by import Derivation
@@ -27,7 +28,7 @@ from helper import compare_lineages
 
 class TestParseJoin(unittest.TestCase):
     def setUp(self):
-        gb_event_source = ttypes.EventSource(
+        gb_event_source = source.EventSource(
             table="gb_table",
             topic=None,
             query=ttypes.Query(
@@ -59,17 +60,15 @@ class TestParseJoin(unittest.TestCase):
         )
 
         self.join = Join(
-            left=api.Source(
-                events=api.EventSource(
-                    table="join_event_table",
-                    query=api.Query(
-                        startPartition="2020-04-09",
-                        selects={
-                            "subject": "subject",
-                            "event_id": "event",
-                        },
-                        timeColumn="CAST(ts AS DOUBLE)",
-                    ),
+            left=source.EventSource(
+                table="join_event_table",
+                query=api.Query(
+                    startPartition="2020-04-09",
+                    selects={
+                        "subject": "subject",
+                        "event_id": "event",
+                    },
+                    timeColumn="CAST(ts AS DOUBLE)",
                 ),
             ),
             output_namespace="test_db",

--- a/api/py/test/sample/group_bys/kaggle/clicks.py
+++ b/api/py/test/sample/group_bys/kaggle/clicks.py
@@ -13,7 +13,6 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
 from ai.chronon.group_by import (
     GroupBy,
@@ -23,6 +22,7 @@ from ai.chronon.group_by import (
     TimeUnit,
     Accuracy
 )
+from ai.chronon.source import EventSource
 from ai.chronon.utils import get_staging_query_output_table_name
 from staging_queries.kaggle.outbrain import base_table
 
@@ -43,14 +43,13 @@ the fields that we care about (`ad_id`, `clicked`, and `ts` columns), it will mi
 """
 
 
-source = Source(
-    events=EventSource(
-        table=get_staging_query_output_table_name(base_table), # Here we use the staging query output table because it has the necessary fields, but for a true streaming source we would likely use a log table
-        topic="some_topic", # You would set your streaming source topic here
-        query=Query(
-            selects=select("ad_id", "clicked"),
-            time_column="ts")
-    ))
+source = EventSource(
+    table=get_staging_query_output_table_name(base_table), # Here we use the staging query output table because it has the necessary fields, but for a true streaming source we would likely use a log table
+    topic="some_topic", # You would set your streaming source topic here
+    query=Query(
+        selects=select("ad_id", "clicked"),
+    time_column="ts")
+)
 
 ad_streaming = GroupBy(
     sources=[source],

--- a/api/py/test/sample/group_bys/kaggle/outbrain.py
+++ b/api/py/test/sample/group_bys/kaggle/outbrain.py
@@ -14,7 +14,6 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
 from ai.chronon.group_by import (
     GroupBy,

--- a/api/py/test/sample/group_bys/quickstart/purchases.py
+++ b/api/py/test/sample/group_bys/quickstart/purchases.py
@@ -13,8 +13,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
+from ai.chronon.source import EventSource
 from ai.chronon.group_by import (
     GroupBy,
     Aggregation,
@@ -28,14 +28,13 @@ This GroupBy aggregates metrics about a user's previous purchases in various win
 """
 
 # This source is raw purchase events. Every time a user makes a purchase, it will be one entry in this source.
-source = Source(
-    events=EventSource(
-        table="data.purchases", # This points to the log table in the warehouse with historical purchase events, updated in batch daily
-        topic=None, # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
-        query=Query(
-            selects=select("user_id","purchase_price"), # Select the fields we care about
-            time_column="ts") # The event time
-    ))
+source = EventSource(
+    table="data.purchases", # This points to the log table in the warehouse with historical purchase events, updated in batch daily
+    topic=None, # See the 'returns' GroupBy for an example that has a streaming source configured. In this case, this would be the streaming source topic that can be listened to for realtime events
+    query=Query(
+        selects=select("user_id","purchase_price"), # Select the fields we care about
+        time_column="ts") # The event time
+)
 
 window_sizes = [Window(length=day, timeUnit=TimeUnit.DAYS) for day in [3, 14, 30]] # Define some window sizes to use below
 

--- a/api/py/test/sample/group_bys/quickstart/returns.py
+++ b/api/py/test/sample/group_bys/quickstart/returns.py
@@ -13,8 +13,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
+from ai.chronon.source import EventSource
 from ai.chronon.group_by import (
     GroupBy,
     Aggregation,
@@ -28,14 +28,13 @@ from ai.chronon.group_by import (
 This GroupBy aggregates metrics about a user's previous purchases in various windows.
 """
 
-source = Source(
-    events=EventSource(
-        table="data.returns", # This points to the log table with historical return events
-        topic="events.returns/fields=ts,return_id,user_id,product_id,refund_amt/host=kafka/port=9092",
-        query=Query(
-            selects=select("user_id","refund_amt"), # Select the fields we care about
-            time_column="ts") # The event time
-    ))
+source = EventSource(
+    table="data.returns", # This points to the log table with historical return events
+    topic="events.returns/fields=ts,return_id,user_id,product_id,refund_amt/host=kafka/port=9092",
+    query=Query(
+        selects=select("user_id","refund_amt"), # Select the fields we care about
+        time_column="ts") # The event time
+)
 
 window_sizes = [Window(length=day, timeUnit=TimeUnit.DAYS) for day in [3, 14, 30]] # Define some window sizes to use below
 

--- a/api/py/test/sample/group_bys/quickstart/schema.py
+++ b/api/py/test/sample/group_bys/quickstart/schema.py
@@ -1,20 +1,18 @@
 from ai.chronon.group_by import GroupBy, Aggregation, Operation
-from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.source import EventSource
 from ai.chronon.query import Query, select
 
 
-logging_schema_source = Source(
-    events=EventSource(
-        table="default.chronon_log_table",
-        query=Query(
-            selects=select(
-                schema_hash="decode(unbase64(key_base64), 'utf-8')",
-                schema_value="decode(unbase64(value_base64), 'utf-8')"
-            ),
-            wheres=["name='SCHEMA_PUBLISH_EVENT'"],
-            time_column="ts_millis",
+logging_schema_source = EventSource(
+    table="default.chronon_log_table",
+    query=Query(
+        selects=select(
+            schema_hash="decode(unbase64(key_base64), 'utf-8')",
+            schema_value="decode(unbase64(value_base64), 'utf-8')"
         ),
-    )
+        wheres=["name='SCHEMA_PUBLISH_EVENT'"],
+        time_column="ts_millis",
+    ),
 )
 
 v1 = GroupBy(

--- a/api/py/test/sample/group_bys/quickstart/users.py
+++ b/api/py/test/sample/group_bys/quickstart/users.py
@@ -13,24 +13,23 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EntitySource
 from ai.chronon.query import Query, select
 from ai.chronon.group_by import (
     GroupBy,
 )
+from ai.chronon.source import EntitySource
 
 """
 The primary key for this GroupBy is the same as the primary key of the source table. Therefore,
 it doesn't perform any aggregation, but just extracts user fields as features.
 """
 
-source = Source(
-    entities=EntitySource(
-        snapshotTable="data.users", # This points to a table that contains daily snapshots of the entire product catalog
-        query=Query(
-            selects=select("user_id","account_created_ds","email_verified"), # Select the fields we care about
-        )
-    ))
+source = EntitySource(
+    snapshotTable="data.users", # This points to a table that contains daily snapshots of the entire product catalog
+    query=Query(
+        selects=select("user_id","account_created_ds","email_verified"), # Select the fields we care about
+    )
+)
 
 v1 = GroupBy(
     sources=[source],

--- a/api/py/test/sample/group_bys/unit_test/user/sample_nested_group_by.py
+++ b/api/py/test/sample/group_bys/unit_test/user/sample_nested_group_by.py
@@ -1,21 +1,19 @@
-from ai.chronon.api import ttypes
 from ai.chronon.api.ttypes import Aggregation, Operation, TimeUnit, Window
 from ai.chronon.group_by import Aggregations, GroupBy
 from ai.chronon.query import Query, select
+from ai.chronon.source import EventSource
 
-source = ttypes.Source(
-    events=ttypes.EventSource(
-        table="random_table_name",
-        query=Query(
-            selects=select(
-                user="id_item",
-                play="if(transaction_type='A', 1, 0)",
-                pause="if(transaction_type='B', 1, 0)",
-            ),
-            start_partition="2023-03-01",
-            time_column="UNIX_TIMESTAMP(ts) * 1000",
+source = EventSource(
+    table="random_table_name",
+    query=Query(
+        selects=select(
+            user="id_item",
+            play="if(transaction_type='A', 1, 0)",
+            pause="if(transaction_type='B', 1, 0)",
         ),
-    )
+        start_partition="2023-03-01",
+        time_column="UNIX_TIMESTAMP(ts) * 1000",
+    ),
 )
 
 windows = [

--- a/api/py/test/sample/joins/quickstart/training_set.py
+++ b/api/py/test/sample/joins/quickstart/training_set.py
@@ -14,8 +14,8 @@
 #     limitations under the License.
 
 from ai.chronon.join import Join, JoinPart
-from ai.chronon.api.ttypes import Source, EventSource
 from ai.chronon.query import Query, select
+from ai.chronon.source import EventSource
 
 from group_bys.quickstart.purchases import v1 as purchases_v1
 from group_bys.quickstart.returns import v1 as returns_v1
@@ -25,14 +25,13 @@ from group_bys.quickstart.users import v1 as users
 This is the "left side" of the join that will comprise our training set. It is responsible for providing the primary keys
 and timestamps for which features will be computed.
 """
-source = Source(
-    events=EventSource(
-        table="data.checkouts", 
-        query=Query(
-            selects=select("user_id"), # The primary key used to join various GroupBys together
-            time_column="ts",
-            ) # The event time used to compute feature values as-of
-    ))
+source = EventSource(
+    table="data.checkouts",
+    query=Query(
+        selects=select("user_id"), # The primary key used to join various GroupBys together
+        time_column="ts",
+        ) # The event time used to compute feature values as-of
+)
 
 v1 = Join(  
     left=source,

--- a/api/py/test/sample/joins/unit_test/user/sample_transactions.py
+++ b/api/py/test/sample/joins/unit_test/user/sample_transactions.py
@@ -1,20 +1,19 @@
 # from airbnb.data_sources_2 import HiveEventSource
-from ai.chronon.api import ttypes
 from ai.chronon.join import Join, JoinPart
 from ai.chronon.query import Query, select
+from ai.chronon.source import EventSource
 from group_bys.unit_test.user.sample_nested_group_by import v1 as nested_v1
 
-source = ttypes.Source(
-    events=ttypes.EventSource(
-        table="item_snapshot",
-        query=Query(
-            selects=select(user="id_requester"),
-            wheres=["dim_requester_user_role = 'user'"],
-            start_partition="2023-03-01",
-            time_column="UNIX_TIMESTAMP(ts_created_at_utc) * 1000",
-        ),
-    )
+source = EventSource(
+    table="item_snapshot",
+    query=Query(
+        selects=select(user="id_requester"),
+        wheres=["dim_requester_user_role = 'user'"],
+        start_partition="2023-03-01",
+        time_column="UNIX_TIMESTAMP(ts_created_at_utc) * 1000",
+    ),
 )
+
 
 v1 = Join(
     left=source,

--- a/api/py/test/sample/production/group_bys/sample_team/event_sample_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/event_sample_group_by.v1
@@ -25,7 +25,8 @@
           "startPartition": "2021-04-09",
           "timeColumn": "ts",
           "setups": []
-        }
+        },
+        "customJson": "{}"
       }
     }
   ],

--- a/api/py/test/sample/production/group_bys/sample_team/sample_deprecation_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_deprecation_group_by.v1
@@ -28,7 +28,8 @@
           "endPartition": "2021-04-09",
           "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
           "setups": []
-        }
+        },
+        "customJson": "{}"
       }
     },
     {
@@ -42,7 +43,8 @@
           "startPartition": "2021-03-01",
           "timeColumn": "__timestamp",
           "setups": []
-        }
+        },
+        "customJson": "{}"
       }
     }
   ],

--- a/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
@@ -29,7 +29,8 @@
           "startPartition": "2021-04-09",
           "timeColumn": "ts",
           "setups": []
-        }
+        },
+        "customJson": "{}"
       }
     }
   ],

--- a/api/py/test/sample/production/group_bys/unit_test/sample_chaining_group_by.chaining_group_by_v1
+++ b/api/py/test/sample/production/group_bys/unit_test/sample_chaining_group_by.chaining_group_by_v1
@@ -46,7 +46,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           "joinParts": [
@@ -78,7 +79,8 @@
                         "startPartition": "2021-04-09",
                         "timeColumn": "ts",
                         "setups": []
-                      }
+                      },
+                      "customJson": "{}"
                     }
                   }
                 ],

--- a/api/py/test/sample/production/group_bys/unit_test/sample_group_by.v1
+++ b/api/py/test/sample/production/group_bys/unit_test/sample_group_by.v1
@@ -25,7 +25,8 @@
           "startPartition": "2021-04-09",
           "timeColumn": "ts",
           "setups": []
-        }
+        },
+        "customJson": "{}"
       }
     }
   ],

--- a/api/py/test/sample/production/group_bys/unit_test/user.sample_nested_group_by.v1
+++ b/api/py/test/sample/production/group_bys/unit_test/user.sample_nested_group_by.v1
@@ -26,7 +26,8 @@
           "startPartition": "2023-03-01",
           "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
           "setups": []
-        }
+        },
+        "customJson": "{}"
       }
     }
   ],

--- a/api/py/test/sample/production/joins/sample_team/sample_backfill_mutation_join.v0
+++ b/api/py/test/sample/production/joins/sample_team/sample_backfill_mutation_join.v0
@@ -29,7 +29,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -59,7 +60,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_chaining_join.parent_join
+++ b/api/py/test/sample/production/joins/sample_team/sample_chaining_join.parent_join
@@ -31,7 +31,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -63,7 +64,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -132,7 +134,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_deprecation_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_deprecation_join.v1
@@ -29,7 +29,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -64,7 +65,8 @@
                 "endPartition": "2021-04-09",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           {
@@ -78,7 +80,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "__timestamp",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join.consistency_check
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.consistency_check
@@ -28,7 +28,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -62,7 +63,8 @@
                 },
                 "startPartition": "2021-03-01",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
@@ -28,7 +28,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -64,7 +65,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join.never
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.never
@@ -27,7 +27,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 },
                 "startPartition": "2021-03-01",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join.no_log_flattener
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.no_log_flattener
@@ -27,7 +27,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 },
                 "startPartition": "2021-03-01",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.v1
@@ -32,7 +32,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -66,7 +67,8 @@
                 },
                 "startPartition": "2021-03-01",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v1
@@ -31,7 +31,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -63,7 +64,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -132,7 +134,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v2
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_bootstrap.v2
@@ -33,7 +33,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -65,7 +66,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -134,7 +136,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -194,7 +197,8 @@
                 "endPartition": "2021-04-09",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           {
@@ -208,7 +212,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "__timestamp",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_derivation.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_derivation.v1
@@ -29,7 +29,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -130,7 +132,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_external_parts.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_external_parts.v1
@@ -27,7 +27,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 },
                 "startPartition": "2021-03-01",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_external_parts.v2
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_external_parts.v2
@@ -27,7 +27,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 },
                 "startPartition": "2021-03-01",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_for_dependency_test.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_for_dependency_test.v1
@@ -27,7 +27,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -59,7 +60,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_group_by_from_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_group_by_from_join.v1
@@ -28,7 +28,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -64,7 +65,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_module.v1
@@ -31,7 +31,8 @@
         },
         "startPartition": "2021-03-01",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -60,7 +61,8 @@
                 "endPartition": "2021-04-09",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           {
@@ -74,7 +76,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "__timestamp",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -135,7 +138,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_join_from_shorthand.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_from_shorthand.v1
@@ -29,7 +29,8 @@
         "startPartition": "2021-03-01",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": []

--- a/api/py/test/sample/production/joins/sample_team/sample_join_with_derivations_on_external_parts.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_join_with_derivations_on_external_parts.v1
@@ -29,7 +29,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -130,7 +132,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/sample_team/sample_label_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_label_join.v1
@@ -29,7 +29,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -129,7 +131,8 @@
                 "endPartition": "2021-04-09",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           {
@@ -143,7 +146,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "__timestamp",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -208,7 +212,8 @@
                   "startPartition": "2021-03-01",
                   "timeColumn": "ts",
                   "setups": []
-                }
+                },
+                "customJson": "{}"
               }
             }
           ],

--- a/api/py/test/sample/production/joins/sample_team/sample_label_join_with_agg.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_label_join_with_agg.v1
@@ -29,7 +29,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -61,7 +62,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -129,7 +131,8 @@
                 "endPartition": "2021-04-09",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           {
@@ -143,7 +146,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "__timestamp",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -211,7 +215,8 @@
                   "startPartition": "2021-03-01",
                   "timeColumn": "ts",
                   "setups": []
-                }
+                },
+                "customJson": "{}"
               }
             }
           ],

--- a/api/py/test/sample/production/joins/sample_team/sample_online_join.v1
+++ b/api/py/test/sample/production/joins/sample_team/sample_online_join.v1
@@ -32,7 +32,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -64,7 +65,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -133,7 +135,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],
@@ -193,7 +196,8 @@
                 "endPartition": "2021-04-09",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           },
           {
@@ -207,7 +211,8 @@
                 "startPartition": "2021-03-01",
                 "timeColumn": "__timestamp",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/unit_test/sample_parent_join.parent_join
+++ b/api/py/test/sample/production/joins/unit_test/sample_parent_join.parent_join
@@ -27,7 +27,8 @@
         "startPartition": "2021-04-09",
         "timeColumn": "ts",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -55,7 +56,8 @@
                 "startPartition": "2021-04-09",
                 "timeColumn": "ts",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/production/joins/unit_test/user.sample_transactions.v1
+++ b/api/py/test/sample/production/joins/unit_test/user.sample_transactions.v1
@@ -30,7 +30,8 @@
         "startPartition": "2023-03-01",
         "timeColumn": "UNIX_TIMESTAMP(ts_created_at_utc) * 1000",
         "setups": []
-      }
+      },
+      "customJson": "{}"
     }
   },
   "joinParts": [
@@ -63,7 +64,8 @@
                 "startPartition": "2023-03-01",
                 "timeColumn": "UNIX_TIMESTAMP(ts) * 1000",
                 "setups": []
-              }
+              },
+              "customJson": "{}"
             }
           }
         ],

--- a/api/py/test/sample/sources/kaggle/outbrain.py
+++ b/api/py/test/sample/sources/kaggle/outbrain.py
@@ -14,7 +14,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.source import EventSource
 from ai.chronon.query import Query, select
 from ai.chronon.utils import get_staging_query_output_table_name
 from staging_queries.kaggle.outbrain import base_table
@@ -29,10 +29,10 @@ def outbrain_left_events(*columns):
     """
     Defines a source based off of the output table of the `base_table` StagingQuery.
     """
-    return Source(events=EventSource(
+    return EventSource(
         table=get_staging_query_output_table_name(base_table),
         query=Query(
             selects=select(*columns),
             time_column="ts",
         ),
-    ))
+    )

--- a/api/py/test/sample/sources/test_sources.py
+++ b/api/py/test/sample/sources/test_sources.py
@@ -18,13 +18,13 @@ from ai.chronon.query import (
     select,
 )
 from ai.chronon.utils import get_staging_query_output_table_name
-from ai.chronon.api import ttypes
+from ai.chronon.source import EventSource, EntitySource
 
 from staging_queries.sample_team import sample_staging_query
 
 
 def basic_event_source(table):
-    return ttypes.Source(events=ttypes.EventSource(
+    return EventSource(
         table=table,
         query=Query(
             selects=select(
@@ -34,11 +34,11 @@ def basic_event_source(table):
             start_partition="2021-04-09",
             time_column="ts",
         ),
-    ))
+    )
 
 
 # Sample Event Source used in tests.
-event_source = ttypes.Source(events=ttypes.EventSource(
+event_source = EventSource(
     table="sample_namespace.sample_table_group_by",
     query=Query(
         selects=select(
@@ -48,15 +48,15 @@ event_source = ttypes.Source(events=ttypes.EventSource(
         start_partition="2021-04-09",
         time_column="ts",
     ),
-))
+)
 
 # Sample Entity Source
-entity_source = ttypes.Source(entities=ttypes.EntitySource(
-    snapshotTable="sample_table.sample_entity_snapshot",
+entity_source = EntitySource(
+    snapshot_table="sample_table.sample_entity_snapshot",
     # hr partition is not necessary - just to demo that we support various 
     # partitioning schemes
-    mutationTable="sample_table.sample_entity_mutations/hr=00:00",
-    mutationTopic="sample_topic",
+    mutation_table="sample_table.sample_entity_mutations/hr=00:00",
+    mutation_topic="sample_topic",
     query=Query(
         start_partition='2021-03-01',
         selects=select(
@@ -65,10 +65,10 @@ entity_source = ttypes.Source(entities=ttypes.EntitySource(
         ),
         time_column="ts"
     ),
-))
+)
 
-batch_entity_source = ttypes.Source(entities=ttypes.EntitySource(
-    snapshotTable="sample_table.sample_entity_snapshot",
+batch_entity_source = EntitySource(
+    snapshot_table="sample_table.sample_entity_snapshot",
     query=Query(
         start_partition='2021-03-01',
         selects=select(
@@ -77,11 +77,11 @@ batch_entity_source = ttypes.Source(entities=ttypes.EntitySource(
         ),
         time_column="ts"
     ),
-))
+)
 
 # Sample Entity Source derived from a staging query.
-staging_entities=ttypes.Source(entities=ttypes.EntitySource(
-    snapshotTable="sample_namespace.{}".format(get_staging_query_output_table_name(sample_staging_query.v1)),
+staging_entities=EntitySource(
+    snapshot_table="sample_namespace.{}".format(get_staging_query_output_table_name(sample_staging_query.v1)),
     query=Query(
         start_partition='2021-03-01',
         selects=select(**{
@@ -91,11 +91,11 @@ staging_entities=ttypes.Source(entities=ttypes.EntitySource(
             'place_id': 'place_id'
         })
     )
-))
+)
 
 
 # A Source that was deprecated but still relevant (requires stitching).
-events_until_20210409 = ttypes.Source(events=ttypes.EventSource(
+events_until_20210409 = EventSource(
     table="sample_namespace.sample_table_group_by",
     query=Query(
         start_partition='2021-03-01',
@@ -106,10 +106,10 @@ events_until_20210409 = ttypes.Source(events=ttypes.EventSource(
         }),
         time_column="UNIX_TIMESTAMP(ts) * 1000"
     ),
-))
+)
 
 # The new source
-events_after_20210409 = ttypes.Source(events=ttypes.EventSource(
+events_after_20210409 = EventSource(
     table="sample_namespace.another_sample_table_group_by",
     query=Query(
         start_partition='2021-03-01',
@@ -119,4 +119,4 @@ events_after_20210409 = ttypes.Source(events=ttypes.EventSource(
         }),
         time_column="__timestamp"
     ),
-))
+)

--- a/api/py/test/test_group_by.py
+++ b/api/py/test/test_group_by.py
@@ -18,7 +18,8 @@ import pytest, json
 from ai.chronon import group_by, query
 from ai.chronon.group_by import GroupBy, Derivation, TimeUnit, Window, Aggregation, Accuracy
 from ai.chronon.api import ttypes
-from ai.chronon.api.ttypes import EventSource, EntitySource, Operation
+from ai.chronon.api.ttypes import Operation
+from ai.chronon.source import EventSource, EntitySource
 
 
 @pytest.fixture
@@ -45,7 +46,7 @@ def event_source(table, topic=None):
     """
     Sample left join
     """
-    return ttypes.EventSource(
+    return EventSource(
         table=table,
         topic=topic,
         query=ttypes.Query(
@@ -64,9 +65,9 @@ def entity_source(snapshotTable, mutationTable):
     """
     Sample source
     """
-    return ttypes.EntitySource(
-        snapshotTable=snapshotTable,
-        mutationTable=mutationTable,
+    return EntitySource(
+        snapshot_table=snapshotTable,
+        mutation_table=mutationTable,
         query=ttypes.Query(
             startPartition="2020-04-09",
             selects={
@@ -201,15 +202,15 @@ def test_generic_collector():
 def test_select_sanitization():
     gb = group_by.GroupBy(
         sources=[
-            ttypes.EventSource(  # No selects are spcified
+            EventSource(  # No selects are spcified
                 table="event_table1",
                 query=query.Query(
                     selects=None,
                     time_column="ts"
                 )
             ),
-            ttypes.EntitySource(  # Some selects are specified
-                snapshotTable="entity_table1",
+            EntitySource(  # Some selects are specified
+                snapshot_table="entity_table1",
                 query=query.Query(
                     selects={
                         "key1": "key1_sql",
@@ -236,8 +237,8 @@ def test_snapshot_with_hour_aggregation():
     with pytest.raises(AssertionError):
         group_by.GroupBy(
             sources=[
-                ttypes.EntitySource(  # Some selects are specified
-                    snapshotTable="entity_table1",
+                EntitySource(  # Some selects are specified
+                    snapshot_table="entity_table1",
                     query=query.Query(
                         selects={
                             "key1": "key1_sql",
@@ -260,7 +261,7 @@ def test_snapshot_with_hour_aggregation():
 def test_additional_metadata():
     gb = group_by.GroupBy(
         sources=[
-            ttypes.EventSource(
+            EventSource(
                 table="event_table1",
                 query=query.Query(
                     selects=None,
@@ -279,7 +280,7 @@ def test_additional_metadata():
 def test_group_by_with_description():
     gb = group_by.GroupBy(
         sources=[
-            ttypes.EventSource(
+            EventSource(
                 table="event_table1",
                 query=query.Query(
                     selects=None,

--- a/api/py/test/test_utils.py
+++ b/api/py/test/test_utils.py
@@ -19,8 +19,9 @@ import pytest
 
 import ai.chronon.api.ttypes as api
 from ai.chronon import utils
-from ai.chronon.api.ttypes import EntitySource, EventSource, Query, Source
+from ai.chronon.api.ttypes import Query
 from ai.chronon.repo.serializer import file2thrift, json2thrift
+from ai.chronon.source import EventSource, EntitySource
 from ai.chronon.utils import get_dependencies, wait_for_simple_schema
 
 
@@ -365,12 +366,11 @@ def test_wait_for_simple_schema_with_subpartition(query_with_partition_column: Q
 
 
 def test_get_dependencies_with_entities_mutation(query_with_partition_column: Query):
-    entity = EntitySource(
-        snapshotTable="snap_table",
-        mutationTable="mut_table",
+    src = EntitySource(
+        snapshot_table="snap_table",
+        mutation_table="mut_table",
         query=query_with_partition_column,
     )
-    src = Source(entities=entity)
     deps_json = get_dependencies(src, lag=0)
     assert len(deps_json) == 2
     deps = [json.loads(d) for d in deps_json]
@@ -382,8 +382,7 @@ def test_get_dependencies_with_entities_mutation(query_with_partition_column: Qu
 
 
 def test_get_dependencies_with_events(query_with_partition_column: Query):
-    event = EventSource(table="event_table", query=query_with_partition_column)
-    src = Source(events=event)
+    src = EventSource(table="event_table", query=query_with_partition_column)
     deps_json = get_dependencies(src, lag=2)
     assert len(deps_json) == 1
     dep = json.loads(deps_json[0])

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -68,6 +68,11 @@ struct EventSource {
     * If each new hive partition contains not just the current day's events but the entire set of events since the begininng. The key property is that the events are not mutated across partitions.
     **/
     4: optional bool isCumulative
+
+    /**
+    * Any extra attributes can be stored here. Ie, Kafka bootstrap servers for a streaming source, or AWS IAM role for accessing Iceberg table
+    **/
+    5: optional string customJson
 }
 
 
@@ -98,6 +103,11 @@ struct EntitySource {
     * The logic used to scan both the table and the topic. Contains row level transformations and filtering expressed as Spark SQL statements.
     */
     4: optional Query query
+
+    /**
+    * Any extra attributes can be stored here. Ie, Kafka bootstrap servers for a streaming source, or AWS IAM role for accessing Iceberg table
+    **/
+    5: optional string customJson
 }
 
 struct ExternalSource {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adding functions to the Python SDK for source objects creation. This is a fully backward-compatible change.

## Why / Goal
The primary motivation is to enable the addition of extra attributes at the source level. Similarly to how it's done in `GroupBy` and `Join`: all extra arguments are stored in the `customJson` attribute. Sources can have all sorts of metadata, ie `bootstrap.server` for Kafka source.

Additional benefits:
* Slightly less verbose API
```
my_source = ttypes.Source(
    events=ttypes.EventSource(
          table=...
    )
)
```
vs
```
my_source = source.EventSource(
    table=...
)
```
* Improving API consistency: existing Python wrappers (ie, `GroupBy`, `Join`) use Pythonic snake case for parameter names, whereas code generated from Thrift uses camel case (ie, `snapshotTable` in `EntitySource`)


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ x ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

