### PR TITLE
Support global aggregations

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -67,4 +67,5 @@ object Constants {
   val chrononArchiveFlag: String = "chronon_archived"
   val ChainingRequestTs: String = "chaining_request_ts"
   val ChainingFetchTs: String = "chaining_fetch_ts"
+  val GlobalAggregationKVStoreKey: String = "__global_aggregation_dummy_key__"
 }

--- a/online/src/main/scala/ai/chronon/online/Api.scala
+++ b/online/src/main/scala/ai/chronon/online/Api.scala
@@ -98,7 +98,12 @@ trait KVStore {
   def createKeyBytes(keys: Map[String, AnyRef],
                      groupByServingInfo: GroupByServingInfoParsed,
                      dataset: String): Array[Byte] = {
-    groupByServingInfo.keyCodec.encode(keys)
+    // For global aggregations (empty key schema), use plain UTF-8 bytes for dummy key
+    if (groupByServingInfo.keyChrononSchema.fields.isEmpty) {
+      Constants.GlobalAggregationKVStoreKey.getBytes(Constants.UTF8)
+    } else {
+      groupByServingInfo.keyCodec.encode(keys)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
This adds support for `keys=None` to signify a global aggregation. Global aggregations can be added to a join and are then joined with each record on the left since they have no keys.


## Why / Goal
Global aggregations are extremely useful for computing sane defaults to be used later in a join coalesce.


## Test Plan
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

