### PR TITLE
Fix logging avro serde for struct columns 

### DIFF
--- a/online/src/main/scala/ai/chronon/online/AvroCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/AvroCodec.scala
@@ -40,6 +40,7 @@ class AvroCodec(val schemaStr: String) extends Serializable {
   @transient private var jsonEncoder: JsonEncoder = null
   val fieldNames: Array[String] = schema.getFields.toScala.map(_.name()).toArray
   @transient lazy val chrononSchema: DataType = AvroConversions.toChrononSchema(schema)
+  @transient lazy val chrononSchemaClean: DataType = AvroConversions.toChrononSchema(schema, cleanName = true)
 
   @transient private var binaryEncoder: BinaryEncoder = null
   @transient private var decoder: BinaryDecoder = null

--- a/online/src/main/scala/ai/chronon/online/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/AvroConversions.scala
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer
 import java.util
 import scala.collection.{AbstractIterator, mutable}
 import scala.util.ScalaJavaConversions.{JListOps, ListOps}
+import scala.util.Try
 
 object AvroConversions {
 
@@ -39,15 +40,24 @@ object AvroConversions {
       case _                  => value
     }
 
-  def toChrononSchema(schema: Schema): DataType = {
+  def cleanSuffix(name: String): String = {
+    if (name.contains(RepetitionSuffix)) {
+      name.substring(0, name.indexOf(RepetitionSuffix))
+    } else {
+      name
+    }
+  }
+
+  def toChrononSchema(schema: Schema, cleanName: Boolean = false): DataType = {
+    def clean(name: String): String = if (cleanName) cleanSuffix(name) else name
     schema.getType match {
       case Schema.Type.RECORD =>
-        StructType(schema.getName,
+        StructType(clean(schema.getName),
                    schema.getFields.toScala.toArray.map { field =>
-                     StructField(field.name(), toChrononSchema(field.schema()))
+                     StructField(clean(field.name()), toChrononSchema(field.schema(), cleanName))
                    })
-      case Schema.Type.ARRAY   => ListType(toChrononSchema(schema.getElementType))
-      case Schema.Type.MAP     => MapType(StringType, toChrononSchema(schema.getValueType))
+      case Schema.Type.ARRAY   => ListType(toChrononSchema(schema.getElementType, cleanName))
+      case Schema.Type.MAP     => MapType(StringType, toChrononSchema(schema.getValueType, cleanName))
       case Schema.Type.STRING  => StringType
       case Schema.Type.INT     => IntType
       case Schema.Type.LONG    => LongType
@@ -55,8 +65,9 @@ object AvroConversions {
       case Schema.Type.DOUBLE  => DoubleType
       case Schema.Type.BYTES   => BinaryType
       case Schema.Type.BOOLEAN => BooleanType
-      case Schema.Type.UNION   => toChrononSchema(schema.getTypes.get(1)) // unions are only used to represent nullability
-      case _                   => throw new UnsupportedOperationException(s"Cannot convert avro type ${schema.getType.toString}")
+      case Schema.Type.UNION =>
+        toChrononSchema(schema.getTypes.get(1), cleanName) // unions are only used to represent nullability
+      case _ => throw new UnsupportedOperationException(s"Cannot convert avro type ${schema.getType.toString}")
     }
   }
 
@@ -191,6 +202,10 @@ object AvroConversions {
 
 case class AvroSchemaTraverser(currentNode: Schema) extends SchemaTraverser[Schema] {
 
+  private lazy val cleanSchema = currentNode.getFields.toScala.map { f =>
+    AvroConversions.cleanSuffix(f.name()) -> f.schema()
+  }.toMap
+
   // We only use union types for nullable fields, and always
   // unbox them when writing the actual schema out.
   private def unboxUnion(maybeUnion: Schema): Schema =
@@ -200,10 +215,11 @@ case class AvroSchemaTraverser(currentNode: Schema) extends SchemaTraverser[Sche
       maybeUnion
     }
 
-  override def getField(field: StructField): SchemaTraverser[Schema] =
+  override def getField(field: StructField): SchemaTraverser[Schema] = {
     copy(
-      unboxUnion(currentNode.getField(field.name).schema())
+      unboxUnion(Try(currentNode.getField(field.name).schema()).getOrElse(cleanSchema(field.name)))
     )
+  }
 
   override def getCollectionType: SchemaTraverser[Schema] =
     copy(

--- a/online/src/main/scala/ai/chronon/online/AvroConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/AvroConversions.scala
@@ -217,7 +217,8 @@ case class AvroSchemaTraverser(currentNode: Schema) extends SchemaTraverser[Sche
 
   override def getField(field: StructField): SchemaTraverser[Schema] = {
     copy(
-      unboxUnion(Try(currentNode.getField(field.name).schema()).getOrElse(cleanSchema(field.name)))
+      unboxUnion(
+        Try(currentNode.getField(field.name).schema()).getOrElse(cleanSchema(AvroConversions.cleanSuffix(field.name))))
     )
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/LoggingSchema.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LoggingSchema.scala
@@ -26,8 +26,8 @@ import scala.util.ScalaJavaConversions.MapOps
  * Schema of a published log event. valueCodec includes both base and derived columns.
  */
 case class LoggingSchema(keyCodec: AvroCodec, valueCodec: AvroCodec) {
-  lazy val keyFields: StructType = keyCodec.chrononSchema.asInstanceOf[StructType]
-  lazy val valueFields: StructType = valueCodec.chrononSchema.asInstanceOf[StructType]
+  lazy val keyFields: StructType = keyCodec.chrononSchemaClean.asInstanceOf[StructType]
+  lazy val valueFields: StructType = valueCodec.chrononSchemaClean.asInstanceOf[StructType]
   lazy val keyIndices: Map[StructField, Int] = keyFields.zipWithIndex.toMap
   lazy val valueIndices: Map[StructField, Int] = valueFields.zipWithIndex.toMap
 

--- a/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
@@ -176,15 +176,24 @@ class SchemaEvolutionTest extends TestCase {
       "struct_schema",
       Array(
         StructField("id", LongType),
-        StructField(name, ListType(StructType(name = "s", fields = Array(StructField("i", LongType))))),
+        StructField(
+          name,
+          StructType(
+            name = "struct_schema_2",
+            fields =
+              Array(StructField("id", LongType),
+                    StructField("context",
+                                StructType(name = "struct_schema_3", fields = Array(StructField("id", LongType)))))
+          )
+        ),
         StructField("ds", StringType)
       )
     )
     val rows = List(
-      Row(1L, Array(Row(100L)), "2022-10-01"),
-      Row(1L, Array(Row(200L)), "2022-10-02"),
-      Row(2L, Array(Row(300L)), "2022-10-01"),
-      Row(2L, Array(Row(400L)), "2022-10-02")
+      Row(1L, Row(100L, Row(1000L)), "2022-10-01"),
+      Row(1L, Row(200L, Row(2000L)), "2022-10-02"),
+      Row(2L, Row(300L, Row(3000L)), "2022-10-01"),
+      Row(2L, Row(400L, Row(4000L)), "2022-10-02")
     )
     val source = Builders.Source.entities(
       query = Builders.Query(
@@ -278,8 +287,8 @@ class SchemaEvolutionTest extends TestCase {
         Map("id" -> 1L.asInstanceOf[AnyRef]),
         Map(
           // Unused
-          "unit_test_list_struct_a_list_struct_a" -> Seq(Array(200L)),
-          "unit_test_list_struct_b_list_struct_b" -> Seq(Array(200L))
+          "unit_test_list_struct_a_list_struct_a" -> Array(200L, Array(2000L)),
+          "unit_test_list_struct_b_list_struct_b" -> Array(200L, Array(2000L))
         )
       )
     )

--- a/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
@@ -26,7 +26,7 @@ import ai.chronon.spark.{LogFlattenerJob, LoggingSchema, SparkSessionBuilder, Ta
 import junit.framework.TestCase
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.junit.Assert.{assertEquals, assertFalse, assertNotEquals, assertTrue}
+import org.junit.Assert.{assertArrayEquals, assertEquals, assertFalse, assertNotEquals, assertSame, assertTrue}
 
 import java.nio.charset.StandardCharsets
 import java.util.{Base64, TimeZone}
@@ -171,6 +171,48 @@ class SchemaEvolutionTest extends TestCase {
     )
   }
 
+  def createStructGroupBy(namespace: String, spark: SparkSession, name: String): GroupByTestSuite = {
+    val schema = StructType(
+      "struct_schema",
+      Array(
+        StructField("id", LongType),
+        StructField(name, ListType(StructType(name = "s", fields = Array(StructField("i", LongType))))),
+        StructField("ds", StringType)
+      )
+    )
+    val rows = List(
+      Row(1L, Array(Row(100L)), "2022-10-01"),
+      Row(1L, Array(Row(200L)), "2022-10-02"),
+      Row(2L, Array(Row(300L)), "2022-10-01"),
+      Row(2L, Array(Row(400L)), "2022-10-02")
+    )
+    val source = Builders.Source.entities(
+      query = Builders.Query(
+        selects = Map(
+          "id" -> "id",
+          name -> name
+        )
+      ),
+      snapshotTable = s"${namespace}.${name}"
+    )
+    val conf = Builders.GroupBy(
+      sources = Seq(source),
+      keyColumns = Seq("id"),
+      aggregations = null,
+      accuracy = Accuracy.SNAPSHOT,
+      metaData = Builders.MetaData(name = s"unit_test/${name}", namespace = namespace, team = "chronon")
+    )
+    val df = spark.createDataFrame(
+      rows.toJava,
+      SparkConversions.fromChrononSchema(schema)
+    )
+    GroupByTestSuite(
+      name,
+      conf,
+      df
+    )
+  }
+
   def createV1Join(namespace: String): JoinTestSuite = {
     val viewsGroupBy = createViewsGroupBy(namespace, spark)
     val joinConf = Builders.Join(
@@ -213,6 +255,31 @@ class SchemaEvolutionTest extends TestCase {
           "unit_test_listing_views_m_views_sum" -> 50L.asInstanceOf[AnyRef],
           "unit_test_listing_attributes_dim_bedrooms" -> 4.asInstanceOf[AnyRef],
           "unit_test_listing_attributes_dim_room_type" -> "ENTIRE_HOME"
+        )
+      )
+    )
+  }
+
+  def createStructJoin(namespace: String): JoinTestSuite = {
+    val groupBy = createStructGroupBy(namespace, spark, "list_struct_a")
+    val groupByB = createStructGroupBy(namespace, spark, "list_struct_b")
+    val joinConf = Builders.Join(
+      left = groupBy.groupByConf.sources.get(0),
+      joinParts = Seq(
+        Builders.JoinPart(groupBy = groupBy.groupByConf),
+        Builders.JoinPart(groupBy = groupByB.groupByConf)
+      ),
+      metaData = Builders.MetaData(name = "unit_test/test_join", namespace = namespace, team = "chronon")
+    )
+    JoinTestSuite(
+      joinConf,
+      Seq(groupBy, groupByB),
+      (
+        Map("id" -> 1L.asInstanceOf[AnyRef]),
+        Map(
+          // Unused
+          "unit_test_list_struct_a_list_struct_a" -> Seq(Array(200L)),
+          "unit_test_list_struct_b_list_struct_b" -> Seq(Array(200L))
         )
       )
     )
@@ -436,5 +503,62 @@ class SchemaEvolutionTest extends TestCase {
   def testRemoveFeatures(): Unit = {
     val namespace = "remove_features"
     testSchemaEvolution(namespace, createV2Join(namespace), createV1Join(namespace))
+  }
+
+  def testStructFeatures(): Unit = {
+    val namespace = "test_struct_features"
+    val joinTestSuite = createStructJoin(namespace)
+
+    val tableUtils: TableUtils = TableUtils(spark)
+    val inMemoryKvStore = OnlineUtils.buildInMemoryKVStore(namespace)
+    val mockApi = new MockApi(() => inMemoryKvStore, namespace)
+    inMemoryKvStore.create(ChrononMetadataKey)
+    val metadataStore = new MetadataStore(inMemoryKvStore, timeoutMillis = 10000)
+
+    /* STAGE 1: Create join v1 and upload the conf to MetadataStore */
+    metadataStore.putJoinConf(joinTestSuite.joinConf)
+    val fetcher = mockApi.buildFetcher(debug = true)
+    val response1 = fetchJoin(fetcher, joinTestSuite)
+    assertTrue(response1.values.get.keys.exists(_.endsWith("_exception")))
+    assertEquals(joinTestSuite.groupBys.length, response1.values.get.keys.size)
+
+    // empty responses are still logged and this schema version is still tracked
+    val logs1 = mockApi.flushLoggedValues
+    val (dataEvent1, _) = extractDataEventAndControlEvent(logs1)
+    assertEquals("", dataEvent1.keyBase64)
+    assertEquals("", dataEvent1.valueBase64)
+
+    /* STAGE 2: GroupBy upload completes and start having successful fetches & logs */
+    runGBUpload(namespace, joinTestSuite, tableUtils, inMemoryKvStore)
+    clearTTLCache(fetcher)
+    val response2 = fetchJoin(fetcher, joinTestSuite)
+    assertEquals(joinTestSuite.fetchExpectations._2.keys.toSeq, response2.values.get.keys.toSeq)
+
+    val logs2 = mockApi.flushLoggedValues
+    val (dataEvent2, controlEvent2) = extractDataEventAndControlEvent(logs2)
+    val schema2 = new String(Base64.getDecoder.decode(controlEvent2.valueBase64), StandardCharsets.UTF_8)
+    val recoveredSchemaHash2 = LoggingSchema.parseLoggingSchema(schema2).hash(joinTestSuite.joinConf.metaData.name)
+    assertEquals(dataEvent2.schemaHash, recoveredSchemaHash2)
+
+    val flattenedDf12 = verifyOfflineTables(
+      logs1 ++ logs2, // combine logs from stage 1 and stage 2 into offline DS = 2022-10-03
+      offlineDs = "2022-10-03",
+      mockApi,
+      joinTestSuite.joinConf,
+      tableUtils
+    )
+
+    // validate flattenedDf12 correctness
+    assertEquals(
+      flattenedDf12.columns.toSeq,
+      Seq(
+        "schema_hash",
+        "ts",
+        "id",
+        "unit_test_list_struct_a_list_struct_a",
+        "unit_test_list_struct_b_list_struct_b",
+        "ds"
+      )
+    )
   }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

When multiple struct columns exist in the same avro schema (e.g. same join) that contain sub-columns with the same name, a suffix REPEATED_{i} is added. This PR fixes an issue in this scenario where the suffix is not handled, causing logging and log-flattener job failures. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Fix logging and log-flattener job failures. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested


## Reviewers

@airbnb/airbnb-chronon-maintainers 
