### PR TITLE
[Chronon] run.py refactor 

### DIFF
--- a/api/py/ai/chronon/repo/run.py
+++ b/api/py/ai/chronon/repo/run.py
@@ -183,6 +183,25 @@ def download_only_once(url, path, skip_download=False):
         check_call("curl {} -o {} --connect-timeout 10".format(url, path))
 
 
+def construct_version(version, base_url, release_tag, suffix=None):
+    if version == "latest":
+        version = None
+    if version:
+        return version if not suffix else f"{version}-{suffix}"
+    metadata_content = check_output("curl -s {}/maven-metadata.xml".format(base_url))
+    meta_tree = ET.fromstring(metadata_content)
+    versions = [
+        node.text
+        for node in meta_tree.findall("./versioning/versions/")
+        if re.search(
+            r"^\d+\.\d+\.\d+{}$".format("\_{}\d*".format(release_tag) if release_tag else ""),
+            node.text,
+        )
+    ]
+    version = versions[-1]
+    return version if not suffix else f"{version}-{suffix}"
+
+
 @retry_decorator(retries=3, backoff=50)
 def download_jar(
     version,
@@ -190,40 +209,30 @@ def download_jar(
     release_tag=None,
     spark_version="3.1.1",
     skip_download=False,
+    jar_url=None,
 ):
     assert (
         spark_version in SUPPORTED_SPARK
     ), f"Received unsupported spark version {spark_version}. Supported spark versions are {SUPPORTED_SPARK}"
     scala_version = SCALA_VERSION_FOR_SPARK[spark_version]
-    maven_url_prefix = os.environ.get("CHRONON_MAVEN_MIRROR_PREFIX", None)
-    default_url_prefix = "https://s01.oss.sonatype.org/service/local/repositories/public/content"
-    url_prefix = maven_url_prefix if maven_url_prefix else default_url_prefix
-    base_url = "{}/ai/chronon/spark_{}_{}".format(url_prefix, jar_type, scala_version)
-    print("Downloading jar from url: " + base_url)
-    jar_path = os.environ.get("CHRONON_DRIVER_JAR", None)
-    if jar_path is None:
-        if version == "latest":
-            version = None
-        if version is None:
-            metadata_content = check_output("curl -s {}/maven-metadata.xml".format(base_url))
-            meta_tree = ET.fromstring(metadata_content)
-            versions = [
-                node.text
-                for node in meta_tree.findall("./versioning/versions/")
-                if re.search(
-                    r"^\d+\.\d+\.\d+{}$".format("\_{}\d*".format(release_tag) if release_tag else ""),
-                    node.text,
-                )
-            ]
-            version = versions[-1]
-        jar_url = "{base_url}/{version}/spark_{jar_type}_{scala_version}-{version}-assembly.jar".format(
-            base_url=base_url,
-            version=version,
-            scala_version=scala_version,
-            jar_type=jar_type,
-        )
-        jar_path = os.path.join("/tmp", jar_url.split("/")[-1])
-        download_only_once(jar_url, jar_path, skip_download)
+
+    if not jar_url:
+        maven_url_prefix = os.environ.get("CHRONON_MAVEN_MIRROR_PREFIX", None)
+        default_url_prefix = "https://s01.oss.sonatype.org/service/local/repositories/public/content"
+        url_prefix = maven_url_prefix if maven_url_prefix else default_url_prefix
+        base_url = "{}/ai/chronon/spark_{}_{}".format(url_prefix, jar_type, scala_version)
+        print("Downloading jar from url: " + base_url)
+        jar_path = os.environ.get("CHRONON_DRIVER_JAR", None)
+        if jar_path is None:
+            version = construct_version(version, base_url, release_tag)
+            jar_url = "{base_url}/{version}/spark_{jar_type}_{scala_version}-{version}-assembly.jar".format(
+                base_url=base_url,
+                version=version,
+                scala_version=scala_version,
+                jar_type=jar_type,
+            )
+    jar_path = os.path.join("/tmp", jar_url.split("/")[-1])
+    download_only_once(jar_url, jar_path, skip_download)
     return jar_path
 
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Refactor `run.py` so that we can easily parse the separated internal airbnb jar url logics to `run.py` `download_jar`

internal counterpart: https://git.musta.ch/third-party/chronon-internal/pull/205

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @yuli-han @hzding621 @pkundurthy 
