### PR TITLE
Fix Bazel build to include Scala files in online module subdirectories

### DIFF
--- a/online/BUILD.bazel
+++ b/online/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_jvm_external//:defs.bzl", "java_export")
 
 scala_library(
     name = "online",
-    srcs = glob(["src/main/scala/ai/chronon/online/*.scala"]) +
+    srcs = glob(["src/main/scala/ai/chronon/online/**/*.scala"]) +
            select_for_scala_version(
                before_2_12 = [
                    "//online/src/main/scala-2.11/ai/chronon/online:ScalaVersionSpecificCatalystHelper.scala",


### PR DESCRIPTION
## Summary
Updates the online module's BUILD.bazel to use a recursive glob pattern (`**/*.scala`) instead of a single-level glob (`*.scala`). This ensures that Scala files in subdirectories, particularly the serde package containing serialization/deserialization utilities (AvroCodec, AvroConversions, SparkConversions), are properly included in the build.

Without this change, files in `src/main/scala/ai/chronon/online/serde/` were not being 
compiled as part of the Bazel build target.

**Changes:**
- `online/BUILD.bazel`: Changed glob pattern from `*.scala` to `**/*.scala` to recursively include all Scala files in subdirectories

**Test**
When we run `bazel build --config java_11 --config scala_2.12 --config spark_3.5 //spark:spark-assembly_deploy.jar` I get the following error:
> online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala:23: error: object serde is not a member of package ai.chronon.online
> import ai.chronon.online.serde.{AvroCodec, AvroConversions}
>                          ^
> online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala:64: error: not found: type AvroCodec
>   def keyCodec: AvroCodec = AvroCodec.of(keyAvroSchema)
>                 ^

which is fixed now with the build file update.