### PR TITLE
adding attributes field to MetaData for GroupBy and Join

### DIFF
--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -363,6 +363,7 @@ def GroupBy(
     derivations: Optional[List[ttypes.Derivation]] = None,
     deprecation_date: Optional[str] = None,
     description: Optional[str] = None,
+    attributes: Optional[Dict[str, str]] = None,
     **kwargs,
 ) -> ttypes.GroupBy:
     """
@@ -481,6 +482,7 @@ def GroupBy(
         Additional properties that would be passed to run.py if specified under additional_args property.
         And provides an option to pass custom values to the processing logic.
     :param description: optional description of this GroupBy
+    :param attributes:  any extra attributes of this GroupBy
     :type kwargs: Dict[str, str]
     :return:
         A GroupBy object containing specified aggregations.
@@ -560,6 +562,7 @@ def GroupBy(
         offlineSchedule=offline_schedule,
         deprecationDate=deprecation_date,
         description=description,
+        attributes=attributes,
     )
 
     group_by = ttypes.GroupBy(

--- a/api/py/ai/chronon/join.py
+++ b/api/py/ai/chronon/join.py
@@ -396,6 +396,7 @@ def Join(
     tags: Optional[Dict[str, str]] = None,
     description: Optional[str] = None,
     model_transforms: Optional[api.ModelTransforms] = None,
+    attributes: Optional[Dict[str, str]] = None,
     **kwargs,
 ) -> api.Join:
     """
@@ -498,6 +499,7 @@ def Join(
     :param description: optional description of this Join
     :param model_transforms:
         A list of model transforms to convert derivation outputs to model outputs using model-based transformations
+    :param attributes:  any extra attributes of this Join
     :return:
         A join object that can be used to backfill or serve data. For ML use-cases this should map 1:1 to model.
     """
@@ -607,6 +609,7 @@ def Join(
         historicalBackfill=historical_backfill,
         deprecationDate=deprecation_date,
         description=description,
+        attributes=attributes,
     )
 
     return api.Join(

--- a/api/py/test/test_group_by.py
+++ b/api/py/test/test_group_by.py
@@ -295,6 +295,26 @@ def test_group_by_with_description():
     assert gb.metaData.description == "GroupBy description"
 
 
+def test_group_by_with_attributes():
+  gb = group_by.GroupBy(
+      sources=[
+        ttypes.EventSource(
+            table="event_table1",
+            query=query.Query(
+                selects=None,
+                time_column="ts"
+            )
+        )
+      ],
+      keys=["key1", "key2"],
+      aggregations=[group_by.Aggregation(input_column="event_id", operation=ttypes.Operation.SUM)],
+      name="test.additional_metadata_gb",
+      attributes=["attr1", "attr1Val"]
+  )
+  assert gb.metaData.attributes == ["attr1", "attr1Val"]
+
+
+
 def test_derivation():
     derivation = Derivation(name="derivation_name", expression="derivation_expression")
     expected_derivation = ttypes.Derivation(

--- a/api/py/test/test_join.py
+++ b/api/py/test/test_join.py
@@ -62,6 +62,14 @@ def test_join_with_description():
     )
     assert join.metaData.description == "Join description"
 
+def test_join_with_attributes():
+  join = Join(
+      left=event_source("sample_namespace.sample_table"),
+      right_parts=[right_part(event_source("sample_namespace.another_table"))],
+      attributes=["attr1", "attr1Val"]
+  )
+  assert join.metaData.attributes == ["attr1", "attr1Val"]
+
 def test_deduped_dependencies():
     """
     Check left and right dependencies are deduped in metadata.

--- a/api/src/main/scala/ai/chronon/api/Builders.scala
+++ b/api/src/main/scala/ai/chronon/api/Builders.scala
@@ -274,7 +274,8 @@ object Builders {
         tableProperties: Map[String, String] = Map.empty,
         historicalBackill: Boolean = true,
         deprecationDate: String = null,
-        description: String = null
+        description: String = null,
+        attributes: Map[String, String] = Map.empty
     ): MetaData = {
       val result = new MetaData()
       result.setName(name)
@@ -296,6 +297,9 @@ object Builders {
         result.setDeprecationDate(deprecationDate)
       if (description != null) {
         result.setDescription(description)
+      }
+      if (attributes != null) {
+        result.setAttributes(attributes.toJava)
       }
       result
     }

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -263,6 +263,7 @@ struct MetaData {
     15: optional string deprecationDate
     // Description for the object holding this metadata
     16: optional string description
+    17: optional map<string, string> attributes
 }
 
 // Equivalent to a FeatureSet in chronon terms


### PR DESCRIPTION
## Summary
Adding attributes field to metadata for GroupBy and Join to pass company specific information 


## Why / Goal
Allow to passthrough some custom and company related information without adding dedicated fields


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

