### PR TITLE
fix: allow derivations to overwrite base columns 

### DIFF
--- a/api/py/ai/chronon/repo/validator.py
+++ b/api/py/ai/chronon/repo/validator.py
@@ -317,13 +317,7 @@ class ChrononRepoValidator(object):
                         )
                     )
             if derivation.name != "*":
-                # Do not validate the name conflict for keys
-                if derivation.name in derived_columns and derivation.name not in key_cols:
-                    errors.append(
-                        "Incorrect derivation name {} due to output column name conflict".format(derivation.name)
-                    )
-                else:
-                    derived_columns.add(derivation.name)
+                derived_columns.add(derivation.name)
         return errors
 
     def _validate_join(self, join: Join) -> List[str]:


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Remove logic in validator.py that checks a derivation column name cannot be same as existing base column. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


This restriction should be relaxed such that a base column's name can be reused. A common use case of this is to support imputation of default values, for example:

```
        Derivation(
            name="group_by_name_col_name",
            expression="COALESCE(group_by_name_col_name, -1L)"
        )
```

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested


## Reviewers

@yuli-han @airbnb/airbnb-chronon-maintainers 
