### PR TITLE
cleanup: standardize on ScalaVersionSpecificCollectionsConverter

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala
@@ -28,9 +28,8 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.security.MessageDigest
 import java.util
 import scala.collection.mutable
-import scala.util.ScalaJavaConversions.IteratorOps
 import scala.reflect.ClassTag
-import scala.util.ScalaJavaConversions.{JListOps, ListOps, MapOps}
+import scala.util.ScalaJavaConversions.{IteratorOps, JListOps, ListOps, MapOps}
 
 class Sum[I: Numeric](inputType: DataType) extends SimpleAggregator[I, I, I] {
   private val numericImpl = implicitly[Numeric[I]]

--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/ColumnAggregator.scala
@@ -22,7 +22,6 @@ import ai.chronon.api._
 import com.fasterxml.jackson.databind.ObjectMapper
 
 import java.util
-import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.util.ScalaJavaConversions.IteratorOps
 
 abstract class ColumnAggregator extends Serializable {
@@ -88,7 +87,7 @@ class VectorDispatcher[Input, IR](agg: SimpleAggregator[Input, IR, _],
     if (inputVal == null) return null
     val anyIterator = inputVal match {
       case inputSeq: collection.Seq[Any]  => inputSeq.iterator
-      case inputList: util.ArrayList[Any] => inputList.iterator().asScala
+      case inputList: util.ArrayList[Any] => inputList.iterator().toScala
     }
     anyIterator.filter { _ != null }.map { toTypedInput }
   }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/ApproxHistogramTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/ApproxHistogramTest.scala
@@ -5,7 +5,7 @@ import junit.framework.TestCase
 import org.junit.Assert._
 
 import java.util
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.{JMapOps, MapOps}
 
 class ApproxHistogramTest extends TestCase {
   def testHistogram(): Unit = {
@@ -143,10 +143,10 @@ class ApproxHistogramTest extends TestCase {
     assertTrue(ir.sketch.isDefined)
 
     val normalized = approxHistogram.denormalize(approxHistogram.normalize(ir))
-    assertEquals(expected, approxHistogram.finalize(normalized).asScala)
+    assertEquals(expected, approxHistogram.finalize(normalized).toScala)
   }
 
-  def toHashMap[T](map: Map[T, Long]): util.HashMap[T, Long] = new util.HashMap[T, Long](map.asJava)
+  def toHashMap[T](map: Map[T, Long]): util.HashMap[T, Long] = new util.HashMap[T, Long](map.toJava)
 
   def makeIr[T](agg: ApproxHistogram[T], counts: Map[T, Long]): ApproxHistogramIr[T] = {
     val values = counts.toSeq.sortBy(_._2)

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/BoundedUniqueCountTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/BoundedUniqueCountTest.scala
@@ -1,12 +1,12 @@
 package ai.chronon.aggregator.test
 
 import ai.chronon.aggregator.base.BoundedUniqueCount
-import ai.chronon.api.{StringType, IntType, LongType, DoubleType, FloatType, BinaryType}
+import ai.chronon.api.{BinaryType, DoubleType, FloatType, IntType, LongType, StringType}
 import junit.framework.TestCase
 import org.junit.Assert._
 
 import java.util
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.JListOps
 
 class BoundedUniqueCountTest extends TestCase {
   def testHappyCase(): Unit = {
@@ -35,8 +35,8 @@ class BoundedUniqueCountTest extends TestCase {
 
   def testMerge(): Unit = {
     val boundedDistinctCount = new BoundedUniqueCount[String](StringType, 5)
-    val ir1 = new util.HashSet[Any](Seq("1", "2", "3").asJava)
-    val ir2 = new util.HashSet[Any](Seq("4", "5", "6").asJava)
+    val ir1 = new util.HashSet[Any](Seq("1", "2", "3").toJava)
+    val ir2 = new util.HashSet[Any](Seq("4", "5", "6").toJava)
 
     val merged = boundedDistinctCount.merge(ir1, ir2)
     val result = boundedDistinctCount.finalize(merged)
@@ -69,8 +69,8 @@ class BoundedUniqueCountTest extends TestCase {
 
   def testIntTypeMerge(): Unit = {
     val boundedDistinctCount = new BoundedUniqueCount[Int](IntType, 5)
-    val ir1 = new util.HashSet[Any](Seq(1, 2, 3).asJava)
-    val ir2 = new util.HashSet[Any](Seq(4, 5, 6).asJava)
+    val ir1 = new util.HashSet[Any](Seq(1, 2, 3).toJava)
+    val ir2 = new util.HashSet[Any](Seq(4, 5, 6).toJava)
 
     val merged = boundedDistinctCount.merge(ir1, ir2)
     val result = boundedDistinctCount.finalize(merged)
@@ -178,8 +178,8 @@ class BoundedUniqueCountTest extends TestCase {
 
   def testBinaryTypeMerge(): Unit = {
     val boundedDistinctCount = new BoundedUniqueCount[Array[Byte]](BinaryType, 5)
-    val ir1 = new util.HashSet[Any](Seq(Array[Byte](1), Array[Byte](2), Array[Byte](3)).asJava)
-    val ir2 = new util.HashSet[Any](Seq(Array[Byte](4), Array[Byte](5), Array[Byte](6)).asJava)
+    val ir1 = new util.HashSet[Any](Seq(Array[Byte](1), Array[Byte](2), Array[Byte](3)).toJava)
+    val ir2 = new util.HashSet[Any](Seq(Array[Byte](4), Array[Byte](5), Array[Byte](6)).toJava)
 
     val merged = boundedDistinctCount.merge(ir1, ir2)
     val result = boundedDistinctCount.finalize(merged)

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/FrequentItemsTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/FrequentItemsTest.scala
@@ -5,7 +5,7 @@ import junit.framework.TestCase
 import org.junit.Assert._
 
 import java.util
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.JMapOps
 
 class FrequentItemsTest extends TestCase {
   def testNonPowerOfTwoAndTruncate(): Unit = {
@@ -154,5 +154,5 @@ class FrequentItemsTest extends TestCase {
     (sketch, ir)
   }
 
-  def toHashMap[T](map: Map[T, Long]): java.util.HashMap[T, Long] = new java.util.HashMap[T, Long](map.asJava)
+  def toHashMap[T](map: Map[T, Long]): java.util.HashMap[T, Long] = new java.util.HashMap[T, Long](map.toJava)
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/MinHeapTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/MinHeapTest.scala
@@ -21,7 +21,7 @@ import junit.framework.TestCase
 import org.junit.Assert._
 
 import java.util
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.ListOps
 
 class MinHeapTest extends TestCase {
   def testInserts(): Unit = {
@@ -35,7 +35,7 @@ class MinHeapTest extends TestCase {
     mh.insert(arr1, 9)
     mh.insert(arr1, 10)
     mh.insert(arr1, -1)
-    assertArrayEquals(arr1.asScala.toArray, Array(9, 4, 5, -1))
+    assertArrayEquals(arr1.toScala.toArray, Array(9, 4, 5, -1))
 
     val arr2 = make_container
     mh.insert(arr2, 5)
@@ -44,9 +44,9 @@ class MinHeapTest extends TestCase {
     mh.insert(arr2, 10)
     mh.insert(arr2, 1)
     mh.insert(arr2, 2)
-    assertArrayEquals(arr2.asScala.toArray, Array(5, 4, 2, 1))
+    assertArrayEquals(arr2.toScala.toArray, Array(5, 4, 2, 1))
 
     mh.merge(arr1, arr2)
-    assertArrayEquals(arr1.asScala.toArray, Array(4, 2, 1, -1))
+    assertArrayEquals(arr1.toScala.toArray, Array(4, 2, 1, -1))
   }
 }

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/RowAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/RowAggregatorTest.scala
@@ -22,10 +22,10 @@ import junit.framework.TestCase
 import org.junit.Assert._
 
 import java.util
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.JListOps
 
 class TestRow(val fieldsSeq: Any*)(tsIndex: Int = 0) extends Row {
-  val fields: util.List[Any] = new java.util.ArrayList[Any](fieldsSeq.asJava)
+  val fields: util.List[Any] = new java.util.ArrayList[Any](fieldsSeq.toJava)
   override val length: Int = fields.size()
 
   override def get(index: Int): Any = fields.get(index)
@@ -93,11 +93,11 @@ class RowAggregatorTest extends TestCase {
       Builders.AggregationPart(Operation.COUNT, "views") -> 3L,
       Builders.AggregationPart(Operation.SUM, "rating") -> 15.0,
       Builders.AggregationPart(Operation.LAST, "title") -> "B",
-      Builders.AggregationPart(Operation.LAST_K, "title", argMap = Map("k" -> "2")) -> List("B", "A").asJava,
-      Builders.AggregationPart(Operation.FIRST_K, "title", argMap = Map("k" -> "2")) -> List("A", "B").asJava,
+      Builders.AggregationPart(Operation.LAST_K, "title", argMap = Map("k" -> "2")) -> List("B", "A").toJava,
+      Builders.AggregationPart(Operation.FIRST_K, "title", argMap = Map("k" -> "2")) -> List("A", "B").toJava,
       Builders.AggregationPart(Operation.FIRST, "title") -> "A",
-      Builders.AggregationPart(Operation.TOP_K, "title", argMap = Map("k" -> "2")) -> List("D", "B").asJava,
-      Builders.AggregationPart(Operation.BOTTOM_K, "title", argMap = Map("k" -> "2")) -> List("A", "A").asJava,
+      Builders.AggregationPart(Operation.TOP_K, "title", argMap = Map("k" -> "2")) -> List("D", "B").toJava,
+      Builders.AggregationPart(Operation.BOTTOM_K, "title", argMap = Map("k" -> "2")) -> List("A", "A").toJava,
       Builders.AggregationPart(Operation.MAX, "title") -> "D",
       Builders.AggregationPart(Operation.MIN, "title") -> "A",
       Builders.AggregationPart(Operation.APPROX_UNIQUE_COUNT, "title") -> 3L,

--- a/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
+++ b/aggregator/src/test/scala/ai/chronon/aggregator/test/SawtoothOnlineAggregatorTest.scala
@@ -143,7 +143,7 @@ class SawtoothOnlineAggregatorTest extends TestCase {
         operation = Operation.HISTOGRAM,
         inputColumn = "action",
         windows = Seq(
-          new Window(3, TimeUnit.DAYS),
+          new Window(3, TimeUnit.DAYS)
         )
       )
     )
@@ -162,15 +162,15 @@ class SawtoothOnlineAggregatorTest extends TestCase {
 
     val finalBatchIr = FinalBatchIr(
       Array[Any](
-        null,                       // collapsed (T-1 -> T)
+        null // collapsed (T-1 -> T)
       ),
       Array(
-        Array.empty,                // 1‑day hops (not used)
-        Array(                      // 1-hour hops
-          hop(1, 1746745200000L),   // 2025-05-08 23:00:00 UTC
-          hop(1, 1746766800000L),   // 2025-05-09 05:00:00 UTC
+        Array.empty, // 1‑day hops (not used)
+        Array( // 1-hour hops
+              hop(1, 1746745200000L), // 2025-05-08 23:00:00 UTC
+              hop(1, 1746766800000L) // 2025-05-09 05:00:00 UTC
         ),
-        Array.empty                  // 5‑minute hops (not used)
+        Array.empty // 5‑minute hops (not used)
       )
     )
     val queryTs = batchEndTs + 100

--- a/api/src/main/scala-2.11/scala/util/ScalaVersionSpecificCollectionsConverter.scala
+++ b/api/src/main/scala-2.11/scala/util/ScalaVersionSpecificCollectionsConverter.scala
@@ -1,6 +1,7 @@
 package scala.util
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.parallel.ParSeq
 
 object ScalaVersionSpecificCollectionsConverter {
@@ -71,6 +72,14 @@ object ScalaJavaConversions {
         null
       } else {
         map.asScala.toMap
+      }
+    }
+
+    def toScalaMutable: mutable.Map[K, V] = {
+      if (map == null) {
+        null
+      } else {
+        map.asScala
       }
     }
   }

--- a/api/src/main/scala-2.12/scala/util/ScalaVersionSpecificCollectionsConverter.scala
+++ b/api/src/main/scala-2.12/scala/util/ScalaVersionSpecificCollectionsConverter.scala
@@ -1,7 +1,5 @@
 package scala.util
 
-import java.util
-import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.collection.parallel.ParSeq
 import scala.jdk.CollectionConverters._
@@ -74,6 +72,14 @@ object ScalaJavaConversions {
         null
       } else {
         map.asScala.toMap
+      }
+    }
+
+    def toScalaMutable: mutable.Map[K, V] = {
+      if (map == null) {
+        null
+      } else {
+        map.asScala
       }
     }
   }

--- a/api/src/main/scala-2.13/scala/util/ScalaVersionSpecificCollectionsConverter.scala
+++ b/api/src/main/scala-2.13/scala/util/ScalaVersionSpecificCollectionsConverter.scala
@@ -16,6 +16,7 @@
 
 package scala.util
 
+import scala.collection.mutable
 import scala.collection.parallel.CollectionConverters.IterableIsParallelizable
 import scala.collection.parallel.ParSeq
 import scala.jdk.CollectionConverters._
@@ -88,6 +89,14 @@ object ScalaJavaConversions {
         null
       } else {
         map.asScala.toMap
+      }
+    }
+
+    def toScalaMutable: mutable.Map[K, V] = {
+      if (map == null) {
+        null
+      } else {
+        map.asScala
       }
     }
   }

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -30,7 +30,6 @@ import java.util.regex.Pattern
 import scala.collection.{Seq, mutable}
 import scala.util.ScalaJavaConversions.{IteratorOps, ListOps, MapOps}
 import scala.util.{Failure, Success, Try}
-import scala.collection.JavaConverters._
 
 object Extensions {
 

--- a/api/src/main/scala/ai/chronon/api/Row.scala
+++ b/api/src/main/scala/ai/chronon/api/Row.scala
@@ -17,8 +17,8 @@
 package ai.chronon.api
 
 import java.util
-import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.collection.mutable
+import scala.util.ScalaJavaConversions.IteratorOps
 
 trait Row {
   def get(index: Int): Any
@@ -157,7 +157,7 @@ object Row {
             composer(
               list
                 .iterator()
-                .asScala
+                .toScala
                 .zipWithIndex
                 .map { case (value, idx) => edit(value, fields(idx).fieldType, getFieldSchema(fields(idx))) },
               dataType,
@@ -177,7 +177,7 @@ object Row {
         value match {
           case list: util.ArrayList[Any] =>
             collector(
-              list.iterator().asScala.map(edit(_, elemType, schemaTraverser.map(_.getCollectionType))),
+              list.iterator().toScala.map(edit(_, elemType, schemaTraverser.map(_.getCollectionType))),
               list.size()
             )
           case arr: Array[_] => // avro only recognizes arrayList for its ArrayType/ListType
@@ -198,7 +198,7 @@ object Row {
             map
               .entrySet()
               .iterator()
-              .asScala
+              .toScala
               .foreach { entry =>
                 newMap.put(
                   edit(

--- a/flink/src/main/scala/ai/chronon/flink/AvroCodecFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/AvroCodecFn.scala
@@ -11,7 +11,7 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Counter
 import org.apache.flink.util.Collector
 
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.ListOps
 
 /**
   * Base class for the Avro conversion Flink operator.
@@ -63,7 +63,7 @@ sealed abstract class BaseAvroCodecFn[IN, OUT] extends RichFlatMapFunction[IN, O
   }
 
   private lazy val getKVColumns: (Array[String], Array[String]) = {
-    val keyColumns = groupByServingInfoParsed.groupBy.keyColumns.asScala.toArray
+    val keyColumns = groupByServingInfoParsed.groupBy.keyColumns.toScala.toArray
     val (additionalColumns, _) = groupByServingInfoParsed.groupBy.dataModel match {
       case DataModel.Events =>
         Seq.empty[String] -> timeColumn

--- a/flink/src/main/scala/ai/chronon/flink/SparkExpressionEvalFn.scala
+++ b/flink/src/main/scala/ai/chronon/flink/SparkExpressionEvalFn.scala
@@ -15,7 +15,7 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper
 import org.apache.spark.sql.types.StructType
 
-import scala.jdk.CollectionConverters.{asScalaBufferConverter, mapAsScalaMapConverter}
+import scala.util.ScalaJavaConversions.{ListOps, MapOps}
 
 /**
   * A Flink function that uses Chronon's CatalystUtil to evaluate the Spark SQL expression in a GroupBy.
@@ -35,8 +35,8 @@ class SparkExpressionEvalFn[T](encoder: Encoder[T], groupBy: GroupBy) extends Ri
   private val timeColumnAlias: String = Constants.TimeColumn
   private val timeColumn: String = Option(query.timeColumn).getOrElse(timeColumnAlias)
   private val transforms: Seq[(String, String)] =
-    (query.selects.asScala ++ Map(timeColumnAlias -> timeColumn)).toSeq
-  private val filters: Seq[String] = query.getWheres.asScala
+    (query.selects.toScala ++ Map(timeColumnAlias -> timeColumn)).toSeq
+  private val filters: Seq[String] = query.getWheres.toScala
 
   @transient private var catalystUtil: CatalystUtil = _
   @transient private var rowSerializer: ExpressionEncoder.Serializer[T] = _

--- a/flink/src/main/scala/ai/chronon/flink/window/KeySelector.scala
+++ b/flink/src/main/scala/ai/chronon/flink/window/KeySelector.scala
@@ -2,7 +2,7 @@ package ai.chronon.flink.window
 
 import ai.chronon.api.GroupBy
 
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.ListOps
 import org.slf4j.LoggerFactory
 
 /**
@@ -24,7 +24,7 @@ object KeySelector {
   def getKeySelectionFunction(groupBy: GroupBy): Map[String, Any] => List[Any] = {
     // List uses MurmurHash.seqHash for its .hashCode(), which gives us hashing based on content.
     // (instead of based on the instance, which is the case for Array).
-    val groupByKeys: List[String] = groupBy.keyColumns.asScala.toList
+    val groupByKeys: List[String] = groupBy.keyColumns.toScala.toList
     logger.info(
       f"Creating key selection function for Flink app. groupByKeys=$groupByKeys"
     )

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobIntegrationTest.scala
@@ -13,7 +13,7 @@ import org.junit.{After, Before, Test}
 import org.mockito.Mockito.withSettings
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-import scala.jdk.CollectionConverters.asScalaBufferConverter
+import scala.util.ScalaJavaConversions.ListOps
 
 class FlinkJobIntegrationTest {
 
@@ -34,7 +34,7 @@ class FlinkJobIntegrationTest {
 
     // Get all keys we expect to be in the GenericRecord
     val decodedKeys: List[String] =
-      groupByServingInfoParsed.groupBy.keyColumns.asScala.map(record.get(_).toString).toList
+      groupByServingInfoParsed.groupBy.keyColumns.toScala.map(record.get(_).toString).toList
 
     val tsMills = in.tsMillis.get
     TimestampedTile(decodedKeys, tileBytes, tsMills)
@@ -86,7 +86,7 @@ class FlinkJobIntegrationTest {
     env.execute("FlinkJobIntegrationTest")
 
     // capture the datastream of the 'created' timestamps of all the written out events
-    val writeEventCreatedDS = CollectSink.values.asScala
+    val writeEventCreatedDS = CollectSink.values.toScala
 
     assert(writeEventCreatedDS.size == elements.size)
     // check that the timestamps of the written out events match the input events
@@ -124,7 +124,7 @@ class FlinkJobIntegrationTest {
     env.execute("TiledFlinkJobIntegrationTest")
 
     // capture the datastream of the 'created' timestamps of all the written out events
-    val writeEventCreatedDS = CollectSink.values.asScala
+    val writeEventCreatedDS = CollectSink.values.toScala
 
     // BASIC ASSERTIONS
     // All elements were processed

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkTestUtils.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkTestUtils.scala
@@ -20,7 +20,7 @@ import java.time.Duration
 import java.util
 import java.util.Collections
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.jdk.CollectionConverters.asScalaBufferConverter
+import scala.util.ScalaJavaConversions.ListOps
 
 case class E2ETestEvent(id: String, int_val: Int, double_val: Double, created: Long)
 
@@ -82,7 +82,7 @@ object FlinkTestUtils {
     // Set key avro schema for groupByServingInfo
     groupByServingInfo.setKeyAvroSchema(
       StructType(
-        groupBy.keyColumns.asScala.map { keyCol =>
+        groupBy.keyColumns.toScala.map { keyCol =>
           val keyColStructType = outputSchema.fields.find(field => field.name == keyCol)
           keyColStructType match {
             case Some(col) => col
@@ -95,7 +95,7 @@ object FlinkTestUtils {
     )
 
     // Set value avro schema for groupByServingInfo
-    val aggInputColNames = groupBy.aggregations.asScala.map(_.inputColumn).toList
+    val aggInputColNames = groupBy.aggregations.toScala.map(_.inputColumn).toList
     groupByServingInfo.setSelectedAvroSchema(
       StructType(outputSchema.fields.filter(field => aggInputColNames.contains(field.name)))
         .toAvroSchema("Value")

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -27,7 +27,7 @@ import java.util.function.Consumer
 import scala.collection.Seq
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.ListOps
 import scala.util.{Failure, Success, Try}
 
 object KVStore {
@@ -285,6 +285,6 @@ abstract class Api(userConf: Map[String, String]) extends Serializable {
     }
     joinOps
       .map(_.join)
-      .foreach(join => externalRegistry.addHandlersByFactory(Option(join.getOnlineExternalParts).map(_.asScala.toSeq)))
+      .foreach(join => externalRegistry.addHandlersByFactory(Option(join.getOnlineExternalParts).map(_.toScala.toSeq)))
   }
 }

--- a/online/src/main/scala/ai/chronon/online/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/AvroConversions.scala
@@ -24,8 +24,8 @@ import org.apache.avro.util.Utf8
 
 import java.nio.ByteBuffer
 import java.util
-import scala.collection.JavaConverters._
 import scala.collection.{AbstractIterator, mutable}
+import scala.util.ScalaJavaConversions.{JListOps, ListOps}
 
 object AvroConversions {
 
@@ -43,7 +43,7 @@ object AvroConversions {
     schema.getType match {
       case Schema.Type.RECORD =>
         StructType(schema.getName,
-                   schema.getFields.asScala.toArray.map { field =>
+                   schema.getFields.toScala.toArray.map { field =>
                      StructField(field.name(), toChrononSchema(field.schema()))
                    })
       case Schema.Type.ARRAY   => ListType(toChrononSchema(schema.getElementType))
@@ -92,7 +92,7 @@ object AvroConversions {
                 defaultValue)
             }
             .toList
-            .asJava
+            .toJava
         )
       case ListType(elementType) => Schema.createArray(fromChrononSchema(elementType, nameSet))
       case MapType(keyType, valueType) => {

--- a/online/src/main/scala/ai/chronon/online/ExternalSourceRegistry.scala
+++ b/online/src/main/scala/ai/chronon/online/ExternalSourceRegistry.scala
@@ -22,7 +22,7 @@ import ai.chronon.online.Fetcher.{Request, Response}
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.{Seq, mutable}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.MapOps
 import scala.util.{Failure, Success}
 
 // users can simply register external endpoints with a lambda that can return the future of a response given keys
@@ -37,13 +37,13 @@ class ExternalSourceRegistry extends Serializable {
   }
 
   val handlerMap: mutable.Map[String, ExternalSourceHandler] = {
-    val result = new ConcurrentHashMap[String, ExternalSourceHandler]().asScala
+    val result = new ConcurrentHashMap[String, ExternalSourceHandler]().toScalaMutable
     result.put(Constants.ContextualSourceName, new ContextualHandler())
     result
   }
 
   val handlerFactoryMap: mutable.Map[String, ExternalSourceFactory] = {
-    val result = new ConcurrentHashMap[String, ExternalSourceFactory]().asScala
+    val result = new ConcurrentHashMap[String, ExternalSourceFactory]().toScalaMutable
     result
   }
 

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -20,7 +20,7 @@ import ai.chronon.aggregator.row.ColumnAggregator
 import ai.chronon.aggregator.windowing
 import ai.chronon.aggregator.windowing.{FinalBatchIr, SawtoothOnlineAggregator, TiledIr}
 import ai.chronon.api.Constants.ChrononMetadataKey
-import ai.chronon.api.Extensions.{GroupByOps, JoinOps, MetadataOps, WindowOps, ThrowableOps}
+import ai.chronon.api.Extensions.{GroupByOps, JoinOps, MetadataOps, ThrowableOps, WindowOps}
 import ai.chronon.api._
 import ai.chronon.online.Fetcher.{ColumnSpec, PrefixedRequest, Request, Response}
 import ai.chronon.online.FetcherCache.{BatchResponses, CachedBatchResponse, KvStoreBatchResponse}
@@ -30,9 +30,9 @@ import ai.chronon.online.DerivationUtils.{applyDeriveFunc, buildRenameOnlyDeriva
 import com.google.gson.Gson
 
 import java.util
-import scala.collection.JavaConverters._
 import scala.collection.Seq
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.ScalaJavaConversions.{IteratorOps, JMapOps}
 import scala.util.{Failure, Success, Try}
 
 // Does internal facing fetching
@@ -155,7 +155,7 @@ class FetcherBase(kvStore: KVStore,
                   .map(_.isSet(
                     "disable_streaming_decoding_error_throws",
                     Map(
-                      "groupby_streaming_dataset" -> servingInfo.groupByServingInfo.groupBy.getMetaData.getName).asJava))
+                      "groupby_streaming_dataset" -> servingInfo.groupByServingInfo.groupBy.getMetaData.getName).toJava))
                 if (groupByFlag.getOrElse(disableErrorThrows)) {
                   Array.empty[TiledIr]
                 } else {
@@ -203,7 +203,7 @@ class FetcherBase(kvStore: KVStore,
                   .map(_.isSet(
                     "disable_streaming_decoding_error_throws",
                     Map(
-                      "groupby_streaming_dataset" -> servingInfo.groupByServingInfo.groupBy.getMetaData.getName).asJava))
+                      "groupby_streaming_dataset" -> servingInfo.groupByServingInfo.groupBy.getMetaData.getName).toJava))
                 if (groupByFlag.getOrElse(disableErrorThrows)) {
                   Seq.empty[Row]
                 } else {
@@ -330,7 +330,7 @@ class FetcherBase(kvStore: KVStore,
       Option(flagStore)
         .exists(
           _.isSet("enable_fetcher_batch_ir_cache",
-                  Map("groupby_streaming_dataset" -> groupBy.getMetaData.getName).asJava))
+                  Map("groupby_streaming_dataset" -> groupBy.getMetaData.getName).toJava))
 
     if (debug)
       logger.info(
@@ -342,7 +342,7 @@ class FetcherBase(kvStore: KVStore,
   // If the flag is set, we check whether the entity is in the active entity list saved on k-v store
   def isEntityValidityCheckEnabled: Boolean = {
     Option(flagStore)
-      .exists(_.isSet("enable_entity_validity_check", Map.empty[String, String].asJava))
+      .exists(_.isSet("enable_entity_validity_check", Map.empty[String, String].toJava))
   }
 
   // 1. fetches GroupByServingInfo
@@ -576,11 +576,11 @@ class FetcherBase(kvStore: KVStore,
     val tailHops = batchRecord(1)
       .asInstanceOf[util.ArrayList[Any]]
       .iterator()
-      .asScala
+      .toScala
       .map(
         _.asInstanceOf[util.ArrayList[Any]]
           .iterator()
-          .asScala
+          .toScala
           .map(hop => gbInfo.aggregator.baseAggregator.denormalizeInPlace(hop.asInstanceOf[Array[Any]]))
           .toArray)
       .toArray

--- a/online/src/main/scala/ai/chronon/online/FetcherCache.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherCache.scala
@@ -17,8 +17,6 @@ import ai.chronon.online.KVStore.{GetRequest, TimedValue}
 import com.github.benmanes.caffeine.cache.{Cache => CaffeineCache}
 
 import scala.util.{Success, Try}
-import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
 import scala.collection.Seq
 import org.slf4j.{Logger, LoggerFactory}
 

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -16,16 +16,15 @@
 
 package ai.chronon.online
 
-import ai.chronon.aggregator.row.RowAggregator
 import ai.chronon.aggregator.windowing.SawtoothOnlineAggregator
 import ai.chronon.api.Constants.{ReversalField, TimeField}
 import ai.chronon.api.Extensions.{GroupByOps, MetadataOps}
 import ai.chronon.api._
 import org.apache.avro.Schema
-import org.apache.spark.sql.SparkSession
-import scala.collection.JavaConverters.asScalaBufferConverter
 
 import ai.chronon.online.DerivationUtils.{DerivationFunc, buildDerivationFunction, buildDerivedFields, timeFields}
+
+import scala.util.ScalaJavaConversions.ListOps
 
 // mixin class - with schema
 class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo, partitionSpec: PartitionSpec)
@@ -41,7 +40,7 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo, parti
 
   lazy val aggregator: SawtoothOnlineAggregator = {
     new SawtoothOnlineAggregator(batchEndTsMillis,
-                                 groupByServingInfo.groupBy.aggregations.asScala.toSeq,
+                                 groupByServingInfo.groupBy.aggregations.toScala.toSeq,
                                  valueChrononSchema.fields.map(sf => (sf.name, sf.fieldType)))
   }
 

--- a/online/src/main/scala/ai/chronon/online/TileCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/TileCodec.scala
@@ -21,7 +21,6 @@ import ai.chronon.api.{BooleanType, DataType, GroupBy, StructType}
 import org.apache.avro.generic.GenericData
 import ai.chronon.api.Extensions.{AggregationOps, MetadataOps, WindowUtils}
 
-import scala.collection.JavaConverters._
 import scala.util.ScalaJavaConversions.ListOps
 
 object TileCodec {
@@ -30,7 +29,7 @@ object TileCodec {
     // feature column aggregations to be computed. We don't include windows in this
     // to keep the aggregation work & payload size small as the multiple windows for a given
     // counter are identical value wise within a tile (e.g. sum_1d and sum_7d are the same in a tile)
-    val unpackedAggs = groupBy.aggregations.asScala.flatMap(_.unWindowed)
+    val unpackedAggs = groupBy.aggregations.toScala.flatMap(_.unWindowed)
     new RowAggregator(inputSchema, unpackedAggs)
   }
 
@@ -39,7 +38,7 @@ object TileCodec {
     // feature column aggregations to be computed. This version includes windows in the feature
     // columns to get the full cross product (buckets * windows) as this is useful in unit tests to compare
     // the final results
-    val unpackedAggs = groupBy.aggregations.asScala.flatMap(_.unpack)
+    val unpackedAggs = groupBy.aggregations.toScala.flatMap(_.unpack)
     new RowAggregator(inputSchema, unpackedAggs)
   }
 }
@@ -95,7 +94,7 @@ class TileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
     val flattenedIr = windowedRowAggregator.init
     var irPos = 0
     var bucketPos = 0
-    groupBy.aggregations.asScala.foreach { aggr =>
+    groupBy.aggregations.toScala.foreach { aggr =>
       val buckets = Option(aggr.buckets)
         .map(_.toScala)
         .getOrElse(Seq(null))

--- a/online/src/test/scala/ai/chronon/online/FetcherCacheTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherCacheTest.scala
@@ -16,7 +16,7 @@ import org.mockito.Mockito
 import org.mockito.stubbing.Stubber
 import org.scalatestplus.mockito.MockitoSugar
 
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.JMapOps
 import scala.util.{Failure, Success, Try}
 
 trait MockitoHelper extends MockitoSugar {
@@ -47,7 +47,7 @@ class FetcherCacheTest extends MockitoHelper {
     // Create a bunch of test batchIrs and store them in cache
     val batchIrs: Map[BatchIrCache.Key, BatchIrCache.Value] =
       (0 until batchIrCacheMaximumSize).map(i => createCacheKey(i) -> createBatchir(i)).toMap
-    batchIrCache.cache.putAll(batchIrs.asJava)
+    batchIrCache.cache.putAll(batchIrs.toJava)
 
     // Check that the cache contains all the batchIrs we created
     batchIrs.foreach(entry => {
@@ -70,7 +70,7 @@ class FetcherCacheTest extends MockitoHelper {
     // Create a bunch of test mapResponses and store them in cache
     val mapResponses: Map[BatchIrCache.Key, BatchIrCache.Value] =
       (0 until batchIrCacheMaximumSize).map(i => createCacheKey(i) -> createMapResponse(i)).toMap
-    batchIrCache.cache.putAll(mapResponses.asJava)
+    batchIrCache.cache.putAll(mapResponses.toJava)
 
     // Check that the cache contains all the mapResponses we created
     mapResponses.foreach(entry => {

--- a/online/src/test/scala/ai/chronon/online/LRUCacheTest.scala
+++ b/online/src/test/scala/ai/chronon/online/LRUCacheTest.scala
@@ -4,8 +4,6 @@ import org.junit.Test
 import com.github.benmanes.caffeine.cache.{Cache => CaffeineCache}
 import ai.chronon.online.LRUCache
 
-import scala.collection.JavaConverters._
-
 class LRUCacheTest {
   val testCache: CaffeineCache[String, String] = LRUCache[String, String]("testCache")
 

--- a/online/src/test/scala/ai/chronon/online/TileCodecTest.scala
+++ b/online/src/test/scala/ai/chronon/online/TileCodecTest.scala
@@ -33,11 +33,11 @@ import ai.chronon.api.{
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.{JListOps, JMapOps}
 
 class TileCodecTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
-  private val histogram = Map[String, Int]("A" -> 3, "B" -> 2).asJava
+  private val histogram = Map[String, Int]("A" -> 3, "B" -> 2).toJava
 
   private val aggregationsAndExpected: Array[(Aggregation, Seq[Any])] = Array(
     Builders.Aggregation(Operation.AVERAGE, "views", Seq(new Window(1, TimeUnit.DAYS))) -> Seq(16.0),
@@ -54,11 +54,11 @@ class TileCodecTest {
     Builders.Aggregation(Operation.LAST_K,
                          "title",
                          Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS)),
-                         argMap = Map("k" -> "2")) -> Seq(List("C", "B").asJava, List("C", "B").asJava),
+                         argMap = Map("k" -> "2")) -> Seq(List("C", "B").toJava, List("C", "B").toJava),
     Builders.Aggregation(Operation.TOP_K,
                          "title",
                          Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS)),
-                         argMap = Map("k" -> "1")) -> Seq(List("C").asJava, List("C").asJava),
+                         argMap = Map("k" -> "1")) -> Seq(List("C").toJava, List("C").toJava),
     Builders.Aggregation(Operation.MIN,
                          "title",
                          Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))) -> Seq("A", "A"),
@@ -79,7 +79,7 @@ class TileCodecTest {
       windows = Seq(new Window(1, TimeUnit.DAYS), new Window(7, TimeUnit.DAYS))
     )
   )
-  private val expectedBucketResult = Map("A" -> 4.0, "B" -> 40.0, "C" -> 4.0).asJava
+  private val expectedBucketResult = Map("A" -> 4.0, "B" -> 40.0, "C" -> 4.0).toJava
   private val expectedBucketedResults = Seq(expectedBucketResult, expectedBucketResult)
 
   private val schema = List(

--- a/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
@@ -23,7 +23,7 @@ import org.junit.Assert.{assertArrayEquals, assertEquals, assertTrue}
 import org.junit.Test
 
 import java.util
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.ListOps
 
 trait CatalystUtilTestSparkSQLStructs {
 
@@ -661,6 +661,6 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     assertEquals(3, result.get.size)
     assertEquals(1000L, result.get("ts"))
     assertEquals("test_key_1", result.get("key"))
-    assertArrayEquals(Array(1L, 2L), result.get("ids").asInstanceOf[java.util.List[Long]].asScala.toArray)
+    assertArrayEquals(Array(1L, 2L), result.get("ids").asInstanceOf[java.util.List[Long]].toScala.toArray)
   }
 }

--- a/online/src/test/scala/ai/chronon/online/test/ExternalSourceFactoryTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/ExternalSourceFactoryTest.scala
@@ -18,7 +18,18 @@ package ai.chronon.online.test
 
 import ai.chronon.api.Extensions.JoinOps
 import ai.chronon.api.{ExternalPart, ExternalSource, ExternalSourceFactoryConfig, Join, MetaData}
-import ai.chronon.online.{Api, ExternalSourceFactory, ExternalSourceHandler, ExternalSourceRegistry, Fetcher, GroupByServingInfoParsed, KVStore, LoggableResponse, StreamDecoder, TTLCache}
+import ai.chronon.online.{
+  Api,
+  ExternalSourceFactory,
+  ExternalSourceHandler,
+  ExternalSourceRegistry,
+  Fetcher,
+  GroupByServingInfoParsed,
+  KVStore,
+  LoggableResponse,
+  StreamDecoder,
+  TTLCache
+}
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 import org.mockito.Mockito.{mock, when}
@@ -28,83 +39,86 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 class ExternalSourceFactoryTest {
-  
+
   // Mock implementations for testing
   class MockExternalSourceFactory extends ExternalSourceFactory {
     override def createExternalSourceHandler(externalSource: ExternalSource): ExternalSourceHandler = {
       new ExternalSourceHandler {
-        override def fetch(requests: scala.collection.Seq[Fetcher.Request]): concurrent.Future[scala.collection.Seq[Fetcher.Response]] = {
+        override def fetch(requests: scala.collection.Seq[Fetcher.Request])
+            : concurrent.Future[scala.collection.Seq[Fetcher.Response]] = {
           concurrent.Future.successful(Seq.empty)
         }
       }
     }
   }
-  
+
   class TestApi(userConf: Map[String, String]) extends Api(userConf) {
     private val mockKvStore = mock(classOf[KVStore])
     private val testRegistry = new ExternalSourceRegistry()
-    
+
     // Map to store mock join configurations for testing
     private var mockJoinConfigs = Map.empty[String, JoinOps]
     private var joinConfigExceptions = Map.empty[String, Exception]
-    
+
     // Add a test factory to the registry
     testRegistry.addFactory("test-factory", new MockExternalSourceFactory())
-    
+
     override def streamDecoder(groupByServingInfoParsed: GroupByServingInfoParsed): StreamDecoder = {
       mock(classOf[StreamDecoder])
     }
-    
+
     override def genKvStore: KVStore = mockKvStore
-    
+
     override def externalRegistry: ExternalSourceRegistry = testRegistry
-    
+
     override def logResponse(resp: LoggableResponse): Unit = {}
-    
+
     // Override fetcher to return a mock that's initialized on-demand
     override lazy val fetcher: Fetcher = {
       val mockFetcher = mock(classOf[Fetcher])
-      
+
       // Create a mock TTLCache for getJoinConf
       val mockTTLCache = mock(classOf[TTLCache[String, Try[JoinOps]]])
-      
+
       // Set up mock behaviors for successful configs
-      mockJoinConfigs.foreach { case (joinName, joinOps) =>
-        when(mockTTLCache.apply(joinName)).thenReturn(Success(joinOps))
+      mockJoinConfigs.foreach {
+        case (joinName, joinOps) =>
+          when(mockTTLCache.apply(joinName)).thenReturn(Success(joinOps))
       }
-      
+
       // Set up mock behaviors for failed configs
-      joinConfigExceptions.foreach { case (joinName, exception) =>
-        when(mockTTLCache.apply(joinName)).thenReturn(Failure(exception))
+      joinConfigExceptions.foreach {
+        case (joinName, exception) =>
+          when(mockTTLCache.apply(joinName)).thenReturn(Failure(exception))
       }
-      
+
       // Wire the TTLCache to the fetcher
       when(mockFetcher.getJoinConf).thenReturn(mockTTLCache)
       mockFetcher
     }
-    
+
     // Helper method to set up mock join configurations for testing
     def setMockJoinConfig(joinName: String, joinOps: JoinOps): Unit = {
       mockJoinConfigs = mockJoinConfigs + (joinName -> joinOps)
       // The mock behavior will be set up when the fetcher lazy val is accessed
     }
-    
+
     // Helper method to simulate join config loading failure
     def setJoinConfigException(joinName: String, exception: Exception): Unit = {
       joinConfigExceptions = joinConfigExceptions + (joinName -> exception)
       // The mock behavior will be set up when the fetcher lazy val is accessed
     }
   }
-  
+
   private def createMockJoin(joinName: String, externalSourceName: String, factoryName: String = null): Join = {
     val join = mock(classOf[Join])
     val externalPart = mock(classOf[ExternalPart])
     val externalSource = mock(classOf[ExternalSource])
     val metadata = mock(classOf[MetaData])
-    
+
     when(metadata.getName).thenReturn(externalSourceName)
     when(externalSource.getMetadata).thenReturn(metadata)
-    
+
     // Handle factory configuration mocking based on factoryName
     if (factoryName == null) {
       // No factory configuration
@@ -117,13 +131,13 @@ class ExternalSourceFactoryTest {
       when(factoryConfig.getFactoryParams).thenReturn(factoryParams)
       when(externalSource.getFactoryConfig).thenReturn(factoryConfig)
     }
-    
+
     when(externalPart.getSource).thenReturn(externalSource)
     when(join.getOnlineExternalParts).thenReturn(Seq(externalPart).asJava)
-    
+
     join
   }
-  
+
   private def createMockJoinOps(join: Join): JoinOps = {
     val joinOps = mock(classOf[JoinOps])
     when(joinOps.join).thenReturn(join)
@@ -133,85 +147,82 @@ class ExternalSourceFactoryTest {
   @Test
   def testRegisterExternalSourcesWithValidFactory(): Unit = {
     val api = new TestApi(Map.empty)
-    
+
     // Create mock join with factory configuration
     val join = createMockJoin("test-join", "test-source", "test-factory")
     val joinOps = createMockJoinOps(join)
-    
+
     // Set up mock join config
     api.setMockJoinConfig("test-join", joinOps)
-    
+
     // Execute the method
     api.registerJoinExternalSources(Seq("test-join"))
-    
+
     // Verify that the handler was registered
-    assertTrue("Handler should be registered", 
-      api.externalRegistry.handlerMap.contains("test-source"))
+    assertTrue("Handler should be registered", api.externalRegistry.handlerMap.contains("test-source"))
   }
 
   @Test
   def testRegisterExternalSourcesWithMissingFactory(): Unit = {
     val api = new TestApi(Map.empty)
-    
+
     // Create mock join with non-existent factory
     val join = createMockJoin("test-join", "test-source", "non-existent-factory")
     val joinOps = createMockJoinOps(join)
-    
+
     // Set up mock join config
     api.setMockJoinConfig("test-join", joinOps)
-    
+
     // Execute and expect exception
     val exception = intercept[IllegalArgumentException] {
       api.registerJoinExternalSources(Seq("test-join"))
     }
-    
-    assertTrue("Exception should mention missing factory", 
-      exception.getMessage.contains("Factory 'non-existent-factory' is not registered"))
-    assertTrue("Exception should list available factories", 
-      exception.getMessage.contains("Available factories: [test-factory]"))
+
+    assertTrue("Exception should mention missing factory",
+               exception.getMessage.contains("Factory 'non-existent-factory' is not registered"))
+    assertTrue("Exception should list available factories",
+               exception.getMessage.contains("Available factories: [test-factory]"))
   }
 
   @Test
   def testRegisterExternalSourcesWithFailedJoinConfig(): Unit = {
     val api = new TestApi(Map.empty)
-    
+
     val originalException = new RuntimeException("Join config not found")
-    
+
     // Set up exception to be thrown by fetcher.getJoinConf
     api.setJoinConfigException("test-join", originalException)
-    
+
     // Execute and expect exception
     val thrownException = intercept[RuntimeException] {
       api.registerJoinExternalSources(Seq("test-join"))
     }
-    
-    assertEquals("Exception should wrap original exception", 
-      originalException, thrownException.getCause)
-    assertTrue("Exception message should mention failed join config", 
-      thrownException.getMessage.contains("Failed to load join configuration for 'test-join'"))
+
+    assertEquals("Exception should wrap original exception", originalException, thrownException.getCause)
+    assertTrue("Exception message should mention failed join config",
+               thrownException.getMessage.contains("Failed to load join configuration for 'test-join'"))
   }
 
   @Test
   def testRegisterExternalSourcesWithNoExternalParts(): Unit = {
     val api = new TestApi(Map.empty)
-    
+
     // Record initial handler count (includes default contextual handler)
     val initialHandlerCount = api.externalRegistry.handlerMap.size
-    
+
     // Create mock join without external parts
     val join = mock(classOf[Join])
     when(join.getOnlineExternalParts).thenReturn(null)
     val joinOps = createMockJoinOps(join)
-    
+
     // Set up mock join config
     api.setMockJoinConfig("test-join", joinOps)
-    
+
     // Execute the method - should not throw exception
     api.registerJoinExternalSources(Seq("test-join"))
-    
+
     // Should complete successfully without registering any new handlers
-    assertEquals("No new handlers should be registered", 
-      initialHandlerCount, api.externalRegistry.handlerMap.size)
+    assertEquals("No new handlers should be registered", initialHandlerCount, api.externalRegistry.handlerMap.size)
   }
 
   @Test
@@ -240,7 +251,6 @@ class ExternalSourceFactoryTest {
       api.registerJoinExternalSources(Seq("test-join"))
     }
 
-    assertTrue("Exception should mention null factoryName",
-      exception.getMessage.contains("factoryName is null"))
+    assertTrue("Exception should mention null factoryName", exception.getMessage.contains("factoryName is null"))
   }
 }

--- a/online/src/test/scala/ai/chronon/online/test/ExternalSourceFactoryTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/ExternalSourceFactoryTest.scala
@@ -35,7 +35,7 @@ import org.junit.Test
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.Assertions.intercept
 
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.JListOps
 import scala.util.{Failure, Success, Try}
 
 class ExternalSourceFactoryTest {
@@ -133,7 +133,7 @@ class ExternalSourceFactoryTest {
     }
 
     when(externalPart.getSource).thenReturn(externalSource)
-    when(join.getOnlineExternalParts).thenReturn(Seq(externalPart).asJava)
+    when(join.getOnlineExternalParts).thenReturn(Seq(externalPart).toJava)
 
     join
   }
@@ -241,7 +241,7 @@ class ExternalSourceFactoryTest {
     when(externalSource.getFactoryConfig).thenReturn(factoryConfig)
     when(factoryConfig.getFactoryName).thenReturn(null) // null factory name
     when(externalPart.getSource).thenReturn(externalSource)
-    when(join.getOnlineExternalParts).thenReturn(Seq(externalPart).asJava)
+    when(join.getOnlineExternalParts).thenReturn(Seq(externalPart).toJava)
 
     val joinOps = createMockJoinOps(join)
     api.setMockJoinConfig("test-join", joinOps)

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -21,7 +21,7 @@ import ai.chronon.api.Extensions.QueryOps
 import ai.chronon.api.{Constants, Query, QueryUtils}
 import org.apache.spark.sql.DataFrame
 
-import scala.collection.JavaConverters._
+import scala.util.ScalaJavaConversions.ListOps
 
 sealed trait DataRange {
   def toTimePoints: Array[Long]
@@ -152,7 +152,7 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
     }
     val wheres =
       whereClauses(partitionCol) ++ queryOpt
-        .flatMap(q => Option(q.wheres).map(_.asScala))
+        .flatMap(q => Option(q.wheres).map(_.toScala))
         .getOrElse(Seq.empty[String])
     QueryUtils.build(selects = queryOpt.map(_.getQuerySelects).orNull,
                      from = table,

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -42,13 +42,13 @@ import org.slf4j.LoggerFactory
 import java.io.{File, IOException}
 import java.net.URI
 import java.nio.file.{Files, Paths}
-import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.io.Source
 import scala.reflect.ClassTag
 import scala.reflect.internal.util.ScalaClassLoader
+import scala.util.ScalaJavaConversions.{ListOps, MapOps}
 import scala.util.{Failure, Success, Try}
 
 // useful to override spark.sql.extensions args - there is no good way to unset that conf apparently
@@ -799,13 +799,13 @@ object Driver {
       require(!args.confPath.isEmpty || !args.name.isEmpty, "--conf-path or --name should be specified!")
       val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
       def readMap: String => Map[String, AnyRef] = { json =>
-        objectMapper.readValue(json, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
+        objectMapper.readValue(json, classOf[java.util.Map[String, AnyRef]]).toScala.toMap
       }
       def readMapList: String => Seq[Map[String, AnyRef]] = { jsonList =>
         objectMapper
           .readValue(jsonList, classOf[java.util.List[java.util.Map[String, AnyRef]]])
-          .asScala
-          .map(_.asScala.toMap)
+          .toScala
+          .map(_.toScala.toMap)
           .toSeq
       }
       val keyMapList =

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -34,7 +34,6 @@ import scala.collection.compat._
 import scala.collection.{Seq, mutable}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
-import scala.jdk.CollectionConverters._
 import scala.util.ScalaJavaConversions.{ListOps, MapOps}
 import scala.util.{Failure, Success, Try}
 
@@ -216,7 +215,7 @@ class Join(joinConf: api.Join,
   }
 
   private def getRightPartsData(leftRange: PartitionRange): Seq[(JoinPart, DataFrame)] = {
-    joinConf.joinParts.asScala.flatMap { joinPart =>
+    joinConf.joinParts.toScala.flatMap { joinPart =>
       val partTable = joinConf.partOutputTable(joinPart)
       if (!tableUtils.tableExists(partTable)) {
         // When a JoinPart is fully bootstrapped, its partTable may not exist and we skip it during final join.
@@ -324,7 +323,7 @@ class Join(joinConf: api.Join,
                   rightCol -> leftBlooms.get(leftCol)
               }.toJMap
 
-              val bloomSizes = rightBlooms.asScala.map {
+              val bloomSizes = rightBlooms.toScala.map {
                 case (rightCol, bloom) =>
                   s"$rightCol -> ${bloom.bitSize()}"
               }

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -32,9 +32,8 @@ import org.slf4j.LoggerFactory
 
 import java.time.Instant
 import java.util
-import scala.collection.JavaConverters._
 import scala.collection.Seq
-import scala.util.ScalaJavaConversions.ListOps
+import scala.util.ScalaJavaConversions.{JMapOps, ListOps, MapOps}
 
 abstract class JoinBase(joinConf: api.Join,
                         endPartition: String,
@@ -57,18 +56,18 @@ abstract class JoinBase(joinConf: api.Join,
 
   // Get table properties from config
   protected val confTableProps: Map[String, String] = Option(joinConf.metaData.tableProperties)
-    .map(_.asScala.toMap)
+    .map(_.toScala.toMap)
     .getOrElse(Map.empty[String, String])
 
   private val gson = new Gson()
   // Combine tableProperties set on conf with encoded Join
   protected val tableProps: Map[String, String] =
     confTableProps ++ Map(
-      Constants.SemanticHashKey -> gson.toJson(joinConf.semanticHash(excludeTopic = true).asJava),
+      Constants.SemanticHashKey -> gson.toJson(joinConf.semanticHash(excludeTopic = true).toJava),
       Constants.SemanticHashOptionsKey -> gson.toJson(
         Map(
           Constants.SemanticHashExcludeTopic -> "true"
-        ).asJava)
+        ).toJava)
     )
 
   def joinWithLeft(leftDf: DataFrame, rightDf: DataFrame, joinPart: JoinPart): DataFrame = {
@@ -474,7 +473,7 @@ abstract class JoinBase(joinConf: api.Join,
     assert(Option(joinConf.metaData.team).nonEmpty,
            s"join.metaData.team needs to be set for join ${joinConf.metaData.name}")
 
-    joinConf.joinParts.asScala.foreach { jp =>
+    joinConf.joinParts.toScala.foreach { jp =>
       assert(Option(jp.groupBy.metaData.team).nonEmpty,
              s"groupBy.metaData.team needs to be set for joinPart ${jp.groupBy.metaData.name}")
     }

--- a/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinUtils.scala
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory
 
 import java.util
 import scala.collection.compat._
-import scala.jdk.CollectionConverters._
+import scala.util.ScalaJavaConversions.ListOps
 
 object JoinUtils {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
@@ -296,11 +296,11 @@ object JoinUtils {
     // make a copy of the original joinPart to avoid accumulating the key filters into the same object
     val joinPart = originalJoinPart.deepCopy()
     // Modifies the joinPart to inject the key filter into the where Clause of GroupBys by hardcoding the keyset
-    val groupByKeyNames = joinPart.groupBy.getKeyColumns.asScala
+    val groupByKeyNames = joinPart.groupBy.getKeyColumns.toScala
 
     val collectedLeft = leftDf.collect()
 
-    joinPart.groupBy.sources.asScala.foreach { source =>
+    joinPart.groupBy.sources.toScala.foreach { source =>
       val selectMap = Option(source.rootQuery.getQuerySelects).getOrElse(Map.empty[String, String])
       val groupByKeyExpressions = groupByKeyNames.map { key =>
         key -> selectMap.getOrElse(key, key)

--- a/spark/src/main/scala/ai/chronon/spark/streaming/TopicChecker.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/TopicChecker.scala
@@ -30,8 +30,8 @@ import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
 
 import java.util
 import java.util.Properties
-import scala.collection.JavaConverters.{asScalaBufferConverter, asScalaIteratorConverter}
 import scala.reflect.ClassTag
+import scala.util.ScalaJavaConversions.{IteratorOps, ListOps}
 import scala.util.Try
 
 object TopicChecker {
@@ -60,7 +60,7 @@ object TopicChecker {
         topicsResult // find closestK matches based on edit distance.
           .entrySet()
           .iterator()
-          .asScala
+          .toScala
           .map { topicListing =>
             val existing = topicListing.getValue.name()
             EditDistance.betweenStrings(existing, topic).total / existing.length.toDouble -> existing
@@ -73,7 +73,7 @@ object TopicChecker {
                                       |
                                       | ------ Most similar topics are ------
                                       |
-                                      |  ${result.asScala.map(_._2).mkString("\n  ")}
+                                      |  ${result.toScala.map(_._2).mkString("\n  ")}
                                       |
                                       | ------ End ------
                                       |""".stripMargin)

--- a/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/AnalyzerTest.scala
@@ -839,14 +839,13 @@ class AnalyzerTest {
     )
 
     // Should throw RuntimeException due to ShortType in schema
-    val analyzer = new Analyzer(
-      tableUtilsWithValidation,
-      tableGroupBy,
-      "2025-09-01",
-      today,
-      enableHitter = false,
-      skipTimestampCheck = true,
-      validateTablePermission = false)
+    val analyzer = new Analyzer(tableUtilsWithValidation,
+                                tableGroupBy,
+                                "2025-09-01",
+                                today,
+                                enableHitter = false,
+                                skipTimestampCheck = true,
+                                validateTablePermission = false)
     analyzer.analyzeGroupBy(tableGroupBy)
   }
 
@@ -899,14 +898,13 @@ class AnalyzerTest {
     )
 
     // Because online is false, this should pass without exception
-    val analyzer = new Analyzer(
-      tableUtilsWithValidation,
-      tableGroupBy,
-      "2025-09-01",
-      today,
-      enableHitter = false,
-      skipTimestampCheck = true,
-      validateTablePermission = false)
+    val analyzer = new Analyzer(tableUtilsWithValidation,
+                                tableGroupBy,
+                                "2025-09-01",
+                                today,
+                                enableHitter = false,
+                                skipTimestampCheck = true,
+                                validateTablePermission = false)
     analyzer.analyzeGroupBy(tableGroupBy)
   }
 

--- a/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetchStatsTest.scala
@@ -36,8 +36,8 @@ import org.apache.spark.sql.SparkSession
 import java.util.TimeZone
 import java.util.concurrent.Executors
 import scala.concurrent.duration.{Duration, SECONDS}
-import scala.collection.JavaConverters._
 import scala.concurrent.{Await, ExecutionContext}
+import scala.util.ScalaJavaConversions.ListOps
 
 /**
   * For testing of the consumption side of Stats end to end.
@@ -137,7 +137,7 @@ class FetchStatsTest extends TestCase {
     val metrics = consistencyJob.buildConsistencyMetrics()
     OnlineUtils.serveConsistency(tableUtils, inMemoryKvStore, today, joinConf)
     OnlineUtils.serveLogStats(tableUtils, inMemoryKvStore, yesterday, joinConf)
-    joinConf.joinParts.asScala.foreach(jp =>
+    joinConf.joinParts.toScala.foreach(jp =>
       OnlineUtils.serve(tableUtils, inMemoryKvStore, kvStoreFunc, namespace, yesterday, jp.groupBy))
 
     // Part 2: Fetch. Build requests, and fetch.

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByTest.scala
@@ -863,10 +863,10 @@ class GroupByTest {
     val testDatabase = s"staging_query_view_test_${Random.alphanumeric.take(6).mkString}"
     tableUtils.createDatabase(testDatabase)
 
-    // Create source data table with partitions  
+    // Create source data table with partitions
     val sourceSchema = List(
       Column("user", StringType, 20),
-      Column("item", StringType, 50), 
+      Column("item", StringType, 50),
       Column("time_spent_ms", LongType, 5000),
       Column("price", DoubleType, 100)
     )
@@ -889,7 +889,7 @@ class GroupByTest {
     stagingQueryJob.createStagingQueryView()
 
     val viewTable = s"$testDatabase.test_staging_view"
-    
+
     // Now create a GroupBy that uses the staging query view as its source
     val source = Builders.Source.events(
       table = viewTable,
@@ -898,12 +898,12 @@ class GroupByTest {
 
     val aggregations = Seq(
       Builders.Aggregation(operation = Operation.COUNT, inputColumn = "time_spent_ms"),
-      Builders.Aggregation(operation = Operation.AVERAGE, 
-                          inputColumn = "price",
-                          windows = Seq(new Window(7, TimeUnit.DAYS))),
+      Builders.Aggregation(operation = Operation.AVERAGE,
+                           inputColumn = "price",
+                           windows = Seq(new Window(7, TimeUnit.DAYS))),
       Builders.Aggregation(operation = Operation.MAX,
-                          inputColumn = "time_spent_ms", 
-                          windows = Seq(new Window(30, TimeUnit.DAYS)))
+                           inputColumn = "time_spent_ms",
+                           windows = Seq(new Window(30, TimeUnit.DAYS)))
     )
 
     val groupByConf = Builders.GroupBy(

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinBasicTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinBasicTest.scala
@@ -33,7 +33,6 @@ import org.scalatest.Assertions.intercept
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
-import scala.collection.JavaConverters._
 import scala.util.Random
 import scala.util.ScalaJavaConversions.ListOps
 import scala.util.Try

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinBloomFilterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinBloomFilterTest.scala
@@ -33,7 +33,6 @@ import org.scalatest.Assertions.intercept
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
-import scala.collection.JavaConverters._
 import scala.util.Random
 import scala.util.ScalaJavaConversions.ListOps
 import scala.util.Try

--- a/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
@@ -323,28 +323,35 @@ class StagingQueryTest {
     val outputView = stagingQueryConfView.metaData.outputTable
     val isView = tableUtils.tableReadFormat(outputView) match {
       case View => true
-      case _ => false
+      case _    => false
     }
-    
+
     assert(isView, s"Expected $outputView to be a view when createView=true")
 
     // Verify virtual partition metadata was written for the view
-    val virtualPartitionExists = try {
-      val metadataCount = tableUtils.sql(s"SELECT COUNT(*) as count FROM ${stagingQueryView.signalPartitionsTable} WHERE table_name = '$outputView'").collect()(0).getAs[Long]("count")
-      metadataCount > 0
-    } catch {
-      case _: Exception => false
-    }
+    val virtualPartitionExists =
+      try {
+        val metadataCount = tableUtils
+          .sql(
+            s"SELECT COUNT(*) as count FROM ${stagingQueryView.signalPartitionsTable} WHERE table_name = '$outputView'")
+          .collect()(0)
+          .getAs[Long]("count")
+        metadataCount > 0
+      } catch {
+        case _: Exception => false
+      }
     assert(virtualPartitionExists, s"Expected virtual partition metadata to exist for view $outputView")
 
     // Verify the structure of virtual partition metadata
     if (virtualPartitionExists) {
-      val metadataRows = tableUtils.sql(s"SELECT * FROM ${stagingQueryView.signalPartitionsTable} WHERE table_name = '$outputView'").collect()
+      val metadataRows = tableUtils
+        .sql(s"SELECT * FROM ${stagingQueryView.signalPartitionsTable} WHERE table_name = '$outputView'")
+        .collect()
       assert(metadataRows.length > 0, "Should have at least one partition metadata entry")
-      
+
       val firstRow = metadataRows(0)
       val tableName = firstRow.getAs[String]("table_name")
-      
+
       assertEquals(s"Virtual partition metadata should have correct table name", outputView, tableName)
     }
 
@@ -362,19 +369,25 @@ class StagingQueryTest {
     val outputTable = stagingQueryConfTable.metaData.outputTable
     val isTable = tableUtils.tableReadFormat(outputTable) match {
       case View => false
-      case _ => true
+      case _    => true
     }
-    
+
     assert(isTable, s"Expected $outputTable to be a table when createView=false")
 
     // Verify virtual partition metadata was NOT written for the table
-    val virtualPartitionExistsForTable = try {
-      val metadataCountForTable = tableUtils.sql(s"SELECT COUNT(*) as count FROM ${stagingQueryTable.signalPartitionsTable} WHERE table_name = '$outputTable'").collect()(0).getAs[Long]("count")
-      metadataCountForTable > 0
-    } catch {
-      case _: Exception => false
-    }
-    assert(!virtualPartitionExistsForTable, s"Expected NO virtual partition metadata for table $outputTable when createView=false")
+    val virtualPartitionExistsForTable =
+      try {
+        val metadataCountForTable = tableUtils
+          .sql(
+            s"SELECT COUNT(*) as count FROM ${stagingQueryTable.signalPartitionsTable} WHERE table_name = '$outputTable'")
+          .collect()(0)
+          .getAs[Long]("count")
+        metadataCountForTable > 0
+      } catch {
+        case _: Exception => false
+      }
+    assert(!virtualPartitionExistsForTable,
+           s"Expected NO virtual partition metadata for table $outputTable when createView=false")
 
     // Test Case 3: createView unset (should default to false and create table)
     val stagingQueryConfUnset = Builders.StagingQuery(
@@ -389,9 +402,9 @@ class StagingQueryTest {
     val outputUnset = stagingQueryConfUnset.metaData.outputTable
     val isTableUnset = tableUtils.tableReadFormat(outputUnset) match {
       case View => false
-      case _ => true
+      case _    => true
     }
-    
+
     assert(isTableUnset, s"Expected $outputUnset to be a table when createView is unset")
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/StreamingTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StreamingTest.scala
@@ -22,15 +22,14 @@ import ai.chronon.api.{Accuracy, Builders, Constants, Operation, TimeUnit, Windo
 import ai.chronon.api.Constants.ChrononMetadataKey
 import ai.chronon.api.Extensions._
 import ai.chronon.spark.test.StreamingTest.buildInMemoryKvStore
-import ai.chronon.online.{MetadataStore}
+import ai.chronon.online.MetadataStore
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.{Join => _, _}
 import junit.framework.TestCase
-import org.apache.spark.sql.{SparkSession}
+import org.apache.spark.sql.SparkSession
 
 import java.util.TimeZone
-
-import scala.collection.JavaConverters.{asScalaBufferConverter, _}
+import scala.util.ScalaJavaConversions.ListOps
 
 object StreamingTest {
   def buildInMemoryKvStore(): InMemoryKvStore = {
@@ -110,7 +109,7 @@ class StreamingTest extends TestCase {
     val metadataStore = new MetadataStore(inMemoryKvStore, timeoutMillis = 10000)
     inMemoryKvStore.create(ChrononMetadataKey)
     metadataStore.putJoinConf(joinConf)
-    joinConf.joinParts.asScala.foreach(jp =>
+    joinConf.joinParts.toScala.foreach(jp =>
       OnlineUtils.serve(tableUtils, inMemoryKvStore, buildInMemoryKvStore, namespace, today, jp.groupBy))
   }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Clean up: remove all references to `scala.jdk.CollectionConverters._` and `scala.collection.JavaConverters._` (all `asScala` and `asJava` calls) and standardize on using `ScalaVersionSpecificCollectionsConverter` across the repo. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Ensure code correctness across all scala versions.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested


## Reviewers
@airbnb/airbnb-chronon-maintainers 
