### PR TITLE
compile-time validations against some unsupported scenarios

### DIFF
--- a/api/py/test/test_join.py
+++ b/api/py/test/test_join.py
@@ -1,4 +1,3 @@
-
 #     Copyright (C) 2023 The Chronon Authors.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +12,15 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from ai.chronon.join import Join, Derivation
-from ai.chronon.group_by import GroupBy
-from ai.chronon.api import ttypes as api
-
-import pytest
 import json
 
+import pytest
+from ai.chronon.api import ttypes as api
+from ai.chronon.group_by import GroupBy
+from ai.chronon.join import Derivation, Join
 
-def event_source(table):
+
+def event_source(table, is_cumulative=False):
     """
     Sample left join
     """
@@ -36,6 +35,7 @@ def event_source(table):
                 },
                 timeColumn="CAST(ts AS DOUBLE)",
             ),
+            isCumulative=is_cumulative,
         ),
     )
 
@@ -54,13 +54,47 @@ def right_part(source):
         ),
     )
 
+
+def join_source():
+    return api.Source(
+        joinSource=api.JoinSource(
+            join=Join(
+                left=event_source("sample_namespace.sample_table"),
+                right_parts=[right_part(event_source("sample_namespace.another_table"))],
+            ),
+            query=api.Query(
+                startPartition="2020-04-09",
+                selects={
+                    "subject": "subject_sql",
+                    "event_id": "event_sql",
+                },
+                timeColumn="CAST(ts AS DOUBLE)",
+            ),
+        )
+    )
+
+
 def test_join_with_description():
     join = Join(
         left=event_source("sample_namespace.sample_table"),
         right_parts=[right_part(event_source("sample_namespace.another_table"))],
-        description="Join description"
+        description="Join description",
     )
     assert join.metaData.description == "Join description"
+
+
+def test_join_validation_failure_cumulative_events_left():
+    with pytest.raises(ValueError, match="NOT supported by Chronon"):
+        join = Join(
+            left=event_source(table="sample_namespace.sample_table", is_cumulative=True),
+            right_parts=[right_part(event_source("sample_namespace.another_table"))],
+        )
+
+
+def test_join_validation_failure_join_source_left():
+    with pytest.raises(ValueError, match="NOT supported by Chronon"):
+        join = Join(left=join_source(), right_parts=[right_part(event_source("sample_namespace.another_table"))])
+
 
 def test_deduped_dependencies():
     """
@@ -68,12 +102,14 @@ def test_deduped_dependencies():
     """
     join = Join(
         left=event_source("sample_namespace.sample_table"),
-        right_parts=[right_part(event_source("sample_namespace.another_table"))])
+        right_parts=[right_part(event_source("sample_namespace.another_table"))],
+    )
     assert len(join.metaData.dependencies) == 2
 
     join = Join(
         left=event_source("sample_namespace.sample_table"),
-        right_parts=[right_part(event_source("sample_namespace.sample_table"))])
+        right_parts=[right_part(event_source("sample_namespace.sample_table"))],
+    )
     assert len(join.metaData.dependencies) == 1
 
 
@@ -81,9 +117,9 @@ def test_additional_args_to_custom_json():
     join = Join(
         left=event_source("sample_namespace.sample_table"),
         right_parts=[right_part(event_source("sample_namespace.sample_table"))],
-        team_override="some_other_team_value"
+        team_override="some_other_team_value",
     )
-    assert json.loads(join.metaData.customJson)['team_override'] == "some_other_team_value"
+    assert json.loads(join.metaData.customJson)["team_override"] == "some_other_team_value"
 
 
 def test_dependencies_propagation():
@@ -96,38 +132,34 @@ def test_dependencies_propagation():
         sources=[event_source("table_2")],
         keys=["subject"],
         aggregations=[],
-        dependencies=["table_2/ds={{ ds }}/key=value"]
+        dependencies=["table_2/ds={{ ds }}/key=value"],
     )
-    join = Join(
-        left=event_source("left_1"),
-        right_parts=[api.JoinPart(gb1), api.JoinPart(gb2)]
-    )
+    join = Join(left=event_source("left_1"), right_parts=[api.JoinPart(gb1), api.JoinPart(gb2)])
 
-    actual = [
-        (json.loads(dep)["name"], json.loads(dep)["spec"])
-        for dep in join.metaData.dependencies
-    ]
+    actual = [(json.loads(dep)["name"], json.loads(dep)["spec"]) for dep in join.metaData.dependencies]
     expected = [
         ("wait_for_left_1_ds", "left_1/ds={{ ds }}"),
         ("wait_for_table_1_ds", "table_1/ds={{ ds }}"),
-        ("wait_for_table_2_ds_ds_key_value", "table_2/ds={{ ds }}/key=value")
+        ("wait_for_table_2_ds_ds_key_value", "table_2/ds={{ ds }}/key=value"),
     ]
     assert expected == actual
 
+
 def test_derivation():
     derivation = Derivation(name="derivation_name", expression="derivation_expression")
-    expected_derivation = api.Derivation(
-        name="derivation_name",
-        expression="derivation_expression")
+    expected_derivation = api.Derivation(name="derivation_name", expression="derivation_expression")
 
     assert derivation == expected_derivation
 
 
 def test_derivation_with_description():
-    derivation = Derivation(name="derivation_name", expression="derivation_expression", description="Derivation description")
+    derivation = Derivation(
+        name="derivation_name", expression="derivation_expression", description="Derivation description"
+    )
     expected_derivation = api.Derivation(
         name="derivation_name",
         expression="derivation_expression",
-        metaData=api.MetaData(description="Derivation description"))
+        metaData=api.MetaData(description="Derivation description"),
+    )
 
     assert derivation == expected_derivation


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Add compile-time validations for joins for some unsupported scenarios:
- left source cannot be a cumulative event source. it leads to issues during backfill
- left source cannot be a join source. left-side chaining is not supported right now. users are encouraged to fall back to table-level dependency. realtime chaining not supported. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Early failures for user authoring configurations that are not supported scenarios.  

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested


## Reviewers

@airbnb/airbnb-chronon-maintainers 