### PR TITLE
[Chronon] Throwing exception when encountering duplicates in join part calculation

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -345,20 +345,22 @@ abstract class JoinBase(joinConf: api.Join,
       rightDfWithDerivations.prettyPrint()
     }
 
-    // Uniqueness check on key columns (+ ts for temporal cases) - throw error if violated
-    val hasTimeColumn = rightDfWithDerivations.columns.contains(Constants.TimeColumn)
-    val keyColumns = joinPart.groupBy.keyColumns.toScala ++
-      (if (hasTimeColumn) Seq(Constants.TimeColumn) else Seq.empty) :+
-      tableUtils.partitionColumn
-    val totalCount = rightDfWithDerivations.count()
-    val distinctCount = rightDfWithDerivations.select(keyColumns.map(col): _*).distinct().count()
+    if (tableUtils.joinPartUniquenessCheck) {
+      // Uniqueness check on key columns (+ ts for temporal cases) - throw error if violated
+      val hasTimeColumn = rightDfWithDerivations.columns.contains(Constants.TimeColumn)
+      val keyColumns = joinPart.groupBy.keyColumns.toScala ++
+        (if (hasTimeColumn) Seq(Constants.TimeColumn) else Seq.empty) :+
+        tableUtils.partitionColumn
+      val totalCount = rightDfWithDerivations.count()
+      val distinctCount = rightDfWithDerivations.select(keyColumns.map(col): _*).distinct().count()
 
-    if (totalCount != distinctCount) {
-      throw new IllegalStateException(
-        s"Uniqueness check failed for join part ${joinPart.groupBy.metaData.name}: " +
-          s"total rows = $totalCount, distinct keys = $distinctCount. " +
-          s"Key columns: ${keyColumns.mkString(", ")}"
-      )
+      if (totalCount != distinctCount) {
+        throw new IllegalStateException(
+          s"Uniqueness check failed for join part ${joinPart.groupBy.metaData.name}: " +
+            s"total rows = $totalCount, distinct keys = $distinctCount. " +
+            s"Key columns: ${keyColumns.mkString(", ")}"
+        )
+      }
     }
 
     Some(rightDfWithDerivations)

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -365,6 +365,10 @@ case class TableUtils(sparkSession: SparkSession) {
   val chrononAvroSchemaValidation: Boolean =
     sparkSession.conf.get("spark.chronon.avroSchemaValidation", "true").toBoolean
 
+  // whether or not to enable joinPart (key col, ts) uniqueness check
+  val joinPartUniquenessCheck: Boolean =
+    sparkSession.conf.get("spark.chronon.joinPartUniquenessCheck", "false").toBoolean
+
   private lazy val tableFormatProvider: FormatProvider = {
     sparkSession.conf.getOption("spark.chronon.table.format_provider") match {
       case Some(clazzName) =>


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

User concern: chronon occasionally randomly produce duplicate records for joins, retry will solve the issue and hard to replicate, solution is to add this alert to fail the job if duplication occurs so that we will be notified and auto-retry will likely resolve the job

Throwing exception when encountering duplicates (should be distinct on `key col` or `key col + ts`) in join part calculation

Default is not enabled, users can choose enable by setting `joinPartUniquenessCheck` to true

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @yuli-han @pkundurthy @hzding621 
