### PR TITLE
Update analyzer to support schema export to Hive table

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Builders.scala
+++ b/api/src/main/scala/ai/chronon/api/Builders.scala
@@ -350,6 +350,13 @@ object Builders {
       }
       derivation
     }
+
+    def wildcard(): Derivation = {
+      val derivation = new Derivation()
+      derivation.setName("*")
+      derivation.setExpression("*")
+      derivation
+    }
   }
 
 }

--- a/api/src/main/scala/ai/chronon/api/Builders.scala
+++ b/api/src/main/scala/ai/chronon/api/Builders.scala
@@ -351,7 +351,7 @@ object Builders {
       derivation
     }
 
-    def wildcard(): Derivation = {
+    def star(): Derivation = {
       val derivation = new Derivation()
       derivation.setName("*")
       derivation.setExpression("*")

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -102,6 +102,7 @@ object Extensions {
     def outputFinalView = s"${metaData.outputNamespace}.${metaData.cleanName}_labeled"
     def outputLatestLabelView = s"${metaData.outputNamespace}.${metaData.cleanName}_labeled_latest"
     def loggedTable = s"${outputTable}_logged"
+    def schemaTable = s"${outputTable}_schema"
 
     def bootstrapTable = s"${outputTable}_bootstrap"
 

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -19,7 +19,7 @@ package ai.chronon.spark
 import ai.chronon.api
 import ai.chronon.api.DataModel.{DataModel, Entities, Events}
 import ai.chronon.api.Extensions._
-import ai.chronon.api._
+import ai.chronon.api.{Accuracy, AggregationPart, Constants, DataType, TimeUnit, Window}
 import ai.chronon.online.SparkConversions
 import ai.chronon.spark.Driver.parseConf
 import com.yahoo.memory.Memory
@@ -731,7 +731,7 @@ class Analyzer(tableUtils: TableUtils,
     }
     val keys = toFields(keySchema)
     val values = toFields(valueSchema)
-    val df = Seq((keys, values, partition)).toDF("key_schema", "value_schema", tableUtils.partitionColumn)
+    val df = Seq((keys, values, partition)).toSeq.toDF("key_schema", "value_schema", tableUtils.partitionColumn)
     tableUtils.insertPartitions(df, table, tableProperties)
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -19,7 +19,7 @@ package ai.chronon.spark
 import ai.chronon.api
 import ai.chronon.api.Extensions.{GroupByOps, MetadataOps, SourceOps, StringOps}
 import ai.chronon.api.ThriftJsonCodec
-import ai.chronon.online.{Api, Fetcher, MetadataDirWalker, MetadataEndPoint, MetadataStore}
+import ai.chronon.online._
 import ai.chronon.spark.stats.{CompareBaseJob, CompareJob, ConsistencyJob, SummaryJob}
 import ai.chronon.spark.streaming.{JoinSourceRunner, TopicChecker}
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -44,8 +44,8 @@ import java.net.URI
 import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 import scala.io.Source
 import scala.reflect.ClassTag
 import scala.reflect.internal.util.ScalaClassLoader
@@ -537,6 +537,12 @@ object Driver {
           descr = "skip table permission check - setting to true will skip the table permission check",
           default = Some(false)
         )
+      val exportSchema: ScallopOption[Boolean] =
+        opt[Boolean](
+          required = false,
+          descr = "export schema from analyzer result into a schema table, default is false",
+          default = Some(false)
+        )
 
       override def subcommandName() = "analyzer_util"
     }
@@ -552,7 +558,7 @@ object Driver {
                    args.enableHitter(),
                    silenceMode = false,
                    skipTimestampCheck = args.skipTimestampCheck(),
-                   validateTablePermission = !args.skipTablePermissionCheck()).run()
+                   validateTablePermission = !args.skipTablePermissionCheck()).run(args.exportSchema())
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -531,6 +531,12 @@ object Driver {
           descr = "skip sampling and timestamp checks - setting to true will result in timestamp checks being skipped",
           default = Some(false)
         )
+      val skipTablePermissionCheck: ScallopOption[Boolean] =
+        opt[Boolean](
+          required = false,
+          descr = "skip table permission check - setting to true will skip the table permission check",
+          default = Some(false)
+        )
 
       override def subcommandName() = "analyzer_util"
     }
@@ -545,7 +551,8 @@ object Driver {
                    args.sample(),
                    args.enableHitter(),
                    silenceMode = false,
-                   skipTimestampCheck = args.skipTimestampCheck()).run
+                   skipTimestampCheck = args.skipTimestampCheck(),
+                   validateTablePermission = !args.skipTablePermissionCheck()).run()
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.sketch.BloomFilter
 import org.slf4j.LoggerFactory
 
 import java.util
-import scala.collection.{Seq, immutable, mutable}
+import scala.collection.{Seq, mutable}
 import scala.util.ScalaJavaConversions.{JListOps, ListOps, MapOps}
 
 class GroupBy(val aggregations: Seq[api.Aggregation],

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.sketch.BloomFilter
 import org.slf4j.LoggerFactory
 
 import java.util
-import scala.collection.{Seq, mutable}
+import scala.collection.{Seq, immutable, mutable}
 import scala.util.ScalaJavaConversions.{JListOps, ListOps, MapOps}
 
 class GroupBy(val aggregations: Seq[api.Aggregation],

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -85,7 +85,8 @@ object MetadataExporter {
         try {
           val groupBy = ThriftJsonCodec.fromJsonFile[api.GroupBy](path, check = false)
           try {
-            val featureMetadata = analyzer.analyzeGroupBy(groupBy, validateTablePermission = false)._1.map(_.asMap)
+            val featureMetadata =
+              analyzer.analyzeGroupBy(groupBy, validateTablePermission = false).outputMetadata.map(_.asMap)
             configData + { "features" -> featureMetadata }
           } catch {
             // Exception while analyzing groupBy

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -85,7 +85,7 @@ object MetadataExporter {
         try {
           val groupBy = ThriftJsonCodec.fromJsonFile[api.GroupBy](path, check = false)
           try {
-            val featureMetadata = analyzer.analyzeGroupBy(groupBy)._1.map(_.asMap)
+            val featureMetadata = analyzer.analyzeGroupBy(groupBy, validateTablePermission = false)._1.map(_.asMap)
             configData + { "features" -> featureMetadata }
           } catch {
             // Exception while analyzing groupBy

--- a/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
@@ -92,7 +92,7 @@ class CompareJob(
   def validate(): Unit = {
     // Extract the schema of the Join, StagingQuery and the keys before calling this.
     val analyzer = new Analyzer(tableUtils, joinConf, startDate, endDate, enableHitter = false)
-    val analyzerResult = analyzer.analyzeJoin(joinConf, false)
+    val analyzerResult = analyzer.analyzeJoin(joinConf)
     val joinChrononSchema = analyzerResult.leftSchema ++ analyzerResult.finalOutputSchema
     val joinSchema = joinChrononSchema.map { case (k, v) => (k, SparkConversions.fromChrononType(v)) }.toMap
     val finalStagingQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, startDate, endDate, endDate)

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -703,8 +703,8 @@ class AnalyzerTest {
         Builders.Derivation.star(),
         Builders
           .Derivation(
-            expression = "prefix_analyzer_test_complex_gb_time_spent_ms_sum_7d / ext_contextual_user_tenure",
-            name = "analyzer_test_time_spent_ms_sum_7d_per_tenure"
+            expression = "prefix_analyzer_test_complex_gb_time_spent_ms_avg_last_7d_diff / ext_contextual_user_tenure",
+            name = "analyzer_test_time_spent_ms_sum_7d_diff_per_tenure"
           )
       ),
       metaData = Builders.MetaData(name = "analyzer_test.complex_join", namespace = namespace, team = "chronon")
@@ -755,7 +755,7 @@ class AnalyzerTest {
       ("prefix_analyzer_test_complex_gb_view_map_last100", api.ListType(api.MapType(api.StringType, api.LongType))),
       ("prefix_analyzer_test_complex_gb_time_spent_ms_avg_last_7d_diff", api.DoubleType),
       ("ext_contextual_user_tenure", api.LongType),
-      ("analyzer_test_time_spent_ms_sum_7d_per_tenure", api.DoubleType)
+      ("analyzer_test_time_spent_ms_sum_7d_diff_per_tenure", api.DoubleType)
     )
 
     // Assertions on analyzer result
@@ -782,7 +782,7 @@ class AnalyzerTest {
         |{"name":"prefix_analyzer_test_complex_gb_view_map_last100","data_type":"array<map<string,bigint>>"},
         |{"name":"prefix_analyzer_test_complex_gb_time_spent_ms_avg_last_7d_diff","data_type":"double"},
         |{"name":"ext_contextual_user_tenure","data_type":"bigint"},
-        |{"name":"analyzer_test_time_spent_ms_sum_7d_per_tenure","data_type":"double"}
+        |{"name":"analyzer_test_time_spent_ms_sum_7d_diff_per_tenure","data_type":"double"}
         |]""".stripMargin.replaceAll("\\s+", "")
 
     assertEquals(keySchemaExpected, keySchema)

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -485,7 +485,7 @@ class AnalyzerTest {
     )
 
     val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
-    val (_, _, noAccessTables) = analyzer.analyzeGroupBy(tableGroupBy, validateTablePermission = true)
+    val (_, _, noAccessTables) = analyzer.analyzeGroupBy(tableGroupBy)
     assertEquals(1, noAccessTables.size)
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -485,8 +485,8 @@ class AnalyzerTest {
     )
 
     val analyzer = new Analyzer(tableUtils, tableGroupBy, oneMonthAgo, today)
-    val (_, _, noAccessTables) = analyzer.analyzeGroupBy(tableGroupBy)
-    assertEquals(1, noAccessTables.size)
+    val analyzerResult = analyzer.analyzeGroupBy(tableGroupBy)
+    assertEquals(1, analyzerResult.noAccessTables.size)
   }
 
   @Test(expected = classOf[java.lang.AssertionError])

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -99,6 +99,8 @@ class AnalyzerTest {
     logger.info(expectedSchema.mkString("\n"))
 
     assertTrue(expectedSchema sameElements analyzerSchema)
+
+    analyzer
   }
 
   @Test(expected = classOf[java.lang.AssertionError])

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -654,7 +654,7 @@ class AnalyzerTest {
         Builders.Aggregation(operation = Operation.LAST_K, argMap = Map("k" -> "100"), inputColumn = "view_map")
       ),
       derivations = Seq(
-        Builders.Derivation.wildcard(),
+        Builders.Derivation.star(),
         Builders.Derivation(
           name = "time_spent_ms_avg_last_7d_diff",
           expression = "time_spent_ms_last_7d - time_spent_ms_average_7d"
@@ -700,7 +700,7 @@ class AnalyzerTest {
       ),
       externalParts = Seq(externalPart),
       derivations = Seq(
-        Builders.Derivation.wildcard(),
+        Builders.Derivation.star(),
         Builders
           .Derivation(
             expression = "prefix_analyzer_test_complex_gb_time_spent_ms_sum_7d / ext_contextual_user_tenure",

--- a/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
@@ -106,9 +106,7 @@ class FetchStatsTest extends TestCase {
       left = Builders.Source.events(Builders.Query(startPartition = start), table = itemQueriesTable),
       joinParts = Seq(Builders.JoinPart(groupBy = gb, prefix = "user")),
       derivations = Seq(
-        Builders.Derivation(
-          name = "*"
-        ),
+        Builders.Derivation.star(),
         Builders.Derivation(
           name = "last_copy",
           expression = "COALESCE(user_ut_fetch_stats_item_views__fetch_stats_test_value_max, 0)"

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -194,7 +194,7 @@ class FetcherTest extends TestCase {
       accuracy = Accuracy.TEMPORAL,
       metaData = Builders.MetaData(name = "unit_test/fetcher_mutations_gb", namespace = namespace, team = "chronon"),
       derivations = Seq(
-        Builders.Derivation(name = "*", expression = "*"),
+        Builders.Derivation.star(),
         Builders.Derivation(name = "rating_average_1d_same", expression = "rating_average_1d")
       )
     )
@@ -326,7 +326,7 @@ class FetcherTest extends TestCase {
       metaData = Builders.MetaData(name = "unit_test/vendor_credit_derivation", namespace = namespace),
       derivations = Seq(
         Builders.Derivation("credit_sum_3d_test_rename", "credit_sum_3d"),
-        Builders.Derivation("*", "*")
+        Builders.Derivation.star()
       )
     )
 
@@ -387,7 +387,7 @@ class FetcherTest extends TestCase {
                                    team = "chronon",
                                    consistencySamplePercent = 30),
       derivations = Seq(
-        Builders.Derivation("*", "*"),
+        Builders.Derivation.star(),
         Builders.Derivation("hist_3d", "unit_test_vendor_ratings_txn_types_histogram_3d"),
         Builders.Derivation("payment_variance", "unit_test_user_payments_payment_variance/2"),
         Builders.Derivation("derived_ds", "from_unixtime(ts/1000, 'yyyy-MM-dd')"),
@@ -674,7 +674,7 @@ class FetcherTest extends TestCase {
     val namespace = "derivation_fetch"
     val joinConf = generateMutationData(namespace)
     val derivations = Seq(
-      Builders.Derivation(name = "*", expression = "*"),
+      Builders.Derivation.star(),
       Builders.Derivation(name = "unit_test_fetcher_mutations_gb_rating_sum_plus",
                           expression = "unit_test_fetcher_mutations_gb_rating_sum + 1"),
       Builders.Derivation(name = "listing_id_renamed", expression = "listing_id")
@@ -687,8 +687,8 @@ class FetcherTest extends TestCase {
   def testTemporalFetchJoinDerivationRenameOnly(): Unit = {
     val namespace = "derivation_fetch_rename_only"
     val joinConf = generateMutationData(namespace)
-    val derivations = Seq(Builders.Derivation(name = "*", expression = "*"),
-                          Builders.Derivation(name = "listing_id_renamed", expression = "listing_id"))
+    val derivations =
+      Seq(Builders.Derivation.star(), Builders.Derivation(name = "listing_id_renamed", expression = "listing_id"))
     joinConf.setDerivations(derivations.toJava)
 
     compareTemporalFetch(joinConf, "2021-04-10", namespace, consistencyCheck = false, dropDsOnWrite = true)

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -311,8 +311,10 @@ class GroupByTest {
     val namespace = "test_analyzer_testGroupByAnalyzer"
     val groupByConf = getSampleGroupBy("unit_analyze_test_item_views", source, namespace)
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (aggregationsMetadata, _, _) =
-      new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)
+    val aggregationsMetadata =
+      new Analyzer(tableUtils, groupByConf, endPartition, today)
+        .analyzeGroupBy(groupByConf, enableHitter = false)
+        .outputMetadata
     val outputTable = backfill(name = "unit_analyze_test_item_views",
                                source = source,
                                endPartition = endPartition,
@@ -349,8 +351,10 @@ class GroupByTest {
                                                          new Window(60, TimeUnit.DAYS))
     )
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (aggregationsMetadata, _, _) =
-      new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)
+    val aggregationsMetadata =
+      new Analyzer(tableUtils, groupByConf, endPartition, today)
+        .analyzeGroupBy(groupByConf, enableHitter = false)
+        .outputMetadata
 
     print(aggregationsMetadata)
     assertTrue(aggregationsMetadata.length == 2)
@@ -374,8 +378,10 @@ class GroupByTest {
     val groupByConf =
       getSampleGroupBy("unit_analyze_test_item_views", source, namespace, Seq.empty, derivations = Seq(derivation))
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
-    val (aggregationsMetadata, _, _) =
-      new Analyzer(tableUtils, groupByConf, endPartition, today).analyzeGroupBy(groupByConf, enableHitter = false)
+    val aggregationsMetadata =
+      new Analyzer(tableUtils, groupByConf, endPartition, today)
+        .analyzeGroupBy(groupByConf, enableHitter = false)
+        .outputMetadata
     val outputTable = backfill(name = "unit_analyze_test_item_views",
                                source = source,
                                endPartition = endPartition,

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -374,7 +374,7 @@ class GroupByTest {
     val (source, endPartition) = createTestSource(30)
     val tableUtils = TableUtils(spark)
     val namespace = "test_analyzer_testGroupByDerivation"
-    val derivation = Builders.Derivation(name = "*", expression = "*")
+    val derivation = Builders.Derivation.star()
     val groupByConf =
       getSampleGroupBy("unit_analyze_test_item_views", source, namespace, Seq.empty, derivations = Seq(derivation))
     val today = tableUtils.partitionSpec.at(System.currentTimeMillis())

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -1275,9 +1275,7 @@ class JoinTest {
 
     joinConfWithExternal.setDerivations(
       Seq(
-        Builders.Derivation(
-          name = "*"
-        ),
+        Builders.Derivation.star(),
         // contextual feature rename
         Builders.Derivation(
           name = "user_txn_count_30d",
@@ -1319,9 +1317,7 @@ class JoinTest {
 
     joinConfWithDerivationWithKey.setDerivations(
       Seq(
-        Builders.Derivation(
-          name = "*"
-        ),
+        Builders.Derivation.star(),
         Builders.Derivation(
           name = "item",
           expression = "item"

--- a/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/bootstrap/DerivationTest.scala
@@ -53,9 +53,7 @@ class DerivationTest {
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
 
     val derivation1 = Builders.Derivation(name = "user_amount_30d_avg", expression = "amount_dollars_sum_30d / 30")
-    val derivation2 = Builders.Derivation(
-      name = "*"
-    )
+    val derivation2 = Builders.Derivation.star()
 
     val groupByWithDerivation = groupBy
       .setDerivations(
@@ -87,9 +85,7 @@ class DerivationTest {
         )
       ),
       derivations = Seq(
-        Builders.Derivation(
-          name = "*"
-        ),
+        Builders.Derivation.star(),
         // contextual feature rename
         Builders.Derivation(
           name = "user_txn_count_30d",
@@ -408,7 +404,7 @@ class DerivationTest {
       joinParts = Seq(joinPart),
       derivations =
         (if (wildcardSelection) {
-           Seq(Derivation("*", "*"))
+           Seq(Derivation.star())
          } else {
            Seq.empty
          }) :+ Builders.Derivation(
@@ -581,10 +577,7 @@ class DerivationTest {
             name = "context_1",
             expression = "ext_contextual_context_1"
           ),
-          Builders.Derivation(
-            name = "*",
-            expression = "*"
-          )
+          Builders.Derivation.star()
         ),
         "test_2"
       ))
@@ -648,7 +641,7 @@ class DerivationTest {
     val groupBy = BootstrapUtils.buildGroupBy(namespace, spark)
     groupBy.setBackfillStartDate(today)
     groupBy.setDerivations(
-      Seq(Builders.Derivation(name = "*"),
+      Seq(Builders.Derivation.star(),
           Builders.Derivation(
             name = "amount_dollars_avg_15d",
             expression = "amount_dollars_sum_15d / 15"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Update analyzer to support schema export to Hive table. The "schema" table will follow the naming convention of backfill table for Join and GroupBy, with a suffix `_schema`. 

Also included some additional fixes in the same PR: 
- Support GroupBy derivations broadly, not just for gbBackfill cases
- Improve `build_derived_columns` in Python API to ensure ordering matches with user's derivations ordering
- Print key_schema in Analyzer output 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Allow building composable steps which consume join schema for additional processing 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Reviewers

@yuli-han @pengyu-hou @airbnb/airbnb-chronon-maintainers 
