### PR TITLE
[CHIP-9] Model transform batch job interface + orchestration

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -292,6 +292,7 @@ def set_runtime_env(args):
                         "backfill-left",
                         "backfill-final",
                         "upload",
+                        "model-transform-batch",
                     }:
                         environment["conf_env"]["CHRONON_CONFIG_ADDITIONAL_ARGS"] = " ".join(
                             custom_json(conf_json).get("additional_args", [])

--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -32,12 +32,7 @@ ONLINE_ARGS = "--online-jar={online_jar} --online-class={online_class} "
 OFFLINE_ARGS = "--conf-path={conf_path} --end-date={ds} "
 ONLINE_WRITE_ARGS = "--conf-path={conf_path} " + ONLINE_ARGS
 ONLINE_OFFLINE_WRITE_ARGS = OFFLINE_ARGS + ONLINE_ARGS
-ONLINE_MODES = [
-    "streaming",
-    "metadata-upload",
-    "fetch",
-    "local-streaming",
-]
+ONLINE_MODES = ["streaming", "metadata-upload", "fetch", "local-streaming", "model-transform-batch"]
 SPARK_MODES = [
     "backfill",
     "backfill-left",
@@ -52,6 +47,7 @@ SPARK_MODES = [
     "log-flattener",
     "metadata-export",
     "label-join",
+    "model-transform-batch",
 ]
 MODES_USING_EMBEDDED = ["metadata-upload", "fetch", "local-streaming"]
 
@@ -76,6 +72,7 @@ MODE_ARGS = {
     "log-flattener": OFFLINE_ARGS,
     "metadata-export": OFFLINE_ARGS,
     "label-join": OFFLINE_ARGS,
+    "model-transform-batch": ONLINE_OFFLINE_WRITE_ARGS,
     "info": "",
 }
 
@@ -104,6 +101,7 @@ ROUTES = {
         "log-flattener": "log-flattener",
         "metadata-export": "metadata-export",
         "label-join": "label-join",
+        "model-transform-batch": "model-transform-batch",
     },
     "staging_queries": {
         "backfill": "staging-query-backfill",
@@ -290,7 +288,10 @@ def set_runtime_env(args):
                     environment["conf_env"] = conf_json.get("metaData").get("modeToEnvMap", {}).get(effective_mode, {})
                     # Load additional args used on backfill.
                     if custom_json(conf_json) and effective_mode in {
-                      "backfill", "backfill-left", "backfill-final", "upload"
+                        "backfill",
+                        "backfill-left",
+                        "backfill-final",
+                        "upload",
                     }:
                         environment["conf_env"]["CHRONON_CONFIG_ADDITIONAL_ARGS"] = " ".join(
                             custom_json(conf_json).get("additional_args", [])

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -1084,6 +1084,18 @@ object Extensions {
       }
     }
 
+    lazy val inputSchema: List[StructField] = {
+      modelTransform.model.inputSchemaScala.map { modelField =>
+        StructField(inputMappingsScala.getOrElse(modelField.name, modelField.name), modelField.fieldType)
+      }
+    }
+
+    lazy val outputSchema: List[StructField] = {
+      modelTransform.model.outputSchemaScala.map { modelField =>
+        StructField(outputMappingsScala.getOrElse(modelField.name, modelField.name), modelField.fieldType)
+      }
+    }
+
     lazy val inputMappingsScala: Map[String, String] =
       Option(modelTransform.inputMappings).map(_.toScala).getOrElse(Map.empty)
     lazy val outputMappingsScala: Map[String, String] =

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -1076,6 +1076,14 @@ object Extensions {
   }
 
   implicit class ModelTransformOps(modelTransform: ModelTransform) {
+    lazy val name: String = {
+      if (modelTransform.isSetPrefix) {
+        Seq(modelTransform.prefix, modelTransform.model.metaData.name).mkString("_")
+      } else {
+        modelTransform.model.metaData.name
+      }
+    }
+
     lazy val inputMappingsScala: Map[String, String] =
       Option(modelTransform.inputMappings).map(_.toScala).getOrElse(Map.empty)
     lazy val outputMappingsScala: Map[String, String] =

--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -39,6 +39,7 @@ object Metrics {
     val JoinLogFlatten = "join.log_flatten"
     val LabelJoin = "label_join"
     val ModelTransform = "model_transform"
+    val ModelTransformBatch = "model_transform.batch"
   }
 
   import Environment._

--- a/online/src/main/scala/ai/chronon/online/ModelBackend.scala
+++ b/online/src/main/scala/ai/chronon/online/ModelBackend.scala
@@ -17,7 +17,7 @@
 package ai.chronon.online
 
 import ai.chronon.api.{Join, Model, ModelTransform}
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import scala.collection.Seq
 import scala.concurrent.Future
@@ -48,6 +48,7 @@ trait ModelBackend {
       join: Join,
       startPartition: String,
       endPartition: String,
-      modelTransform: Option[ModelTransform] = None
-  ): Unit
+      modelTransform: Option[ModelTransform] = None,
+      jobContextJson: Option[String] = None
+  ): Option[DataFrame] = None
 }

--- a/online/src/main/scala/ai/chronon/online/ModelBackend.scala
+++ b/online/src/main/scala/ai/chronon/online/ModelBackend.scala
@@ -16,7 +16,8 @@
 
 package ai.chronon.online
 
-import ai.chronon.api.{Join, Model}
+import ai.chronon.api.{Join, Model, ModelTransform}
+import org.apache.spark.sql.SparkSession
 
 import scala.collection.Seq
 import scala.concurrent.Future
@@ -31,7 +32,22 @@ case class RunModelInferenceResponse(request: RunModelInferenceRequest, outputs:
 
 trait ModelBackend {
 
+  /**
+    * Run online model inference which returns the model output directly.
+    * This method is used in fetcher.fetchJoin to process the model inference
+    * @return RunModelInferenceResponse containing the model outputs for the given inputs.
+    */
   def runModelInference(runModelInferenceRequest: RunModelInferenceRequest): Future[RunModelInferenceResponse]
-  // Run online model inference which returns the model output directly.
-  // Will be used in fetcher.fetchJoin
+
+  /**
+    * Run batch model inference job which will be executed asynchronously in batch.
+    * @return a job ID that can be used to check the status of the job.
+    */
+  def runModelInferenceBatchJob(
+      sparkSession: SparkSession,
+      join: Join,
+      startPartition: String,
+      endPartition: String,
+      modelTransform: Option[ModelTransform] = None
+  ): Unit
 }

--- a/spark/src/main/scala/ai/chronon/spark/ModelTransformBatchJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ModelTransformBatchJob.scala
@@ -1,7 +1,23 @@
+/*
+ *    Copyright (C) 2025 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package ai.chronon.spark
 import ai.chronon.api.Extensions.{JoinOps, MetadataOps, ModelTransformOps, SourceOps}
 import ai.chronon.api.ModelTransform
-import ai.chronon.online.ModelBackend
+import ai.chronon.online.{Metrics, ModelBackend}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 
@@ -11,11 +27,20 @@ case class ModelTransformBatchJob(
     modelBackend: ModelBackend,
     join: ai.chronon.api.Join,
     endPartition: String,
-    startPartitionOverride: Option[String],
-    stepDays: Int,
-    modelTransformOverrideName: Option[String],
-    jobContextJson: Option[String]
+    startPartitionOverride: Option[String] = None,
+    stepDays: Int = 30,
+    modelTransformOverrideName: Option[String] = None,
+    jobContextJson: Option[String] = None
 ) {
+
+  private lazy val metrics: Metrics.Context = {
+    val joinMetric = Metrics.Context(Metrics.Environment.ModelTransformBatch, join)
+    if (modelTransformOverride.isDefined) {
+      joinMetric.copy(model = modelTransformOverride.get.name)
+    } else {
+      joinMetric
+    }
+  }
 
   private lazy val logger = LoggerFactory.getLogger(getClass)
   private lazy val tableUtils = TableUtils(sparkSession)
@@ -59,7 +84,7 @@ case class ModelTransformBatchJob(
       )
       .getOrElse(Seq.empty)
 
-    val stepRanges = unfilledRanges.flatMap(_.steps(stepDays))
+    val stepRanges = unfilledRanges.flatMap(_.steps(stepDays)).toSeq
 
     logger.info(s"""Compute ranges:
          |Total ranges to fill based on left table: $rangeToFill,
@@ -74,6 +99,7 @@ case class ModelTransformBatchJob(
     val computeRanges = getComputeRanges(endPartition, startPartitionOverride, stepDays)
     computeRanges.foreach { range =>
       logger.info(s"Running model transform batch job for range: ${range.start} to ${range.end}")
+      val startMillis = System.currentTimeMillis()
       val outputDfOpt = modelBackend.runModelInferenceBatchJob(
         sparkSession,
         join,
@@ -91,6 +117,9 @@ case class ModelTransformBatchJob(
             s"Assuming data has been written by ModelBackend.")
       }
 
+      val elapsedMins = (System.currentTimeMillis() - startMillis) / (60 * 1000)
+      metrics.gauge(Metrics.Name.LatencyMinutes, elapsedMins)
+      metrics.gauge(Metrics.Name.PartitionCount, range.partitions.length)
       logger.info(s"Completed model transform batch job for range: ${range.start} to ${range.end}")
     }
   }

--- a/spark/src/main/scala/ai/chronon/spark/ModelTransformBatchJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ModelTransformBatchJob.scala
@@ -1,30 +1,97 @@
 package ai.chronon.spark
-import ai.chronon.api.Extensions.{JoinOps, ModelTransformOps}
+import ai.chronon.api.Extensions.{JoinOps, MetadataOps, ModelTransformOps, SourceOps}
 import ai.chronon.api.ModelTransform
 import ai.chronon.online.ModelBackend
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.slf4j.LoggerFactory
+
+import scala.util.ScalaJavaConversions.MapOps
 case class ModelTransformBatchJob(
     sparkSession: SparkSession,
     modelBackend: ModelBackend,
     join: ai.chronon.api.Join,
-    startPartition: String,
     endPartition: String,
-    modelTransformOverride: Option[String]
+    startPartitionOverride: Option[String],
+    stepDays: Int,
+    modelTransformOverrideName: Option[String],
+    jobContextJson: Option[String]
 ) {
 
-  private def getModelTransformOverride: Option[ModelTransform] = {
-    modelTransformOverride.flatMap(modelTransformName =>
+  private lazy val logger = LoggerFactory.getLogger(getClass)
+  private lazy val tableUtils = TableUtils(sparkSession)
+  private lazy val modelTransformOverride: Option[ModelTransform] = {
+    modelTransformOverrideName.flatMap(modelTransformName =>
       join.modelTransformsListScala.find { modelTransform: ModelTransform =>
         modelTransform.name == modelTransformName
       })
   }
-  def run(): Unit = {
-    modelBackend.runModelInferenceBatchJob(
-      sparkSession,
-      join,
-      startPartition,
-      endPartition,
-      getModelTransformOverride
+
+  private def writeFinalOutput(outputDf: DataFrame): Unit = {
+    val tableProperties = Option(join.metaData.tableProperties)
+      .map(_.toScala.toMap)
+      .getOrElse(Map.empty[String, String])
+
+    tableUtils.insertPartitions(
+      outputDf,
+      join.metaData.outputTable,
+      tableProperties,
+      autoExpand = true
     )
+  }
+
+  private def getComputeRanges(endPartition: String,
+                               startPartitionOverride: Option[String],
+                               stepDays: Int): Seq[PartitionRange] = {
+    val rangeToFill = JoinUtils.getRangesToFill(
+      join.left,
+      tableUtils,
+      endPartition,
+      startPartitionOverride,
+      join.historicalBackfill
+    )
+    val unfilledRanges = tableUtils
+      .unfilledRanges(
+        join.metaData.outputTable,
+        rangeToFill,
+        // Check ranges to fill based on pre-mt table
+        Some(Seq(join.metaData.preModelTransformsTable)),
+        skipFirstHole = true
+      )
+      .getOrElse(Seq.empty)
+
+    val stepRanges = unfilledRanges.flatMap(_.steps(stepDays))
+
+    logger.info(s"""Compute ranges:
+         |Total ranges to fill based on left table: $rangeToFill,
+         |Unfilled ranges in the output table based on pre-mt table: $unfilledRanges
+         |Unfilled ranges split by step days: $stepRanges
+         |""".stripMargin)
+
+    stepRanges
+  }
+
+  def run(): Unit = {
+    val computeRanges = getComputeRanges(endPartition, startPartitionOverride, stepDays)
+    computeRanges.foreach { range =>
+      logger.info(s"Running model transform batch job for range: ${range.start} to ${range.end}")
+      val outputDfOpt = modelBackend.runModelInferenceBatchJob(
+        sparkSession,
+        join,
+        range.start,
+        range.end,
+        modelTransformOverride,
+        jobContextJson
+      )
+      if (outputDfOpt.isDefined) {
+        logger.info(s"Writing output for range: ${range.start} to ${range.end}")
+        outputDfOpt.foreach(writeFinalOutput)
+      } else {
+        logger.warn(
+          s"No output DataFrame is provided for range: ${range.start} to ${range.end}. " +
+            s"Assuming data has been written by ModelBackend.")
+      }
+
+      logger.info(s"Completed model transform batch job for range: ${range.start} to ${range.end}")
+    }
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/ModelTransformBatchJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ModelTransformBatchJob.scala
@@ -1,0 +1,30 @@
+package ai.chronon.spark
+import ai.chronon.api.Extensions.{JoinOps, ModelTransformOps}
+import ai.chronon.api.ModelTransform
+import ai.chronon.online.ModelBackend
+import org.apache.spark.sql.SparkSession
+case class ModelTransformBatchJob(
+    sparkSession: SparkSession,
+    modelBackend: ModelBackend,
+    join: ai.chronon.api.Join,
+    startPartition: String,
+    endPartition: String,
+    modelTransformOverride: Option[String]
+) {
+
+  private def getModelTransformOverride: Option[ModelTransform] = {
+    modelTransformOverride.flatMap(modelTransformName =>
+      join.modelTransformsListScala.find { modelTransform: ModelTransform =>
+        modelTransform.name == modelTransformName
+      })
+  }
+  def run(): Unit = {
+    modelBackend.runModelInferenceBatchJob(
+      sparkSession,
+      join,
+      startPartition,
+      endPartition,
+      getModelTransformOverride
+    )
+  }
+}

--- a/spark/src/main/scala/ai/chronon/spark/SemanticHashUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/SemanticHashUtils.scala
@@ -142,7 +142,11 @@ object SemanticHashUtils {
     val derivedChanges = oldSemanticHash.get(join.derivedKey) != newSemanticHash.get(join.derivedKey)
     // TODO: make this incremental, retain the main table and continue joining, dropping etc
     val mainTable = if (partsToDrop.nonEmpty || added.nonEmpty || derivedChanges) {
-      Some(join.metaData.outputTable)
+      if (join.hasModelTransforms) {
+        Some(join.metaData.preModelTransformsTable)
+      } else {
+        Some(join.metaData.outputTable)
+      }
     } else None
     partsToDrop ++ mainTable
   }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

implement model transform batch job:
- Add interface to `ModelBackend` that triggers model inference batch job 
- Orchestration logic in `ModelTransformBatchJob` which handles compute-range calculations 
- Update join bootstrap logic to handle model fields 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Support offline job for joins with model transforms 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested


## Reviewers

@airbnb/airbnb-chronon-maintainers @pengyu-hou  
