### PR TITLE
Fix over counting due to bathIR mutation when enabling cache

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -160,7 +160,7 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
           if ((batchEndTs - window.millis) + tailBufferMillis > hopStart && hopStart >= queryTail) {
             val hopVal = hopIr(baseIrIndices(i))
             // When the first relevant hop is null (the collapsed is null),
-            // clone the hop to avoid mutation, because merge bulk later expect to mutate the first element in the list
+            // clone the hop to avoid mutation, because merge bulk later will mutate the first element in the list
             if (relevantHops(0) == null) {
               relevantHops += windowedAggregator(i).clone(hopVal)
             } else {

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -158,7 +158,14 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
           val hopIr = hopIrs(idx)
           val hopStart = hopIr.last.asInstanceOf[Long]
           if ((batchEndTs - window.millis) + tailBufferMillis > hopStart && hopStart >= queryTail) {
-            relevantHops += hopIr(baseIrIndices(i))
+            val hopVal = hopIr(baseIrIndices(i))
+            // When first relevant hop is null, there the collapsed is null,
+            // clone the hop to avoid mutation of first element of the list in merge
+            if (relevantHops(0) == null) {
+              relevantHops += windowedAggregator(i).clone(hopVal)
+            } else {
+              relevantHops += hopVal
+            }
           }
           idx += 1
         }

--- a/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothMutationAggregator.scala
@@ -159,8 +159,8 @@ class SawtoothMutationAggregator(aggregations: Seq[Aggregation],
           val hopStart = hopIr.last.asInstanceOf[Long]
           if ((batchEndTs - window.millis) + tailBufferMillis > hopStart && hopStart >= queryTail) {
             val hopVal = hopIr(baseIrIndices(i))
-            // When first relevant hop is null, there the collapsed is null,
-            // clone the hop to avoid mutation of first element of the list in merge
+            // When the first relevant hop is null (the collapsed is null),
+            // clone the hop to avoid mutation, because merge bulk later expect to mutate the first element in the list
             if (relevantHops(0) == null) {
               relevantHops += windowedAggregator(i).clone(hopVal)
             } else {

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
@@ -131,7 +131,7 @@ class SawtoothOnlineAggregatorTest extends TestCase {
     }
   }
 
-  def testLambdaAggregateFinalizedTiledDoesNotMutateHistogramTailHops(): Unit = {
+  def testLambdaAggregateDoNotMutateBatchIrAndOverCount(): Unit = {
     val aggregations = Seq(
       Builders.Aggregation(
         operation = Operation.HISTOGRAM,

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
@@ -17,7 +17,7 @@
 package ai.chronon.aggregator.test
 
 import ai.chronon.aggregator.test.SawtoothAggregatorTest.sawtoothAggregate
-import ai.chronon.aggregator.windowing.{FiveMinuteResolution, SawtoothOnlineAggregator, TsUtils}
+import ai.chronon.aggregator.windowing.{FinalBatchIr, FiveMinuteResolution, SawtoothOnlineAggregator, TsUtils}
 import ai.chronon.api.Extensions.{WindowOps, WindowUtils}
 import ai.chronon.api._
 import com.google.gson.Gson
@@ -131,4 +131,52 @@ class SawtoothOnlineAggregatorTest extends TestCase {
     }
   }
 
+  def testLambdaAggregateFinalizedTiledDoesNotMutateHistogramTailHops(): Unit = {
+    val aggregations = Seq(
+      Builders.Aggregation(
+        operation = Operation.HISTOGRAM,
+        inputColumn = "action",
+        windows = Seq(
+          new Window(3, TimeUnit.DAYS),
+        )
+      )
+    )
+    val inputSchema: Seq[(String, DataType)] = Seq(
+      ("ts", LongType),
+      ("action", StringType)
+    )
+    val batchEndTs = 1746921600000L // 2025-05-11 00:00:00 UTC
+    val onlineAgg = new SawtoothOnlineAggregator(batchEndTs, aggregations, inputSchema)
+
+    def hop(count: Int, ts: Long): Array[Any] = {
+      val m = new java.util.HashMap[String, Int]();
+      m.put("view", count)
+      Array[Any](m, ts)
+    }
+
+    val finalBatchIr = FinalBatchIr(
+      Array[Any](
+        null,                       // collapsed (T-1 -> T)
+      ),
+      Array(
+        Array.empty,                // 1‑day hops (not used)
+        Array(                      // 1-hour hops
+          hop(1, 1746745200000L),   // 2025-05-08 23:00:00 UTC
+          hop(1, 1746766800000L),   // 2025-05-09 05:00:00 UTC
+        ),
+        Array.empty                  // 5‑minute hops (not used)
+      )
+    )
+    val queryTs = batchEndTs + 100
+
+    val expectedCount = 2
+    var aggResult: Array[Any] = Array()
+    for (_ <- 0 until 10) {
+      aggResult = onlineAgg.lambdaAggregateFinalizedTiled(finalBatchIr, Seq.empty.toIterator, queryTs)
+      val res3d0 = aggResult(0).asInstanceOf[java.util.Map[String, Int]]
+      assertEquals(expectedCount, res3d0.get("view"))
+      val mutated = finalBatchIr.tailHops(1)(0)(0).asInstanceOf[java.util.Map[String, Int]].get("view")
+      assertEquals(1, mutated)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Upon enabling cache, we re-use final bath IR.
- Currently, an edge case when collapsed value is null, we mutate batchIR and result in over-counting
- This PR clone the hop from IR tail so we don't mutate it.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- Verified that before the fix tests failed, IR is mutated and we actually return same instance of map
- Added unit test.


## Checklist
- [ ] Documentation update

## Reviewers

