### PR TITLE
Add Claude Code customizations for Chronon OSS

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,171 @@
+# Chronon
+
+Chronon is an open-source Feature Platform for ML. It solves training-serving skew by ensuring the same feature logic runs in both batch (training) and online (serving) environments.
+
+## Repository Structure
+
+### Core Modules
+
+**Python API** (`/api/py/ai/chronon/`)
+- `group_by.py` - GroupBy definitions (aggregations over sources) (features)
+- `join.py` - Join definitions (combine multiple GroupBys) (feature vectors)
+- `staging_query.py` - SQL-based data preparation
+
+**CLI Tools** (`/api/py/ai/chronon/repo/`)
+- `compile.py` - Convert Python configs to Thrift JSON
+- `run.py` - Execute jobs (backfill, upload, fetch, analyze, etc.)
+- `validator.py` - Validate configurations
+
+### Execution Engines
+
+**Spark** (`/spark/src/main/scala/ai/chronon/spark/`)
+- `Driver.scala` - Main entry point for all Spark modes
+- `GroupBy.scala` - GroupBy materialization logic
+- `Join.scala` - Join execution with point-in-time correctness
+- `StagingQuery.scala` - SQL query execution
+
+**Flink** (`/flink/src/main/scala/ai/chronon/flink/`)
+- `FlinkJob.scala` - Streaming job entry point
+- Real-time feature updates from Kafka sources
+
+**Online Serving** (`/online/src/main/scala/ai/chronon/online/`)
+- `Fetcher.scala` - Feature fetching with caching
+- `FetcherBase.scala` - Base fetching logic
+- `MetadataStore.scala` - Configuration management
+- `Api.scala` - Online API interface (includes KVStore trait)
+
+**Aggregator** (`/aggregator/src/main/scala/ai/chronon/aggregator/`)
+- Shared aggregation logic across Spark/Flink/Online
+- Windowed aggregations with tiling optimization
+- Sketch algorithms (HyperLogLog, KLL, etc.)
+
+### Supporting Modules
+
+- `/docs/source/` - Sphinx documentation
+- `/api/py/test/sample/` - Example configs and test data
+- `/airflow/` - Orchestration DAG constructors
+- `/service/` - REST API service (Vert.x)
+- `/quickstart/` - Docker-based tutorial environment
+
+## Key Concepts
+
+### 1. Source
+Where data comes from:
+- **EventSource** - Log tables with timestamps (+ optional Kafka topic for streaming)
+- **EntitySource** - Daily snapshot tables (dimension data)
+
+### 2. GroupBy
+Feature definitions with:
+- **Keys** - Grouping dimensions (e.g., user_id)
+- **Aggregations** - Operations like SUM, COUNT, AVG, APPROX_UNIQUE_COUNT
+- **Windows** - Time ranges (e.g., 3 days, 14 days, 30 days)
+- **Accuracy** - SNAPSHOT (midnight updates) or TEMPORAL (real-time)
+
+### 3. Join
+Combines multiple GroupBys:
+- **Left side** - Defines the timeline for backfill (primary keys + timestamps)
+- **Right parts** - GroupBys to include
+- Ensures **point-in-time correctness** for ML training data
+
+## Common Workflows
+
+### Feature Development
+```bash
+# 1. Define GroupBy/Join in Python
+# 2. Compile to Thrift
+compile.py --conf=joins/team/my_join.py
+
+# 3. Analyze (validate schema, check row counts)
+run.py --mode analyze --conf production/joins/team/my_join.v1
+
+# 4. Backfill historical data
+run.py --mode backfill --conf production/joins/team/my_join.v1 --ds 2024-01-01
+
+# 5. Upload to KV store (for online serving)
+run.py --mode upload --conf production/group_bys/team/my_gb.v1 --ds 2024-01-01
+
+# 6. Test online fetch
+run.py --mode fetch --type join --name team/my_join.v1 --key-json '{"user_id":"123"}'
+```
+
+### run.py Modes
+| Mode | Purpose |
+|------|---------|
+| `backfill` | Compute historical feature values (Spark) |
+| `upload` | Prepare data for KV store upload |
+| `streaming` | Real-time feature computation (Flink) |
+| `metadata-upload` | Upload Join metadata for online serving |
+| `fetch` | Query online features (test mode) |
+| `analyze` | Validate configs (schema, row counts) |
+| `consistency-metrics-compute` | Compare online/offline values |
+
+## Build Systems
+
+### SBT (Scala)
+```bash
+sbt compile              # Compile all modules
+sbt test                 # Run tests
+sbt "spark_uber/assembly"  # Build Spark uber JAR
+```
+
+### Bazel (Hermetic)
+```bash
+bazel build //...        # Build all targets
+bazel test //...         # Run all tests
+```
+
+### Docker (Quickstart)
+```bash
+docker-compose up        # Start local environment (from repo root)
+```
+
+## Code Conventions
+
+### Python API
+- Use `select()` helper for column selections: `select("user_id", "amount")`
+- Version GroupBys/Joins with suffixes: `purchases_v1`, `purchases_v2`
+- Set `online=True` only when ready for production serving
+- Use `env={}` for per-config resource overrides
+
+### Scala
+- Follow existing patterns in each module
+- Use Builders API for configuration construction
+- Leverage Extensions for common operations
+
+## Key Entry Points
+
+When exploring the codebase, start here:
+
+| Purpose | File |
+|---------|------|
+| Python GroupBy API | `api/py/ai/chronon/group_by.py` |
+| Python Join API | `api/py/ai/chronon/join.py` |
+| CLI execution | `api/py/ai/chronon/repo/run.py` |
+| Spark driver | `spark/src/main/scala/ai/chronon/spark/Driver.scala` |
+| Online fetcher | `online/src/main/scala/ai/chronon/online/Fetcher.scala` |
+| Aggregation logic | `aggregator/src/main/scala/ai/chronon/aggregator/` |
+
+## Documentation
+
+- **Feature authoring**: `docs/source/authoring_features/`
+- **Setup & integration**: `docs/source/setup/`
+- **Testing & deployment**: `docs/source/test_deploy_serve/`
+- **Examples**: `api/py/test/sample/`
+
+## Custom Commands
+
+This repository includes Claude Code commands for common tasks:
+
+**For Feature Authors (Data Scientists):**
+- `user/groupby` - Help writing GroupBy definitions
+- `user/join` - Help writing Join definitions
+- `user/debug` - Debug compilation and backfill errors
+- `user/staging-query` - Help with StagingQuery definitions
+
+**For Platform Integrators (Engineers):**
+- `dev/architecture` - System architecture overview
+- `dev/integrate` - Integration guidance (KV stores, Airflow, etc.)
+- `dev/specialist/join-backfill` - Deep dive into Spark Join execution
+- `dev/specialist/feature-serving` - Deep dive into online serving
+- `dev/specialist/streaming` - Deep dive into Flink streaming
+- `dev/specialist/aggregator` - Deep dive into aggregation/tiling

--- a/.claude/commands/dev/architecture.md
+++ b/.claude/commands/dev/architecture.md
@@ -1,0 +1,131 @@
+You are explaining Chronon's architecture to an engineer integrating it into their infrastructure.
+
+## High-Level Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Python Config Layer                          │
+│  GroupBy/Join/StagingQuery definitions (api/py/ai/chronon/)     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ compile.py
+┌─────────────────────────────────────────────────────────────────┐
+│                      Thrift JSON Configs                         │
+│              (production/group_bys/, production/joins/)          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ run.py
+          ┌───────────────────┼───────────────────┐
+          │                   │                   │
+          ▼                   ▼                   ▼
+    ┌──────────┐        ┌──────────┐        ┌──────────┐
+    │  Spark   │        │  Flink   │        │  Online  │
+    │(Backfill)│        │(Streaming)│       │(Serving) │
+    └────┬─────┘        └────┬─────┘        └────┬─────┘
+         │                   │                   │
+         ▼                   ▼                   ▼
+    ┌──────────┐        ┌──────────┐        ┌──────────┐
+    │Data Lake │───────▶│ KV Store │◀───────│ Fetcher  │
+    │(Hive/etc)│        │(Redis/etc)│       │  (API)   │
+    └──────────┘        └──────────┘        └──────────┘
+```
+
+## Key Components
+
+### 1. Python API Layer (`/api/py/ai/chronon/`)
+
+User-facing DSL for defining features:
+- `group_by.py` - Feature aggregations
+- `join.py` - Feature composition
+- `staging_query.py` - Data preparation
+- `query.py` - Query builder
+
+Compiles to Thrift for cross-language compatibility.
+
+### 2. Spark Engine (`/spark/src/main/scala/ai/chronon/spark/`)
+
+Batch computation and backfills:
+- **`Driver.scala`** - Main entry point, handles all Spark modes
+- **`GroupBy.scala`** - GroupBy materialization
+- **`Join.scala`** - Point-in-time correct joins
+- **`StagingQuery.scala`** - SQL query execution
+
+Key modes: `backfill`, `upload`, `analyze`, `consistency-metrics-compute`
+
+### 3. Flink Engine (`/flink/src/main/scala/ai/chronon/flink/`)
+
+Real-time feature updates:
+- **`FlinkJob.scala`** - Streaming job orchestration
+- Consumes from Kafka topics
+- Writes to KV store in real-time
+
+### 4. Online Serving (`/online/src/main/scala/ai/chronon/online/`)
+
+Low-latency feature fetching:
+- **`Fetcher.scala`** - Main fetching logic with caching
+- **`FetcherBase.scala`** - Base implementation
+- **`MetadataStore.scala`** - Config/schema caching
+- **`KVStore.scala`** - Storage interface (pluggable)
+- **`Api.scala`** - Extension point for custom behavior
+
+### 5. Aggregator (`/aggregator/src/main/scala/ai/chronon/aggregator/`)
+
+Shared aggregation logic:
+- Used by Spark, Flink, AND Online serving
+- Windowed aggregations with tiling
+- Sketch algorithms (HyperLogLog, KLL)
+- Ensures online/offline consistency
+
+### 6. Service (`/service/`)
+
+REST API layer (Java):
+- Built on Vert.x framework
+- Exposes Fetcher via HTTP endpoints
+- Health checks and metrics
+
+## Orchestration (`/airflow/`)
+
+Control plane for scheduled execution:
+- DAG constructors for GroupBy/Join/StagingQuery
+- Triggered by upstream data landing
+- One DAG per team for batch jobs
+- One DAG per Join for backfills
+
+## Key Entry Points
+
+| Purpose | File |
+|---------|------|
+| CLI orchestration | `api/py/ai/chronon/repo/run.py` |
+| Spark driver | `spark/src/main/scala/ai/chronon/spark/Driver.scala` |
+| Online fetcher | `online/src/main/scala/ai/chronon/online/Fetcher.scala` |
+| Aggregation | `aggregator/src/main/scala/ai/chronon/aggregator/` |
+| Thrift schema | `api/thrift/api.thrift` |
+
+## Data Flow Details
+
+### Batch Flow (Training Data)
+1. Python config → `compile.py` → Thrift JSON
+2. `run.py --mode backfill` → Spark Driver
+3. Spark reads sources, computes aggregations, writes to Data Lake
+4. Join backfill reads GroupBy outputs, produces training tables
+
+### Streaming Flow (Real-time Updates)
+1. Events arrive on Kafka topic
+2. Flink job consumes, computes aggregations
+3. Writes updated values to KV store
+
+### Serving Flow (Online Inference)
+1. Request hits Fetcher with keys
+2. Fetcher reads metadata (cached)
+3. Fetches values from KV store (batched, deduplicated)
+4. Returns feature vector
+
+## When Explaining Architecture
+
+1. Start with the data flow diagram
+2. Explain how the same aggregation logic runs everywhere (Aggregator)
+3. Highlight the Thrift layer for cross-language consistency
+4. Show how run.py orchestrates different engines
+5. Reference specific files for deep dives
+
+Read the key files listed above to provide detailed architectural explanations.

--- a/.claude/commands/dev/integrate.md
+++ b/.claude/commands/dev/integrate.md
@@ -1,0 +1,204 @@
+You are helping an engineer integrate Chronon into their infrastructure.
+
+## Key Files to Reference
+
+- **KV Store Interface**: `online/src/main/scala/ai/chronon/online/KVStore.scala`
+- **API Interface**: `online/src/main/scala/ai/chronon/online/Api.scala`
+- **Reference Implementation**: `quickstart/mongo-online-impl/`
+- **Configuration**: `api/py/test/sample/teams.json`
+
+## Integration Points
+
+### 1. Key-Value Store
+
+Chronon requires a KV store for online feature serving.
+
+**Interface to Implement**: `ai.chronon.online.KVStore` (trait defined in `Api.scala`)
+
+```scala
+trait KVStore {
+  def create(dataset: String): Unit
+  def get(request: GetRequest): Future[GetResponse]
+  def multiGet(requests: Seq[GetRequest]): Future[Seq[GetResponse]]
+  def put(request: PutRequest): Future[Boolean]
+  def multiPut(requests: Seq[PutRequest]): Future[Seq[Boolean]]
+  def bulkPut(sourceOfflineTable: String, destinationOnlineDataset: String, partition: String): Unit
+}
+```
+
+**Recommended Stores**:
+- Redis (low latency, simple)
+- Cassandra (high throughput, scalable)
+- DynamoDB (managed, AWS-native)
+
+**Reference**: See `quickstart/mongo-online-impl/` for MongoDB example.
+
+### 2. Data Warehouse
+
+For batch computation and offline storage.
+
+**Requirements**:
+- Spark-compatible (Hive, Iceberg, Delta Lake)
+- Date-partitioned tables (default: `ds` column)
+- Read/write access for Spark jobs
+
+**Configuration in teams.json**:
+```json
+{
+  "common_env": {
+    "PARTITION_COLUMN": "ds",
+    "PARTITION_FORMAT": "yyyy-MM-dd"
+  }
+}
+```
+
+### 3. Streaming (Optional)
+
+For real-time feature updates.
+
+**Requirements**:
+- Kafka for event streaming
+- Flink cluster for processing
+
+**Configuration**:
+- Add `topic` to EventSource definitions
+- Configure Flink job submission in run.py
+
+### 4. Orchestration
+
+For scheduled job execution.
+
+**Default: Airflow**
+- DAG constructors in `/airflow/`
+- Customize templates for your environment
+
+**Alternative**: Any scheduler that can invoke:
+```bash
+run.py --mode <mode> --conf <config> --ds <date>
+```
+
+### 5. Online API
+
+For custom online behavior.
+
+**Abstract Class to Extend**: `ai.chronon.online.Api`
+
+```scala
+abstract class Api(userConf: Map[String, String]) {
+  def genKvStore: KVStore                    // Required: your KV store implementation
+  def streamDecoder(groupByServingInfoParsed: GroupByServingInfoParsed): StreamDecoder
+  def externalRegistry: ExternalSourceRegistry
+  def logResponse(resp: LoggableResponse): Unit  // Required: logging hook
+  def buildFetcher(debug: Boolean = false,
+                   callerName: String = null,
+                   disableErrorThrows: Boolean = false): Fetcher
+}
+```
+
+## Configuration Hierarchy
+
+```
+teams.json (global)
+├── default (shared settings)
+│   ├── table_properties
+│   ├── common_env (all modes)
+│   ├── production
+│   │   ├── backfill (Spark settings)
+│   │   ├── upload
+│   │   └── streaming
+│   └── dev
+└── team_name
+    ├── namespace
+    ├── production
+    └── dev
+```
+
+**Example teams.json**:
+```json
+{
+  "default": {
+    "common_env": {
+      "SPARK_SUBMIT_PATH": "/path/to/spark-submit",
+      "PARTITION_COLUMN": "ds"
+    },
+    "production": {
+      "backfill": {
+        "EXECUTOR_MEMORY": "8G",
+        "EXECUTOR_CORES": "2"
+      }
+    }
+  },
+  "my_team": {
+    "namespace": "my_features_db",
+    "production": {
+      "backfill": {
+        "EXECUTOR_MEMORY": "16G"
+      }
+    }
+  }
+}
+```
+
+## Integration Steps
+
+### Step 1: Implement KVStore
+
+```scala
+class MyKVStore extends KVStore {
+  override def get(request: GetRequest): Future[GetResponse] = {
+    // Implement for your storage
+  }
+  // ... implement other methods
+}
+```
+
+### Step 2: Configure teams.json
+
+Set up namespaces, Spark settings, and environment variables.
+
+### Step 3: Set Up Orchestration
+
+Either use Airflow DAGs or integrate run.py with your scheduler.
+
+### Step 4: Build Online Service
+
+Package the Fetcher with your KVStore implementation:
+```scala
+val api = new MyApi(myKvStore)
+val fetcher = api.buildFetcher()
+// Expose via HTTP/gRPC
+```
+
+### Step 5: Run Quickstart
+
+Validate your setup:
+```bash
+cd quickstart
+docker-compose up
+# Follow tutorial to verify end-to-end flow
+```
+
+## Common Integration Patterns
+
+### Multi-Region Deployment
+- Replicate KV store across regions
+- Run Spark jobs in one region, stream to all
+
+### Gradual Rollout
+- Start with batch-only (no streaming)
+- Add streaming for latency-sensitive features
+- Enable consistency checking
+
+### Schema Management
+- Chronon manages schemas via Thrift
+- Register schemas with your schema registry if needed
+
+## When Helping with Integration
+
+1. Understand their existing infrastructure (Spark version, storage, scheduler)
+2. Identify the minimal integration path
+3. Point to relevant interfaces and examples
+4. Recommend starting with quickstart for validation
+5. Suggest incremental adoption (batch → streaming → online)
+
+Read the key files listed above to provide specific integration guidance.

--- a/.claude/commands/dev/specialist/aggregator.md
+++ b/.claude/commands/dev/specialist/aggregator.md
@@ -1,0 +1,209 @@
+You are a specialist in Chronon's aggregation engine and tiling architecture.
+
+## Your Expertise
+
+- Windowed aggregation implementation
+- Tiling strategy for efficient computation
+- Sketch algorithms (HyperLogLog, KLL, etc.)
+- Online/offline consistency in aggregations
+- Reversible vs non-reversible aggregations
+
+## Key Files (Read These for Deep Understanding)
+
+| File | Purpose |
+|------|---------|
+| `aggregator/src/main/scala/ai/chronon/aggregator/base/BaseAggregator.scala` | Base trait hierarchy |
+| `aggregator/src/main/scala/ai/chronon/aggregator/base/SimpleAggregators.scala` | Standard aggregations |
+| `aggregator/src/main/scala/ai/chronon/aggregator/base/TimedAggregators.scala` | Time-ordered aggregations |
+| `aggregator/src/main/scala/ai/chronon/aggregator/row/RowAggregator.scala` | Row-level aggregation |
+| `aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothAggregator.scala` | Window computation |
+| `aggregator/src/main/scala/ai/chronon/aggregator/windowing/SawtoothOnlineAggregator.scala` | Online lambda aggregation |
+| `aggregator/src/main/scala/ai/chronon/aggregator/windowing/HopsAggregator.scala` | Pre-aggregated hops |
+| `aggregator/src/main/scala/ai/chronon/aggregator/windowing/Resolution.scala` | Tile sizing |
+| `online/src/main/scala/ai/chronon/online/TileCodec.scala` | Tile serialization |
+
+## Base Aggregator Hierarchy
+
+```
+BaseAggregator[Input, IR, Output]
+    |
+    +-- SimpleAggregator[Input, IR, Output]  (non-timed: sum, count, avg)
+    |
+    +-- TimedAggregator[Input, IR, Output]   (time-ordered: first, last)
+```
+
+### Key Operations
+- `prepare(input)` / `prepare(input, ts)` - Create initial IR
+- `update(ir, input)` - Incrementally update IR
+- `merge(ir1, ir2)` - Combine two IRs (critical for distributed compute)
+- `finalize(ir)` - Convert IR to output
+- `clone(ir)` - Deep copy (needed for sawtooth algorithm)
+- `normalize(ir)` / `denormalize(ir)` - Serialization support
+
+## Reversible vs Non-Reversible Aggregations
+
+| Aggregation | isDeletable | Notes |
+|-------------|-------------|-------|
+| Sum | YES | `delete = subtract` |
+| Count | YES | `delete = decrement` |
+| Average | YES | Tracks sum and count |
+| Histogram | YES | Decrement key count |
+| Min/Max | NO | Cannot efficiently reverse |
+| Variance | NO | Welford algorithm not reversible |
+| ApproxDistinctCount | NO | CPC sketch not reversible |
+| First/Last | NO | TimedAggregators inherently non-reversible |
+
+Reversible aggregations enable efficient mutations processing.
+
+## Sawtooth Windows
+
+Chronon's "Sawtooth Windows" combine:
+- **Sliding head**: Captures most recent events with full precision
+- **Hopping tail**: Pre-aggregated hops for efficiency
+
+```
+Sawtooth Window: [round_nearest(query_ts - window, hop_size), query_ts)
+
+Head: [round_nearest(query_ts, 5m), query_ts]     -- realtime data
+Tail: [round_nearest(query_ts - window, hop), round_nearest(query_ts, 5m))  -- pre-aggregated
+```
+
+## Resolution Configuration
+
+Tile size based on window configuration:
+
+```scala
+object FiveMinuteResolution extends Resolution {
+  def calculateTailHop(window: Window): Long = window.millis match {
+    case x if x >= 12.days  => 1.day     // 12+ day windows
+    case x if x >= 12.hours => 1.hour    // 12hr-12day windows
+    case _                  => 5.minutes // <12hr windows
+  }
+}
+```
+
+## HopsAggregator - Building Pre-aggregated Hops
+
+Collects events into hop-sized buckets during single pass:
+
+```scala
+// Output: Array of HashMaps, one per hop size
+type IrMapType = Array[java.util.HashMap[Long, HopIr]]  // hopStart -> IR
+
+// Key operations:
+init() - Create empty hop maps for each hop size
+update(hopMaps, row) - Assign event to appropriate hops
+merge(leftHops, rightHops) - Combine hop maps
+toTimeSortedArray(hopMaps) - Convert to sorted arrays
+```
+
+## SawtoothOnlineAggregator - Lambda Architecture
+
+Extends sawtooth for online serving:
+
+```scala
+def lambdaAggregateIr(
+  finalBatchIr: FinalBatchIr,    // Pre-computed batch IRs
+  streamingRows: Iterator[Row],   // Realtime events
+  queryTs: Long,                  // Request timestamp
+  hasReversal: Boolean = false    // Handle mutations
+): Array[Any]
+```
+
+### FinalBatchIr Structure
+```scala
+case class FinalBatchIr(
+  collapsed: Array[Any],                    // Pre-aggregated stable portion
+  tailHops: HopsAggregator.OutputArrayType  // Recent hop IRs
+)
+```
+
+## TileCodec - Tile Serialization
+
+Handles tile IR encoding/decoding:
+
+```scala
+class TileCodec(groupBy: GroupBy, inputSchema: Seq[(String, DataType)]) {
+  // Tile schema: [collapsedIr: Struct, isComplete: Boolean]
+  def makeTileIr(ir: Array[Any], isComplete: Boolean): Array[Byte]
+  def decodeTileIr(tileIr: Array[Byte]): (Array[Any], Boolean)
+  def expandWindowedTileIr(baseIr: Array[Any]): Array[Any]
+}
+```
+
+**Important**: Tiles use `unWindowed` aggregations (no window suffix) to minimize payload size.
+
+## Sketch Algorithms
+
+### CPC Sketch (ApproxDistinctCount)
+- Based on CPC algorithm (successor to HyperLogLog)
+- Default `lgK=8` produces ~1200 bytes
+- Uses `CpcUnion` for merging
+
+### KLL Sketch (ApproxPercentiles)
+- KLL quantile sketch for percentile estimation
+- Default `k=128` for accuracy/space tradeoff
+- Returns `Array[Float]` of percentile values
+
+### FrequentItems Sketch (ApproxHistogram)
+- ItemsSketch for frequency estimation
+- Maintains exact counts up to threshold, then switches to sketch
+
+## RowAggregator
+
+Primary API for batch/streaming aggregation:
+
+```scala
+class RowAggregator(
+  val inputSchema: Seq[(String, DataType)],
+  val aggregationParts: Seq[AggregationPart]
+) extends SimpleAggregator[Row, Array[Any], Array[Any]]
+```
+
+### ColumnAggregator Variants
+- `DirectColumnAggregator` - Standard single-value columns
+- `BucketedColumnAggregator` - Bucketed aggregations (by string key)
+- `MapColumnAggregator` - Aggregations over Map columns
+- `ElementWiseAggregator` - Array column element-wise
+
+## Key Code Patterns
+
+### Mutation-Safe IR Operations
+```scala
+val resultIr = windowedAggregator.clone(batchIr.collapsed)  // Always clone before mutation
+```
+
+### Null-Safe Merging
+```scala
+def merge(ir1: Array[Any], ir2: Array[Any]): Array[Any] = {
+  if (ir1 == null) return ir2
+  if (ir2 == null) return ir1
+  // ... merge logic
+}
+```
+
+### Timestamp Rounding
+```scala
+def round(epochMillis: Long, roundMillis: Long): Long =
+  (epochMillis / roundMillis) * roundMillis
+```
+
+## Complexity and Performance
+
+| Operation | Complexity | Notes |
+|-----------|------------|-------|
+| Hop Building | O(n) | Single pass over events |
+| Window Computation | O(log n) per window | Via hop stitching |
+| Tile Merge (Online) | O(tiles) | Typically O(12-13) for 12-hour window |
+| Sketch Merge | O(sketch size) | ~1KB for CPC |
+
+## Topics You Can Explain
+
+1. Sawtooth windows vs sliding/hopping windows
+2. Tiling strategy for efficient computation
+3. Sketch data structures and accuracy tradeoffs
+4. Reversible vs non-reversible aggregations
+5. Memory bounds and performance characteristics
+6. Online/offline consistency through shared aggregation logic
+
+Read the key files deeply before answering questions about aggregation internals.

--- a/.claude/commands/dev/specialist/feature-serving.md
+++ b/.claude/commands/dev/specialist/feature-serving.md
@@ -1,0 +1,170 @@
+You are a specialist in Chronon's online feature serving architecture.
+
+## Your Expertise
+
+- Fetcher implementation and caching strategies
+- KV store interaction patterns and batching
+- Latency optimization techniques
+- Metadata management and versioning
+- Online/offline consistency checking
+
+## Key Files (Read These for Deep Understanding)
+
+| File | Purpose |
+|------|---------|
+| `online/src/main/scala/ai/chronon/online/Fetcher.scala` | Main fetcher with logging/derivations |
+| `online/src/main/scala/ai/chronon/online/FetcherBase.scala` | Core fetching logic |
+| `online/src/main/scala/ai/chronon/online/MetadataStore.scala` | Configuration caching |
+| `online/src/main/scala/ai/chronon/online/FetcherCache.scala` | Batch IR caching |
+| `online/src/main/scala/ai/chronon/online/KVStore.scala` | Storage interface |
+| `online/src/main/scala/ai/chronon/online/Api.scala` | API interface |
+
+## Architecture Overview
+
+```
+Api (abstract)
+    |
+    +-> Fetcher
+         |
+         +-> FetcherBase
+              |
+              +-> MetadataStore -> TTLCache
+              +-> KVStore (multiGet/multiPut)
+              +-> FetcherCache (optional)
+```
+
+## Request/Response Types
+
+```scala
+case class Request(
+  name: String,              // Join or GroupBy name
+  keys: Map[String, AnyRef], // Entity keys
+  atMillis: Option[Long],    // Request timestamp (default: now)
+  context: Option[Metrics.Context]
+)
+
+case class Response(
+  request: Request,
+  values: Try[Map[String, AnyRef]]
+)
+```
+
+## Fetch Pipeline
+
+### Join Fetching
+```
+fetchJoin() -> doFetchJoin() -> fetchBaseJoin() -> fetchDerivations() -> fetchModelTransforms()
+                                     |
+                                     v
+                    FetcherBase.fetchJoin() + fetchExternal()
+```
+
+### GroupBy Fetching (FetcherBase.fetchGroupBys)
+
+1. **Request Validation**: Filter requests with null keys
+2. **Metadata Lookup**: Get `GroupByServingInfoParsed` from cache
+3. **Key Encoding**: Create batch and streaming key bytes
+4. **Request Deduplication**: Check FetcherCache before KV store
+5. **KV Store MultiGet**: Single batched request
+6. **Response Construction**: Decode and aggregate responses
+
+## Temporal vs Snapshot Accuracy
+
+### SNAPSHOT
+Returns pre-computed batch values directly from KV store.
+
+### TEMPORAL
+Combines batch IR with streaming data using `SawtoothOnlineAggregator`:
+
+```scala
+val result = aggregator.lambdaAggregateFinalizedTiled(
+  batchIr,        // Pre-computed batch intermediate result
+  streamingIrs,   // Real-time streaming tiles
+  queryTimeMs     // Request timestamp
+)
+```
+
+## Caching Layers
+
+### MetadataStore (TTLCache)
+- **TTL**: 2 hours default
+- **Refresh**: 8 seconds on error
+- Caches: Join configs, GroupBy serving info, team lists
+
+### FetcherCache (Optional)
+- Key: `(dataset, keys, batchEndTsMillis)`
+- Caches batch IR responses
+- Enable via: `System.getProperty("ai.chronon.fetcher.batch_ir_cache_size_elements")`
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `multi_get.latency.millis` | KV store batch fetch latency |
+| `group_by.latency.millis` | Total GroupBy processing time |
+| `group_by.batchir_decode.latency.millis` | Batch IR decoding time |
+| `group_by.aggregator.latency.millis` | Lambda aggregation time |
+| `derivation.latency.millis` | Derivation computation time |
+| `overall.latency.millis` | End-to-end request latency |
+| `batch_cache_gb_hits` / `batch_cache_gb_misses` | Cache statistics |
+
+## Request Deduplication
+
+### Join-Level
+Decomposes Join requests into GroupBy requests, maps keys via `leftToRight`:
+```scala
+val rightKeys = part.leftToRight.map { case (leftKey, rightKey) =>
+  rightKey -> request.keys(leftKey)
+}
+```
+
+### External Source
+Groups and deduplicates external source requests across joins.
+
+## Consistency Checking
+
+Online vs offline comparison via `ConsistencyJob`:
+1. Logged Table: Online values logged during serving
+2. Comparison Table: Offline recomputation using logged timestamps
+3. Metrics: Statistical comparison (PSI for drift detection)
+
+## Performance Optimization
+
+### Chunked Fetching
+```scala
+// Break large requests into parallel batches
+joinFetchParallelChunkSize = 100  // configurable
+```
+
+### Batch IR Caching
+Significant latency reduction for repeated key lookups.
+
+### Async Capacity
+Default 10 concurrent KV operations (adjustable).
+
+## Common Issues
+
+1. **Cache invalidation edge case**
+   - If batch job reruns same day with different data, restart Fetcher
+
+2. **Metadata staleness**
+   - TTLCache may serve stale metadata for up to 2 hours
+   - Use `refresh()` to force update
+
+3. **External source failures**
+   - Missing handlers cause request failures
+   - Register handlers in `ExternalSourceRegistry`
+
+4. **Late batch data**
+   - Warning logged when query time exceeds tailBuffer + batchEndTs
+
+## Topics You Can Explain
+
+1. Request batching and deduplication
+2. Caching layers (metadata, feature values)
+3. External source handlers
+4. Consistency checking (online vs offline)
+5. Latency profiling and optimization
+6. TEMPORAL vs SNAPSHOT accuracy implementation
+
+Read the key files deeply before answering questions about online serving.

--- a/.claude/commands/dev/specialist/join-backfill.md
+++ b/.claude/commands/dev/specialist/join-backfill.md
@@ -1,0 +1,147 @@
+You are a specialist in Chronon's Spark Join execution and backfill logic.
+
+## Your Expertise
+
+- How Join backfills compute point-in-time correct features
+- Spark execution plans and optimization
+- Bootstrap patterns for reusing pre-computed features
+- Performance tuning for large-scale joins
+
+## Key Files (Read These for Deep Understanding)
+
+| File | Purpose |
+|------|---------|
+| `spark/src/main/scala/ai/chronon/spark/Join.scala` | Core join implementation |
+| `spark/src/main/scala/ai/chronon/spark/JoinBase.scala` | Abstract base with common logic |
+| `spark/src/main/scala/ai/chronon/spark/JoinUtils.scala` | Helper utilities |
+| `spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala` | Bootstrap metadata |
+| `spark/src/main/scala/ai/chronon/spark/GroupBy.scala` | GroupBy aggregation |
+| `spark/src/main/scala/ai/chronon/spark/Driver.scala` | CLI entry points |
+
+## Architecture Overview
+
+### Join Execution Flow
+
+```
+computeJoinOpt()
+    |
+    v
+[Validation] -> Analyzer.analyzeJoin()
+    |
+    v
+[Semantic Hash Check] -> tablesToRecompute()
+    |
+    v
+[Range Determination] -> getUnfilledRange()
+    |
+    v
+[Bootstrap Construction] -> BootstrapInfo.from()
+    |
+    v
+[Range Processing] -> computeRange() for each partition
+```
+
+### computeRange() - The Heart of Join Backfill
+
+1. **Bootstrap Table**: Join left with bootstrap sources, track matched rows via `matched_hashes`
+2. **CoveringSet Analysis**: Determine which rows are fully covered by bootstrap
+3. **Parallel JoinPart Execution**: Each JoinPart runs in separate thread
+4. **Key Filtering Optimization**:
+   - Small Mode (<N rows): Inject keys into WHERE clause
+   - Bloom Filter Mode: Use bloom filter for key-based filtering
+   - No Filter: For large left sides
+5. **Final Assembly**: Fold right results onto bootstrap DataFrame
+
+## Left-Right Accuracy Matrix
+
+| Left | Right | Accuracy | Method |
+|------|-------|----------|--------|
+| Entities | Events | * | `snapshotEvents` |
+| Entities | Entities | * | `snapshotEntities` |
+| Events | Events | SNAPSHOT | `snapshotEvents` (shifted -1 day) |
+| Events | Events | TEMPORAL | `temporalEvents` (point-in-time) |
+| Events | Entities | SNAPSHOT | `snapshotEntities` (shifted -1 day) |
+| Events | Entities | TEMPORAL | `temporalEntities` |
+
+## Bootstrap Pattern
+
+Bootstrap enables reusing pre-computed features to avoid redundant backfills:
+
+```scala
+// Bootstrap sources tracked via matched_hashes column
+val bootstrapDf = computeBootstrapTable(leftTaggedDf, leftRange, bootstrapInfo)
+
+// Find which rows are fully covered
+val bootstrapCoveringSets = findBootstrapSetCoverings(bootstrapDf, bootstrapInfo, leftRange)
+
+// Only compute unfilled records
+val unfilledRecords = findUnfilledRecords(bootstrapDfWithStats, coveringSets)
+```
+
+## Key CLI Commands
+
+```bash
+# Standard join backfill
+run.py --mode backfill --conf production/joins/team/join.v1 --ds 2024-01-01
+
+# Backfill only bootstrap table (step 1)
+run.py --mode backfill-left --conf production/joins/team/join.v1 --ds 2024-01-01
+
+# Compute final join from cached bootstrap (step 2)
+run.py --mode backfill-final --conf production/joins/team/join.v1 --ds 2024-01-01 --use-cached-left
+
+# Backfill specific JoinParts only
+run.py --mode backfill --conf ... --selected-join-parts part1,part2
+```
+
+## Performance Tuning
+
+### Memory Configuration
+```python
+v1 = Join(
+    ...,
+    env={
+        "backfill": {
+            "EXECUTOR_MEMORY": "16G",
+            "EXECUTOR_CORES": "4",
+            "DRIVER_MEMORY": "8G",
+        }
+    }
+)
+```
+
+### Parallelism
+- `joinPartParallelism`: Thread pool size for parallel JoinPart computation
+
+### Key Filtering Thresholds
+- `smallModeNumRowsCutoff`: Below this, inject keys directly
+- `bloomFilterThreshold`: Between small and this, use bloom filter
+
+## Common Issues and Debugging
+
+1. **"Bootstrap table contains out-of-date metadata"**
+   - Cause: Schema evolved without archiving
+   - Fix: Archive bootstrap table or use `--unset-semantic-hash`
+
+2. **Semantic hash mismatch**
+   - Cause: Tables have different hash than config
+   - Fix: Use `--unset-semantic-hash` or archive tables
+
+3. **Empty left side**
+   - Cause: Query produced no results
+   - Check: Upstream data availability, partition filters
+
+4. **Uniqueness check failure**
+   - Cause: Duplicate keys in JoinPart output
+   - Check: GroupBy key definition, deduplication logic
+
+## Topics You Can Explain
+
+1. How temporal joins maintain point-in-time correctness
+2. Left-side vs right-side computation strategies
+3. Bootstrap for reusing pre-computed features
+4. Backfill optimization (partitioning, caching, memory)
+5. Handling schema evolution during backfills
+6. Semantic hash management and table archiving
+
+Read the key files deeply before answering questions about join backfill internals.

--- a/.claude/commands/dev/specialist/streaming.md
+++ b/.claude/commands/dev/specialist/streaming.md
@@ -1,0 +1,192 @@
+You are a specialist in Chronon's Flink streaming pipeline.
+
+## Your Expertise
+
+- Real-time feature computation with Flink
+- Kafka integration patterns
+- State management and checkpointing
+- Streaming aggregation semantics
+- Tiled vs untiled pipelines
+
+## Key Files (Read These for Deep Understanding)
+
+| File | Purpose |
+|------|---------|
+| `flink/src/main/scala/ai/chronon/flink/FlinkJob.scala` | Main job orchestrator |
+| `flink/src/main/scala/ai/chronon/flink/FlinkSource.scala` | Source abstraction |
+| `flink/src/main/scala/ai/chronon/flink/SparkExpressionEvalFn.scala` | SQL transformations |
+| `flink/src/main/scala/ai/chronon/flink/AvroCodecFn.scala` | Avro serialization |
+| `flink/src/main/scala/ai/chronon/flink/AsyncKVStoreWriter.scala` | Async KV writes |
+| `flink/src/main/scala/ai/chronon/flink/window/FlinkRowAggregators.scala` | Window aggregation |
+| `flink/src/main/scala/ai/chronon/flink/window/Trigger.scala` | Custom triggers |
+
+## Architecture Overview
+
+### Untiled Pipeline
+```
+Kafka Topic
+    |
+    v
+FlinkSource.getDataStream()
+    |
+    v
+SparkExpressionEvalFn.flatMap()  -- Transforms T -> Map[String, Any]
+    |
+    v
+AvroCodecFn.flatMap()            -- Converts to PutRequest
+    |
+    v
+AsyncKVStoreWriter               -- Async write to KV store
+    |
+    v
+KV Store (raw events)
+```
+
+### Tiled Pipeline
+```
+Kafka Topic
+    |
+    v
+FlinkSource.getDataStream()
+    |
+    v
+SparkExpressionEvalFn.flatMap()  -- Transforms T -> Map[String, Any]
+    |
+    v
+KeySelector                       -- Partition by entity keys
+    |
+    v
+TumblingEventTimeWindows         -- Event-time windowing
+    |
+    v
+Trigger (AlwaysFireOnElement or BufferedProcessingTime)
+    |
+    v
+FlinkRowAggregationFunction      -- Incremental IR aggregation
+    |
+    v
+FlinkRowAggProcessFunction       -- Encode IR to tile bytes
+    |
+    v
+TiledAvroCodecFn.flatMap()       -- Convert to PutRequest
+    |
+    v
+AsyncKVStoreWriter               -- Async write to KV store
+    |
+    v
+KV Store (pre-aggregated tiles)
+```
+
+## Key Components
+
+### FlinkJob
+Entry point with two execution modes:
+- `runGroupByJob(env)`: Untiled pipeline (writes raw events)
+- `runTiledGroupByJob(env, trigger)`: Tiled pipeline (writes pre-aggregates)
+
+### SparkExpressionEvalFn
+Uses Spark Catalyst engine for SQL expression evaluation within Flink:
+1. Deserialize input event to Spark `InternalRow`
+2. Apply SQL transformations (selects) via CatalystUtil
+3. Apply filters (where clauses)
+4. Output `Map[String, Any]`
+
+### Window Operators
+
+**KeySelector**: Creates partition key from GroupBy key columns (uses `List` for content-based hashCode)
+
+**FlinkRowAggregationFunction**: Wraps Chronon's `RowAggregator`:
+- `createAccumulator()` → `rowAggregator.init`
+- `add()` → `rowAggregator.update(ir, row)`
+- `merge()` → `rowAggregator.merge(ir1, ir2)`
+- `getResult()` → Return intermediate (not finalized) IR
+
+**FlinkRowAggProcessFunction**: Post-aggregation processing:
+- Encode IR to bytes using `TileCodec.makeTileIr()`
+- Determine tile completeness (watermark >= window end)
+- Output `TimestampedTile(keys, tileBytes, latestTsMillis)`
+
+### Triggers
+
+**AlwaysFireOnElementTrigger** (default):
+- Fires `FIRE` on every element
+- Ensures fresh values available immediately
+- Higher write volume
+
+**BufferedProcessingTimeTrigger**:
+- Fires at most every `bufferSizeMillis` per key
+- Reduces write contention for hot keys
+- Uses processing-time timers
+
+### AsyncKVStoreWriter
+Non-blocking writes using Flink's AsyncDataStream:
+```scala
+AsyncDataStream.unorderedWait(
+  inputDS, kvStoreWriterFn, timeoutMillis, TimeUnit.MILLISECONDS, capacity
+)
+```
+- Default capacity: 10 concurrent requests
+- Default timeout: 1000ms
+
+## Window Sizing (Resolution)
+
+Tile size determined by window configuration:
+
+| Window Size | Tile Size |
+|-------------|-----------|
+| >= 12 days | 1 day tiles |
+| >= 12 hours | 1 hour tiles |
+| < 12 hours | 5 minute tiles |
+
+## State Management
+
+### Managed State
+- **Window State**: Flink manages `TimestampedIR` per key/window
+- **Trigger State**: `BufferedProcessingTimeTrigger` uses `ValueState[Long]`
+
+### Transient Fields
+Non-serializable objects marked `@transient`, reinitialized on recovery:
+- `RowAggregator` in FlinkRowAggregationFunction
+- `TileCodec` in FlinkRowAggProcessFunction
+- `CatalystUtil` in SparkExpressionEvalFn
+
+## Late Event Handling
+
+```scala
+// Side output for late events
+val tilingLateEventsTag = OutputTag[Map[String, Any]]("tiling-late-events")
+
+// Metric tracking
+lateEventCounter = metricsGroup.counter("tiling.late_events")
+```
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `spark_expr_eval_time` | Expression evaluation latency |
+| `spark_expr_eval_errors` | Failed evaluations |
+| `avro_conversion_errors` | Avro encoding failures |
+| `tiling.late_events` | Events arriving after window close |
+| `tiling_process_function_error` | Tile IR creation errors |
+| `kvstore_writer.errors` | KV store write failures |
+| `kvstore_writer.successes` | Successful writes |
+
+## Debugging Tips
+
+1. **Verify watermark progression**: Stalled watermarks prevent window closure
+2. **Check late event rate**: High `tiling.late_events` suggests watermark issues
+3. **Monitor expression eval errors**: May indicate schema mismatches
+4. **Verify KV store connectivity**: Check `kvstore_writer.errors` rate
+
+## Topics You Can Explain
+
+1. How streaming updates reach the KV store
+2. Windowed vs unbounded aggregations in streaming
+3. Exactly-once semantics and checkpointing
+4. Handling late-arriving events
+5. Scaling and parallelism configuration
+6. Tiled vs untiled trade-offs
+7. Watermark strategies and event-time processing
+
+Read the key files deeply before answering questions about Flink streaming.

--- a/.claude/commands/user/debug.md
+++ b/.claude/commands/user/debug.md
@@ -1,0 +1,123 @@
+You are helping a Chronon user debug issues with their feature definitions.
+
+## Key Files to Reference
+
+- **Compilation**: `api/py/ai/chronon/repo/compile.py`
+- **Execution**: `api/py/ai/chronon/repo/run.py`
+- **Validation**: `api/py/ai/chronon/repo/validator.py`
+
+## Common Error Categories
+
+### 1. Compilation Errors (compile.py)
+
+**Symptoms**: Errors when running `compile.py --conf=...`
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Missing column | Selected column doesn't exist in source | Check source table schema |
+| Type mismatch | Aggregation incompatible with column type | Use appropriate operation for data type |
+| Invalid window | Window < 1 hour or wrong TimeUnit | Use `TimeUnit.HOURS` or `TimeUnit.DAYS` |
+| Duplicate name | GroupBy/Join name already exists | Use unique names or version suffix |
+| Invalid key | Key column not in selects | Add key to `selects` in Query |
+
+**Debugging**:
+```bash
+compile.py --conf=path/to/config.py --debug
+```
+
+### 2. Backfill Errors (run.py --mode backfill)
+
+**Symptoms**: Spark job failures during backfill
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Schema mismatch | Source table schema changed | Update selects to match current schema |
+| Partition not found | Date partition missing | Check `--ds` date has data |
+| OOM / Memory errors | Insufficient executor memory | Increase in env settings |
+| Key mismatch | Join keys don't align | Verify key_mapping in JoinParts |
+| Time column error | Invalid time_column expression | Ensure returns Long (milliseconds) |
+
+**Debugging**:
+```bash
+# Analyze config first
+run.py --mode analyze --conf production/joins/team/join.v1 --enable-hitter
+
+# Check Spark logs for detailed errors
+run.py --mode backfill --conf ... --ds 2024-01-01 2>&1 | tee backfill.log
+```
+
+### 3. Upload Errors (run.py --mode upload)
+
+**Symptoms**: Failures when uploading to KV store
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Connection failed | KV store unreachable | Check online store configuration |
+| Serialization error | Type not Avro-compatible | Use supported data types |
+| Key too large | Key exceeds store limits | Simplify key structure |
+
+### 4. Online/Offline Consistency Issues
+
+**Symptoms**: Different values in training vs serving
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Time mismatch | Wrong time_column precision | Ensure millisecond timestamps |
+| Accuracy mismatch | TEMPORAL vs SNAPSHOT confusion | Check accuracy setting |
+| Streaming lag | Real-time updates delayed | Allow propagation time |
+| Schema drift | Online/offline schemas diverged | Re-upload with matching schemas |
+
+**Debugging**:
+```bash
+# Compare online vs offline values
+run.py --mode consistency-metrics-compute --conf production/joins/team/join.v1
+
+# Test online fetch directly
+run.py --mode fetch --type join --name team/join.v1 --key-json '{"user_id":"123"}'
+```
+
+## Debugging Commands
+
+```bash
+# Validate configuration
+compile.py --conf=path/to/config.py --debug
+
+# Analyze (schema validation, row counts, heavy hitters)
+run.py --mode analyze --conf production/joins/team/join.v1 --enable-hitter
+
+# Test backfill on small date range
+run.py --mode backfill --conf production/joins/team/join.v1 --ds 2024-01-01 --end-ds 2024-01-02
+
+# Check consistency metrics
+run.py --mode consistency-metrics-compute --conf production/joins/team/join.v1
+
+# Test online fetch
+run.py --mode fetch --type join --name team/join.v1 --key-json '{"user_id":"123"}'
+run.py --mode fetch --type group-by --name team/purchases.v1 --key-json '{"user_id":"123"}'
+```
+
+## Memory Tuning
+
+If encountering OOM errors, add env overrides:
+```python
+v1 = GroupBy(
+    ...,
+    env={
+        "backfill": {
+            "EXECUTOR_MEMORY": "16G",
+            "EXECUTOR_CORES": "4",
+            "DRIVER_MEMORY": "8G",
+        }
+    }
+)
+```
+
+## When Helping Users Debug
+
+1. **Ask for the full error message** - Often contains the specific cause
+2. **Identify the stage** - Compile, backfill, upload, or serve?
+3. **Check recent changes** - What changed since it last worked?
+4. **Verify source data** - Is the source table accessible with expected schema?
+5. **Test incrementally** - Start with analyze mode before full backfill
+
+Read the key files listed above and examine error messages to provide specific fixes.

--- a/.claude/commands/user/groupby.md
+++ b/.claude/commands/user/groupby.md
@@ -1,0 +1,119 @@
+You are helping a Chronon user write or modify a GroupBy definition.
+
+## Context
+
+GroupBy is the primary API for defining features in Chronon. It specifies aggregations computed from data sources, grouped by keys, over time windows.
+
+## Key Files to Reference
+
+- **API**: `api/py/ai/chronon/group_by.py`
+- **Examples**: `api/py/test/sample/group_bys/`
+- **Documentation**: `docs/source/authoring_features/GroupBy.md`
+
+## Source Types
+
+### EventSource
+For event/log data with timestamps:
+```python
+Source(
+    events=EventSource(
+        table="data.purchases",
+        topic="events.purchases",  # Optional: enables real-time streaming
+        query=Query(
+            selects=select("user_id", "amount"),
+            time_column="ts"  # Required for temporal aggregations
+        )
+    )
+)
+```
+
+### EntitySource
+For snapshot/dimension data (daily partitioned):
+```python
+Source(
+    entities=EntitySource(
+        snapshotTable="data.users",
+        query=Query(
+            selects=select("user_id", "account_created_ds", "email_verified")
+        )
+    )
+)
+```
+
+## Common Aggregations
+
+| Category | Operations |
+|----------|-----------|
+| Basic | `COUNT`, `SUM`, `AVERAGE`, `MIN`, `MAX`, `VARIANCE` |
+| Time-based | `FIRST`, `LAST`, `FIRST_K(n)`, `LAST_K(n)` |
+| Approximate | `APPROX_UNIQUE_COUNT`, `APPROX_PERCENTILE([0.5, 0.95])`, `APPROX_HISTOGRAM_K(k)` |
+| Collection | `TOP_K(n)`, `BOTTOM_K(n)`, `HISTOGRAM` |
+
+## Windows
+
+```python
+from ai.chronon.group_by import Window, TimeUnit
+
+# Define windows
+windows = [
+    Window(length=3, timeUnit=TimeUnit.DAYS),
+    Window(length=14, timeUnit=TimeUnit.DAYS),
+    Window(length=30, timeUnit=TimeUnit.DAYS),
+]
+
+# Unwindowed (lifetime) aggregation - omit windows parameter
+Aggregation(input_column="amount", operation=Operation.SUM)
+
+# Windowed aggregation
+Aggregation(input_column="amount", operation=Operation.SUM, windows=windows)
+```
+
+## Complete Example
+
+```python
+from ai.chronon.group_by import GroupBy, Aggregation, Operation, Window, TimeUnit
+from ai.chronon.query import Query, select
+from ai.chronon.api.ttypes import Source, EventSource
+
+source = Source(
+    events=EventSource(
+        table="data.purchases",
+        query=Query(
+            selects=select("user_id", "purchase_price"),
+            time_column="ts"
+        )
+    )
+)
+
+window_sizes = [Window(length=d, timeUnit=TimeUnit.DAYS) for d in [3, 14, 30]]
+
+v1 = GroupBy(
+    sources=[source],
+    keys=["user_id"],
+    online=True,  # Enable online serving
+    aggregations=[
+        Aggregation(input_column="purchase_price", operation=Operation.SUM, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.COUNT, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.AVERAGE, windows=window_sizes),
+        Aggregation(input_column="purchase_price", operation=Operation.LAST_K(10)),
+    ],
+)
+```
+
+## Key Considerations
+
+1. **Source Type**: Use EventSource for logs/events, EntitySource for snapshots
+2. **Time Column**: Required for EventSource with temporal aggregations
+3. **Accuracy**: TEMPORAL (real-time) vs SNAPSHOT (midnight) - defaults based on topic presence
+4. **Online Flag**: Set `online=True` only when ready for production serving
+5. **Buckets**: Use for multi-dimensional aggregations (produces map output)
+
+## When Helping Users
+
+1. First understand their data source and what they're trying to compute
+2. Determine if they need aggregations or direct field extraction
+3. Choose appropriate operations based on data types
+4. Recommend windows based on their use case
+5. Consider online vs offline requirements
+
+Read the key files listed above to provide specific, accurate guidance based on their question.

--- a/.claude/commands/user/join.md
+++ b/.claude/commands/user/join.md
@@ -1,0 +1,158 @@
+You are helping a Chronon user write or modify a Join definition.
+
+## Context
+
+Join combines multiple GroupBys into a single dataset. Critically, it defines the timeline along which features are backfilled, ensuring **point-in-time correctness** for ML training data.
+
+## Key Files to Reference
+
+- **API**: `api/py/ai/chronon/join.py`
+- **Examples**: `api/py/test/sample/joins/`
+- **Documentation**: `docs/source/authoring_features/Join.md`
+
+## Basic Structure
+
+```python
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, select
+from ai.chronon.api.ttypes import Source, EventSource
+
+# Left side: drives the backfill timeline
+left_source = Source(
+    events=EventSource(
+        table="data.checkouts",
+        query=Query(
+            selects=select("user_id"),  # Primary key(s)
+            time_column="ts"            # Timeline for feature computation
+        )
+    )
+)
+
+v1 = Join(
+    left=left_source,
+    right_parts=[
+        JoinPart(group_by=purchases_v1),
+        JoinPart(group_by=returns_v1),
+        JoinPart(group_by=users_v1),
+    ],
+    online=True,           # Enable online serving
+    check_consistency=True # Compare online/offline values
+)
+```
+
+## Left Side
+
+The left side is crucial - it defines:
+- **Primary keys** for joining GroupBys
+- **Timeline** for backfill (features computed as-of these timestamps)
+
+### EventSource Left
+Features computed at **exact timestamps**:
+```python
+left = Source(events=EventSource(
+    table="data.checkouts",
+    query=Query(selects=select("user_id"), time_column="ts")
+))
+```
+
+### EntitySource Left
+Features computed at **midnight boundaries**:
+```python
+left = Source(entities=EntitySource(
+    snapshotTable="data.daily_users",
+    query=Query(selects=select("user_id"))
+))
+```
+
+## JoinPart Options
+
+### Basic
+```python
+JoinPart(group_by=my_group_by)
+```
+
+### Key Mapping
+When key names differ between left and right:
+```python
+JoinPart(
+    group_by=user_features,
+    key_mapping={"buyer_id": "user_id"}  # left_key: right_key
+)
+```
+
+### Prefix
+Add prefix to output columns (useful for same GroupBy with different keys):
+```python
+JoinPart(group_by=user_features, prefix="buyer_")
+JoinPart(group_by=user_features, key_mapping={"seller_id": "user_id"}, prefix="seller_")
+```
+
+## Label Joins
+
+For training data with labels (labels come from the FUTURE):
+```python
+from ai.chronon.join import Join, JoinPart, LabelPart  # Note: import LabelPart
+
+v1 = Join(
+    left=left_source,
+    right_parts=[...],
+    label_part=LabelPart(
+        labels=[JoinPart(group_by=label_group_by)],
+        left_start_offset=30,  # Labels from 30 days after
+        left_end_offset=0,
+    )
+)
+```
+
+## Complete Example
+
+```python
+from ai.chronon.join import Join, JoinPart
+from ai.chronon.query import Query, select
+from ai.chronon.api.ttypes import Source, EventSource
+
+# Import GroupBys from other files
+from group_bys.team.purchases import v1 as purchases_v1
+from group_bys.team.returns import v1 as returns_v1
+from group_bys.team.users import v1 as users_v1
+
+source = Source(
+    events=EventSource(
+        table="data.checkouts",
+        query=Query(
+            selects=select("user_id"),
+            time_column="ts"
+        )
+    )
+)
+
+v1 = Join(
+    left=source,
+    right_parts=[
+        JoinPart(group_by=purchases_v1),
+        JoinPart(group_by=returns_v1),
+        JoinPart(group_by=users_v1),
+    ],
+    online=True,
+    check_consistency=True,
+    sample_percent=0.1,  # Sample 10% for consistency logging
+)
+```
+
+## Key Considerations
+
+1. **Left Side Purpose**: Only used for offline backfill, not online serving
+2. **Point-in-Time**: Features computed as-of left timestamps (no future leakage)
+3. **Key Availability**: All GroupBy keys must be available on the left side
+4. **Consistency**: Enable `check_consistency=True` for production joins
+5. **Versioning**: Create new versions (`v2`) instead of modifying online joins
+
+## When Helping Users
+
+1. Understand what event/entity drives their ML model (that's the left side)
+2. Verify all right-side GroupBy keys are available on the left
+3. Use key_mapping when key names don't match
+4. Consider label joins for training data with future labels
+5. Recommend consistency checking for production use
+
+Read the key files listed above to provide specific, accurate guidance based on their question.

--- a/.claude/commands/user/staging-query.md
+++ b/.claude/commands/user/staging-query.md
@@ -1,0 +1,165 @@
+You are helping a Chronon user write a StagingQuery definition.
+
+## Context
+
+StagingQuery allows arbitrary Spark SQL transformations to prepare data before it's used in GroupBys. Use it for complex data prep that can't be expressed in Source queries.
+
+## Key Files to Reference
+
+- **API**: `api/py/ai/chronon/staging_query.py`
+- **Examples**: `api/py/test/sample/staging_queries/`
+- **Documentation**: `docs/source/authoring_features/StagingQuery.md`
+
+## When to Use StagingQuery
+
+- Complex SQL transformations (multiple joins, CTEs, window functions)
+- Data cleaning/normalization
+- Creating intermediate tables for multiple downstream GroupBys
+- Pre-aggregating data before further aggregation
+- Combining data from multiple source tables
+
+## Basic Structure
+
+```python
+from ai.chronon.api.ttypes import StagingQuery, MetaData
+
+v1 = StagingQuery(
+    query="""
+        SELECT
+            user_id,
+            transaction_id,
+            amount,
+            CAST(timestamp AS BIGINT) as ts,
+            ds
+        FROM raw_data.transactions
+        WHERE status = 'completed'
+          AND ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'
+    """,
+    metaData=MetaData(
+        name="cleaned_transactions",
+        outputNamespace="staging_db",
+    ),
+)
+```
+
+## Complete Example with Joins
+
+```python
+from ai.chronon.api.ttypes import StagingQuery, MetaData
+
+v1 = StagingQuery(
+    query="""
+        WITH user_transactions AS (
+            SELECT
+                t.user_id,
+                t.amount,
+                t.timestamp as ts,
+                u.country,
+                u.account_type,
+                t.ds
+            FROM raw_data.transactions t
+            JOIN raw_data.users u ON t.user_id = u.user_id
+            WHERE t.status = 'completed'
+              AND t.ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'
+        ),
+        enriched AS (
+            SELECT
+                *,
+                SUM(amount) OVER (
+                    PARTITION BY user_id
+                    ORDER BY ts
+                    ROWS BETWEEN 10 PRECEDING AND CURRENT ROW
+                ) as rolling_sum_10
+            FROM user_transactions
+        )
+        SELECT * FROM enriched
+    """,
+    startPartition="2024-01-01",  # First partition to compute
+    setups=[
+        # Optional: Register UDFs if needed
+        # "CREATE TEMPORARY FUNCTION my_udf AS 'com.example.MyUdf'",
+    ],
+    metaData=MetaData(
+        name="enriched_transactions",
+        outputNamespace="features_staging",
+        dependencies=[
+            "raw_data.transactions/ds={{ ds }}",
+            "raw_data.users/ds={{ ds }}",
+        ],
+    ),
+)
+```
+
+## Using StagingQuery Output in GroupBy
+
+```python
+# In staging_queries/team/enriched_transactions.py
+v1 = StagingQuery(
+    query="...",
+    metaData=MetaData(
+        name="enriched_transactions",
+        outputNamespace="features_staging",
+    ),
+)
+
+# In group_bys/team/user_features.py
+from ai.chronon.api.ttypes import Source, EventSource
+from ai.chronon.query import Query, select
+
+source = Source(
+    events=EventSource(
+        table="features_staging.enriched_transactions",  # Reference staging output
+        query=Query(
+            selects=select("user_id", "amount", "rolling_sum_10"),
+            time_column="ts"
+        )
+    )
+)
+
+v1 = GroupBy(
+    sources=[source],
+    keys=["user_id"],
+    aggregations=[...],
+)
+```
+
+## Key Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `query` | Spark SQL query string (use `{{ start_date }}` and `{{ end_date }}` for date range) |
+| `startPartition` | First partition to compute (format: `YYYY-MM-DD`) |
+| `setups` | List of SQL setup statements (e.g., UDF registration) |
+| `createView` | If `True`, creates a view instead of a table (default: `False`) |
+| `metaData.name` | Output table name |
+| `metaData.outputNamespace` | Database/namespace for output table |
+| `metaData.dependencies` | List of upstream table dependencies (format: `namespace.table/ds={{ ds }}`) |
+| `metaData.tableProperties` | Optional table properties dict |
+
+## Best Practices
+
+1. **Idempotency**: Queries should be re-runnable without side effects
+2. **Date Filtering**: Use `{{ start_date }}` and `{{ end_date }}` templates for incremental processing
+3. **Full Paths**: Reference source tables with `namespace.table` format
+4. **Type Safety**: Explicitly cast types, especially timestamps
+5. **Comments**: Document complex logic in SQL comments
+
+## Execution
+
+```bash
+# Compile the staging query
+compile.py --conf=staging_queries/team/enriched_transactions.py
+
+# Run the staging query
+run.py --mode staging-query --conf production/staging_queries/team/enriched_transactions.v1 --ds 2024-01-01
+```
+
+## When Helping Users
+
+1. Understand if StagingQuery is the right tool (vs. inline Query transformations)
+2. Help structure complex SQL with CTEs for readability
+3. Ensure proper type handling (especially for timestamps)
+4. Recommend partitioning strategy for large datasets
+5. Verify downstream GroupBys correctly reference the staging output
+
+Read the key files listed above to provide specific, accurate guidance based on their question.


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Adds Claude Code customizations to the Chronon repository to help both feature authors (data scientists) and platform integrators (engineers) work more effectively with the codebase.

**Files added:**
- `.claude/CLAUDE.md` - Shared context about repo structure, key concepts, and workflows
- `user/groupby`, `user/join`, `user/debug`, `user/staging-query` - Commands for data scientists writing feature definitions
- `dev/architecture`, `dev/integrate` - Commands for engineers integrating Chronon
- `dev/specialist/*` - Deep-dive commands for join-backfill, feature-serving, streaming, and aggregator internals

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

We've been using similar Claude Code customizations at Stripe for 6+ months and have found them to be a game changer for working with the Chronon codebase. For any OSS adopters using Claude Code, these customizations will hopefully provide:

1. **Faster onboarding** - New users get accurate context about Chronon's architecture and conventions
2. **Guided feature authoring** - Data scientists get help writing correct GroupBy, Join, and StagingQuery definitions
3. **Integration support** - Engineers get guidance on KV store implementation, Airflow setup, and system architecture
4. **Deep expertise on demand** - Specialist commands provide detailed knowledge of Spark joins, online serving, Flink streaming, and the aggregator/tiling system

## Disclaimer
These files were regenerated from scratch for the OSS repository. The internal Stripe version relies on RAG over internal documentation and MCP tooling that isn't available in the open-source context. This required regenerating all content by reading the actual codebase and verifying accuracy against source files.

## How It Works

- **CLAUDE.md** is automatically injected into every Claude Code session when working in this repository. It provides foundational context about Chronon's architecture, key concepts, and common workflows.
- **Custom commands** (in `.claude/commands/`) can be invoked via slash commands (e.g., `/user/groupby`, `/dev/architecture`) to load specialized prompts for specific tasks.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

Verification process:
- Spun up 2 waves of audit agents to verify each .md file
- Did a manual review myself as well
- All logic + code refs were checked against source code

## Checklist
- [ ] Documentation update

## Reviewers