### PR TITLE
support tinyint/smallint for online serving

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Row.scala
+++ b/api/src/main/scala/ai/chronon/api/Row.scala
@@ -120,6 +120,8 @@ object Row {
         }
       case BinaryType => debinarizer(value.asInstanceOf[BinaryType])
       case StringType => deStringer(value.asInstanceOf[StringType])
+      case ShortType  => value.asInstanceOf[Number].shortValue()
+      case ByteType   => value.asInstanceOf[Number].byteValue()
       case _          => value
     }
   }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

support tinyint/smallint data for online serving by using avro int. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

convenience for users with tinyint/smallint input data without explicit conversion. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested


## Reviewers

@airbnb/airbnb-chronon-maintainers @pengyu-hou @Shiyinghaha 
