### PR TITLE
[Online]Enable ds derivation in online for rename-only derivations

### DIFF
--- a/online/src/main/scala/ai/chronon/online/DerivationUtils.scala
+++ b/online/src/main/scala/ai/chronon/online/DerivationUtils.scala
@@ -110,7 +110,7 @@ object DerivationUtils {
       }
       val expressions: Seq[StructField] = baseExpressions ++ derivationsScala.derivationsWithoutStar.map { d =>
         {
-          val allSchema = StructType("all", (keySchema ++ baseValueSchema).toArray)
+          val allSchema = StructType("all", (keySchema ++ baseValueSchema).toArray ++ timeFields)
           if (allSchema.typeOf(d.expression).isEmpty) {
             throw new IllegalArgumentException(
               s"Failed to run expression ${d.expression} for ${d.name}. Please ensure the derivation is " +


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Currently we are enabling derivation on ds for offline(It is used for the case where the wildcard derivation is not used and ds is not included in final schema), but online derivation on ds is disabled  for rename-only derivations, which caused online-offline consistency. 

The change is to enable the ds derivation in online for rename-only derivations

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @hzding621 @Shiyinghaha 
