### PR TITLE
fix: update analyzer handling for input file

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, immutable, mutable}
 import scala.util.ScalaJavaConversions.ListOps
+import scala.util.Try
 
 //@SerialVersionUID(3457890987L)
 //class ItemSketchSerializable(var mapSize: Int) extends ItemsSketch[String](mapSize) with Serializable {}
@@ -803,8 +804,25 @@ class Analyzer(tableUtils: TableUtils,
           runAnalyzeJoin(parseConf[api.Join](confPath), exportSchema)
         } else if (confPath.contains("/group_bys/")) {
           runAnalyzeGroupBy(parseConf[api.GroupBy](confPath), exportSchema)
+        } else {
+          val joinConfTry = Try(parseConf[api.Join](confPath))
+          if (joinConfTry.isSuccess) {
+            runAnalyzeJoin(joinConfTry.get, exportSchema)
+          } else {
+            val groupByConfTry = Try(parseConf[api.GroupBy](confPath))
+            if (groupByConfTry.isSuccess) {
+              runAnalyzeGroupBy(groupByConfTry.get, exportSchema)
+            } else {
+              throw new IllegalArgumentException(
+                s"Cannot parse the config at $confPath as either Join or GroupBy. Please check the config file."
+              )
+            }
+          }
         }
       case groupByConf: api.GroupBy => runAnalyzeGroupBy(groupByConf, exportSchema)
       case joinConf: api.Join       => runAnalyzeJoin(joinConf, exportSchema)
+      case _ =>
+        throw new IllegalArgumentException(
+          "conf must be either a path to a config file, or a GroupBy or Join config: " + conf)
     }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Allow analyzer input path to be a standalone conf file (without joins or group_bys prefix), and it will determine file type by try loading the content. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Support a different type of way to pass in analyzer input config. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested


## Reviewers
@airbnb/airbnb-chronon-maintainers 
