### PR TITLE
Enable metadata export to hive table

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -554,12 +554,21 @@ object Driver {
       val inputRootPath: ScallopOption[String] =
         opt[String](required = true, descr = "Base path of config repo to export from")
       val outputRootPath: ScallopOption[String] =
-        opt[String](required = true, descr = "Base path to write output metadata files to")
+        opt[String](required = false, descr = "Base path to write output metadata files to")
+      val outputTableName: ScallopOption[String] =
+        opt[String](required = false, descr = "Hive table to write output metadata to")
+      val outputTablePropertiesJson: ScallopOption[String] =
+        opt[String](required = false, descr = "Optional output table properties in JSON format")
       override def subcommandName() = "metadata-export"
     }
 
     def run(args: Args): Unit = {
-      MetadataExporter.run(args.inputRootPath(), args.outputRootPath())
+      val dsOpt: Option[String] = if (args.endDate().isEmpty) None else Some(args.endDate())
+      MetadataExporter.run(args.inputRootPath(),
+                           args.outputRootPath.toOption,
+                           args.outputTableName.toOption,
+                           dsOpt,
+                           args.outputTablePropertiesJson.toOption)
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -24,6 +24,7 @@ import ai.chronon.api.ThriftJsonCodec
 import ai.chronon.online.Metrics
 import ai.chronon.online.Metrics.Environment
 import java.nio.file.{Files, Paths}
+import org.apache.spark.sql.functions._
 
 import collection.mutable.ListBuffer
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -38,9 +39,12 @@ object MetadataExporter {
 
   val mapper = new ObjectMapper()
   mapper.registerModule(DefaultScalaModule)
-  val tableUtils = TableUtils(SparkSessionBuilder.build("metadata_exporter"))
+  val sparkSession = SparkSessionBuilder.build("metadata_exporter")
+  val tableUtils = TableUtils(sparkSession)
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   private val yesterday = tableUtils.partitionSpec.before(today)
+
+  private val partitionColumns = Seq("entityType", "ds")
 
   def getFilePaths(inputPath: String): Seq[String] = {
     val rootDir = new File(inputPath)
@@ -127,7 +131,7 @@ object MetadataExporter {
     mapper.writeValueAsString(enrichedData)
   }
 
-  def writeOutput(data: String, path: String, outputDirectory: String): Unit = {
+  def writeOutputToFile(data: String, path: String, outputDirectory: String): Unit = {
     Files.createDirectories(Paths.get(outputDirectory))
     val file = new File(outputDirectory + "/" + path.split("/").last)
     file.createNewFile()
@@ -137,14 +141,45 @@ object MetadataExporter {
     logger.info(s"${path} : Wrote to output directory successfully")
   }
 
+  def writeOutputToTable(dataWithPath: Seq[(String, String)],
+                         tableName: String,
+                         ds: String,
+                         outputTablePropertiesJson: Option[String]): Unit = {
+    import sparkSession.implicits._
+    // Step 1: Convert to DataFrame
+    val dfRaw = dataWithPath.toDF("path", "metadata")
+    val tableProperties = outputTablePropertiesJson
+      .map(json => mapper.readValue(json, classOf[Map[String, String]]))
+      .getOrElse(Map.empty[String, String])
+
+    // Step 2: Add ds and entityType (extracted from path)
+    val dfWithPartitions = dfRaw
+      .withColumn("ds", lit(ds))
+      .withColumn("entityType",
+        when($"path".contains(GROUPBY_PATH_SUFFIX), "groupBy")
+          .when($"path".contains(JOIN_PATH_SUFFIX), "join")
+          .otherwise("unknown")
+      )
+
+    // Step 3: insert data into hive table
+    tableUtils.insertPartitions(
+      dfWithPartitions,
+        tableName,
+        tableProperties,
+        partitionColumns
+    )
+
+    logger.info(s"${tableName} : Wrote to output table successfully")
+  }
+
   def processEntities(inputPath: String, outputPath: String): Unit = {
     val processSuccess = getFilePaths(inputPath).map { path =>
       try {
         val data = enrichMetadata(path)
         if (path.contains(GROUPBY_PATH_SUFFIX)) {
-          writeOutput(data, path, outputPath + GROUPBY_PATH_SUFFIX)
+          writeOutputToFile(data, path, outputPath + GROUPBY_PATH_SUFFIX)
         } else if (path.contains(JOIN_PATH_SUFFIX)) {
-          writeOutput(data, path, outputPath + JOIN_PATH_SUFFIX)
+          writeOutputToFile(data, path, outputPath + JOIN_PATH_SUFFIX)
         }
         (path, true, None)
       } catch {
@@ -157,7 +192,48 @@ object MetadataExporter {
         s"Failed to process ${failuresAndTraces.length}: \n ${failuresAndTraces.mkString("\n")}")
   }
 
-  def run(inputPath: String, outputPath: String): Unit = {
-    processEntities(inputPath, outputPath)
+  def processEntities(inputPath: String,
+                      outputTableName: String,
+                      ds: String,
+                      extraOutputTablePropertiesJson: Option[String]): Unit = {
+    val processedData = getFilePaths(inputPath).map { path =>
+      try {
+        val data = enrichMetadata(path)
+        (path, true, data)
+      } catch {
+        case exception: Throwable => (path, false, ExceptionUtils.getStackTrace(exception))
+      }
+    }
+    val failuresAndTraces = processedData.filter(!_._2)
+    logger.info(
+      s"Successfully processed ${processedData.filter(_._2).length} from $inputPath \n " +
+        s"Failed to process ${failuresAndTraces.length}: \n ${failuresAndTraces.mkString("\n")}")
+    val processedSucceededData = processedData.filter(_._2).map(x => (x._1, x._3))
+    writeOutputToTable(processedSucceededData, outputTableName, ds, extraOutputTablePropertiesJson)
+  }
+
+  def run(inputPath: String,
+          outputPathOpt: Option[String],
+          outputTableNameOpt: Option[String],
+          ds: Option[String],
+          outputTablePropertiesJson: Option[String]): Unit = {
+    if (outputPathOpt.isDefined) {
+      processEntities(inputPath, outputPathOpt.get)
+    } else if (outputTableNameOpt.isDefined) {
+      if (ds.isEmpty) {
+        throw new IllegalArgumentException(
+          s"`outputTableName` was provided (${outputTableNameOpt.get}), but `ds` (DataStore) is missing.\n" +
+            s"To write to a Hive table, both `outputTableName` and `ds` must be provided."
+        )
+      }
+      processEntities(inputPath, outputTableNameOpt.get, ds.get, outputTablePropertiesJson)
+    } else {
+      throw new IllegalArgumentException(
+        s"Missing output destination: either `outputRootPath` or `outputTableName` must be provided.\n" +
+          s"To fix this, specify one of the following:\n" +
+          s"  --outputRootPath <path>   (to write output files to the file system)\n" +
+          s"  --outputTableName <name>  (to write output to a Hive table — requires `ds` to be passed as well)"
+      )
+    }
   }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Currently the metadata-exporter supports generating and exporting the metadata to a local directory. This PR is to add support to export metadata to a hive table with given table name and table properties. 

After the change the metadata exporter supports two sub-mode
1. write to local directory. If output-root-path is passed.
2. write to a hive table. if output-table-name and ds is passed

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

python3 ~/.local/bin/run.py   --mode=metadata-export   --input-root-path production/joins/zipline_test --output-table-name zipline.chronon_metadata   --ds 2025-07-28   --output-table-properties-json='{"abb_retention_config_json":"{\"policy\":\"delete_by_last_modified\",\"days\":365,\"reason\":\"Chronon_metadata_table\"}"}'   --chronon-jar ~/test/chronon-spark.jar | tee ~/test/metadata_export.log

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @pengyu-hou @Shiyinghaha 
