### PR TITLE
Correct dependency table names in Python test files

### DIFF
--- a/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
+++ b/api/py/test/sample/production/group_bys/sample_team/sample_group_by_group_by.v1
@@ -4,7 +4,7 @@
     "production": 0,
     "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
     "dependencies": [
-      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
     ],
     "tableProperties": {
       "sample_config_json": "{\"sample_key\": \"sample_value\"}",
@@ -17,7 +17,7 @@
   "sources": [
     {
       "events": {
-        "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill",
+        "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
         "query": {
           "selects": {
             "event": "event_expr",

--- a/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
+++ b/api/py/test/sample/production/joins/sample_team/sample_join.group_by_of_group_by
@@ -6,7 +6,7 @@
     "customJson": "{\"check_consistency\": false, \"lag\": 0, \"join_tags\": null, \"join_part_tags\": {}}",
     "dependencies": [
       "{\"name\": \"wait_for_sample_namespace.sample_team_sample_staging_query_v1_ds\", \"spec\": \"sample_namespace.sample_team_sample_staging_query_v1/ds={{ ds }}\", \"start\": \"2021-03-01\", \"end\": null}",
-      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+      "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
     ],
     "tableProperties": {
       "source": "chronon"
@@ -39,7 +39,7 @@
           "production": 0,
           "customJson": "{\"lag\": 0, \"groupby_tags\": null, \"column_tags\": {}}",
           "dependencies": [
-            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
+            "{\"name\": \"wait_for_sample_namespace.sample_team_sample_group_by_require_backfill_ds\", \"spec\": \"sample_namespace.sample_team_sample_group_by_require_backfill/ds={{ ds }}\", \"start\": \"2021-04-09\", \"end\": null}"
           ],
           "tableProperties": {
             "sample_config_json": "{\"sample_key\": \"sample_value\"}",
@@ -52,7 +52,7 @@
         "sources": [
           {
             "events": {
-              "table": "sample_namespace.sample_team_sample_group_by_group_by_require_backfill",
+              "table": "sample_namespace.sample_team_sample_group_by_require_backfill",
               "query": {
                 "selects": {
                   "event": "event_expr",


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
As titled, manually verified the Python config [api/py/test/sample/group_bys/sample_team/sample_group_by_group_by.py](https://github.com/airbnb/chronon/blob/main/api/py/test/sample/group_bys/sample_team/sample_group_by_group_by.py#L28): it reads the output table from [api/py/test/sample/group_bys/sample_team/sample_group_by.py](https://github.com/airbnb/chronon/blob/main/api/py/test/sample/group_bys/sample_team/sample_group_by.py#L40)
So looks like the dependency table name should be `sample_team_sample_group_by_require_backfill`, not `sample_team_sample_group_by_group_by_require_backfill`.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@airbnb/airbnb-chronon-maintainers 
