### PR TITLE
[Metadata]Update lineage parser to handle standalone staging query as well

### DIFF
--- a/api/py/ai/chronon/lineage/lineage_parser.py
+++ b/api/py/ai/chronon/lineage/lineage_parser.py
@@ -564,13 +564,18 @@ class LineageParser:
 
     def handle_staging_query(self, staging_query: Any) -> None:
         """
-        Store a staging query configuration.
+        Store and parse a staging query configuration.
+
+        Previously staging queries were lazily parsed only when referenced by a GroupBy or Join.
+        This caused "no lineage" for standalone staging queries not used by any config.
+        Now we parse immediately to ensure all staging queries have lineage.
 
         :param staging_query: The staging query configuration object.
         :return: None
         """
         table_name = output_table_name(staging_query, full_name=True)
         self.staging_queries[table_name] = staging_query
+        self.parse_staging_query(staging_query)
 
     def parse_staging_query(self, staging_query: Any) -> None:
         """

--- a/api/py/test/lineage/test_parse_lineage.py
+++ b/api/py/test/lineage/test_parse_lineage.py
@@ -29,6 +29,36 @@ class TestParseLineage(unittest.TestCase):
         for attr in attributes:
             self.assertGreater(len(getattr(metadata, attr)), 0, f"{attr} should not be empty")
 
+    def test_standalone_staging_query_has_lineage(self):
+        """
+        Test that standalone staging queries (not referenced by any GroupBy/Join)
+        are parsed and have lineage. This was a bug where staging queries were
+        lazily parsed only when referenced, causing "no lineage" for standalone ones.
+        """
+        parser = LineageParser()
+        parser.parse_lineage(TEST_BASE_PATH)
+        metadata = parser.metadata
+
+        # The standalone staging query should be in configs
+        standalone_config_name = "sample_team.standalone_staging_query.v1"
+        self.assertIn(
+            standalone_config_name, metadata.configs, "Standalone staging query should be parsed and in configs"
+        )
+
+        # The standalone staging query output table should be in parsed_staging_query_tables
+        standalone_table = "sample_namespace.sample_team_standalone_staging_query_v1"
+        self.assertIn(
+            standalone_table,
+            parser.parsed_staging_query_tables,
+            f"Standalone staging query {standalone_table} should be parsed",
+        )
+
+        # The standalone staging query output table should have lineage
+        standalone_lineages = [lineage for lineage in metadata.lineages if lineage.output_table == standalone_table]
+        self.assertGreater(
+            len(standalone_lineages), 0, f"Standalone staging query {standalone_table} should have lineage"
+        )
+
     def test_cannot_parse_lineage(self):
         # Can't parse lineage since there is no specific column.
         lineage = build_lineage("output", "SELECT COUNT(*) AS a FROM input")

--- a/api/py/test/sample/production/staging_queries/sample_team/standalone_staging_query.v1
+++ b/api/py/test/sample/production/staging_queries/sample_team/standalone_staging_query.v1
@@ -1,0 +1,12 @@
+{
+  "metaData": {
+    "name": "sample_team.standalone_staging_query.v1",
+    "dependencies": [
+      "sample_namespace.source_table/ds={{ ds }}"
+    ],
+    "outputNamespace": "sample_namespace",
+    "team": "sample_team"
+  },
+  "query": "\nSELECT\n    user_id,\n    listing_id,\n    event_type,\n    ds\nFROM sample_namespace.source_table\nWHERE ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'\n",
+  "startPartition": "2020-01-01"
+}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Problem:                                                                                                                                                                                                      
Staging queries were lazily parsed only when referenced by a GroupBy or Join. Standalone staging queries not used by any config never got parsed, resulting in "no lineage" for their output columns.                                                                                                                                                                                 

Fix:                                                                                                                                                                                                         Parse staging queries immediately in handle_staging_query() instead of deferring to when they're referenced.
                                                                                                                                                                                                                
Changes:                                                                                                                                                                                                      
api/py/ai/chronon/lineage/lineage_parser.py: Add self.parse_staging_query(staging_query) call in handle_staging_query()                                                                                     
api/py/test/lineage/test_parse_lineage.py: Add test test_standalone_staging_query_has_lineage                                                                                                               
api/py/test/sample/production/staging_queries/sample_team/standalone_staging_query.v1: Add test fixture

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@Shiyinghaha @pengyu-hou @anbmic 
