### PR TITLE
[codex] Watermark tiled Flink rows after Spark expression eval

### DIFF
--- a/flink/src/main/scala/ai/chronon/flink/ChrononWatermarkStrategies.scala
+++ b/flink/src/main/scala/ai/chronon/flink/ChrononWatermarkStrategies.scala
@@ -6,9 +6,8 @@ import org.apache.flink.api.common.eventtime.{SerializableTimestampAssigner, Wat
 import java.time.Duration
 
 object ChrononWatermarkStrategies {
-  def sparkExpressionEvalWatermarkStrategy(
-      allowedOutOfOrderness: Duration,
-      idlenessTimeout: Duration): WatermarkStrategy[Map[String, Any]] =
+  def sparkExpressionEvalWatermarkStrategy(allowedOutOfOrderness: Duration,
+                                           idlenessTimeout: Duration): WatermarkStrategy[Map[String, Any]] =
     WatermarkStrategy
       .forBoundedOutOfOrderness[Map[String, Any]](allowedOutOfOrderness)
       .withIdleness(idlenessTimeout)

--- a/flink/src/main/scala/ai/chronon/flink/ChrononWatermarkStrategies.scala
+++ b/flink/src/main/scala/ai/chronon/flink/ChrononWatermarkStrategies.scala
@@ -1,0 +1,22 @@
+package ai.chronon.flink
+
+import ai.chronon.api.Constants
+import org.apache.flink.api.common.eventtime.{SerializableTimestampAssigner, WatermarkStrategy}
+
+import java.time.Duration
+
+object ChrononWatermarkStrategies {
+  def sparkExpressionEvalWatermarkStrategy(
+      allowedOutOfOrderness: Duration,
+      idlenessTimeout: Duration): WatermarkStrategy[Map[String, Any]] =
+    WatermarkStrategy
+      .forBoundedOutOfOrderness[Map[String, Any]](allowedOutOfOrderness)
+      .withIdleness(idlenessTimeout)
+      .withTimestampAssigner(new SerializableTimestampAssigner[Map[String, Any]] {
+        override def extractTimestamp(element: Map[String, Any], recordTimestamp: Long): Long =
+          chrononTimeColumnMillis(element)
+      })
+
+  private[flink] def chrononTimeColumnMillis(element: Map[String, Any]): Long =
+    element(Constants.TimeColumn).asInstanceOf[Number].longValue()
+}

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -149,8 +149,8 @@ class FlinkJob[T](eventSrc: FlinkSource[T],
       .name(s"Spark expression eval for $featureGroupName")
       .setParallelism(sourceStream.parallelism) // Use same parallelism as previous operator
 
+    // Constants.TimeColumn is only available after Spark expression evaluation.
     val watermarkedSparkExprEvalDS: DataStream[Map[String, Any]] = sparkExprEvalDS
-      // Constants.TimeColumn is only available after Spark expression evaluation.
       .assignTimestampsAndWatermarks(
         ChrononWatermarkStrategies.sparkExpressionEvalWatermarkStrategy(
           tiledEventTimeOutOfOrderness,

--- a/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
+++ b/flink/src/main/scala/ai/chronon/flink/FlinkJob.scala
@@ -23,6 +23,13 @@ import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow
 import org.slf4j.LoggerFactory
 
+import java.time.Duration
+
+object FlinkJob {
+  val DefaultTiledEventTimeOutOfOrderness: Duration = Duration.ofMinutes(5)
+  val DefaultTiledEventTimeIdlenessTimeout: Duration = Duration.ofSeconds(30)
+}
+
 /**
   * Flink job that processes a single streaming GroupBy and writes out the results to the KV store.
   *
@@ -34,13 +41,17 @@ import org.slf4j.LoggerFactory
   * @param groupByServingInfoParsed - The GroupBy we are working with
   * @param encoder - Spark Encoder for the input data type
   * @param parallelism - Parallelism to use for the Flink job
+  * @param tiledEventTimeOutOfOrderness - Out-of-orderness tolerance for tiled event-time watermarks
+  * @param tiledEventTimeIdlenessTimeout - Idleness timeout for tiled event-time watermark generation
   * @tparam T - The input data type
   */
 class FlinkJob[T](eventSrc: FlinkSource[T],
                   sinkFn: RichAsyncFunction[PutRequest, WriteResponse],
                   groupByServingInfoParsed: GroupByServingInfoParsed,
                   encoder: Encoder[T],
-                  parallelism: Int) {
+                  parallelism: Int,
+                  tiledEventTimeOutOfOrderness: Duration = FlinkJob.DefaultTiledEventTimeOutOfOrderness,
+                  tiledEventTimeIdlenessTimeout: Duration = FlinkJob.DefaultTiledEventTimeIdlenessTimeout) {
   private[this] val logger = LoggerFactory.getLogger(getClass)
 
   val featureGroupName: String = groupByServingInfoParsed.groupBy.getMetaData.getName
@@ -138,6 +149,18 @@ class FlinkJob[T](eventSrc: FlinkSource[T],
       .name(s"Spark expression eval for $featureGroupName")
       .setParallelism(sourceStream.parallelism) // Use same parallelism as previous operator
 
+    val watermarkedSparkExprEvalDS: DataStream[Map[String, Any]] = sparkExprEvalDS
+      // Constants.TimeColumn is only available after Spark expression evaluation.
+      .assignTimestampsAndWatermarks(
+        ChrononWatermarkStrategies.sparkExpressionEvalWatermarkStrategy(
+          tiledEventTimeOutOfOrderness,
+          tiledEventTimeIdlenessTimeout
+        )
+      )
+      .uid(s"event-watermarked-spark-$featureGroupName")
+      .name(s"Watermark Spark rows for $featureGroupName")
+      .setParallelism(sourceStream.parallelism)
+
     val inputSchema: Seq[(String, DataType)] =
       exprEval.getOutputSchema.fields
         .map(field => (field.name, SparkConversions.toChrononType(field.name, field.dataType)))
@@ -161,7 +184,7 @@ class FlinkJob[T](eventSrc: FlinkSource[T],
     //    - The only purpose of this window function is to mark tiles as closed so we can do client-side caching in SFS
     // 7. Output: TimestampedTile, containing the current IRs (Avro encoded) and the timestamp of the current element
     val tilingDS: DataStream[TimestampedTile] =
-      sparkExprEvalDS
+      watermarkedSparkExprEvalDS
         .keyBy(KeySelector.getKeySelectionFunction(groupByServingInfoParsed.groupBy))
         .window(window)
         .trigger(trigger)

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkJobIntegrationTest.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkJobIntegrationTest.scala
@@ -1,5 +1,6 @@
 package ai.chronon.flink.test
 
+import ai.chronon.api.{TimeUnit, Window}
 import ai.chronon.flink.window.{TimestampedIR, TimestampedTile}
 import ai.chronon.flink.{FlinkJob, SparkExpressionEvalFn}
 import ai.chronon.online.{Api, GroupByServingInfoParsed}
@@ -13,6 +14,7 @@ import org.junit.{After, Before, Test}
 import org.mockito.Mockito.withSettings
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.time.Instant
 import scala.util.ScalaJavaConversions.ListOps
 
 class FlinkJobIntegrationTest {
@@ -46,6 +48,12 @@ class FlinkJobIntegrationTest {
     val tileIR = groupByServingInfoParsed.tiledCodec.decodeTileIr(timestampedTile.tileBytes)
     TimestampedIR(tileIR._1, Some(timestampedTile.latestTsMillis))
   }
+
+  private def toMillis(iso: String): Long =
+    Instant.parse(iso).toEpochMilli
+
+  private def tileStart(tsMillis: Long, tileSizeMillis: Long): Long =
+    tsMillis - Math.floorMod(tsMillis, tileSizeMillis)
 
   @Before
   def setup(): Unit = {
@@ -157,5 +165,47 @@ class FlinkJobIntegrationTest {
     )
 
     assertEquals(expectedFinalIRsPerKey, finalIRsPerKey)
+  }
+
+  @Test
+  def testTiledFlinkJobWatermarksAfterSparkExpressionEval(): Unit = {
+    implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val elements = Seq(
+      E2ETestEvent("id1", 1, 1.0, toMillis("2025-07-20T12:59:49Z")),
+      E2ETestEvent("id1", 1, 1.0, toMillis("2025-07-20T12:59:58Z"))
+    )
+    val source = new ShiftedWatermarkedE2EEventSource(elements, shiftMillis = 10000L)
+
+    val groupBy = FlinkTestUtils.makeGroupBy(
+      Seq("id"),
+      windows = Seq(new Window(1, TimeUnit.HOURS))
+    )
+
+    val encoder = Encoders.product[E2ETestEvent]
+    val outputSchema = new SparkExpressionEvalFn(encoder, groupBy).getOutputSchema
+    val groupByServingInfoParsed =
+      FlinkTestUtils.makeTestGroupByServingInfoParsed(groupBy, encoder.schema, outputSchema)
+    val mockApi = mock[Api](withSettings().serializable())
+    val writerFn = new MockAsyncKVStoreWriter(Seq(true, true), mockApi, "testTiledFlinkJobEventTimeWatermarkFG")
+    val job = new FlinkJob[E2ETestEvent](source, writerFn, groupByServingInfoParsed, encoder, 1)
+    job.runTiledGroupByJob(env).addSink(new CollectSink)
+
+    env.execute("TiledFlinkJobEventTimeWatermarkIntegrationTest")
+
+    val targetTileStart = toMillis("2025-07-20T12:00:00Z")
+    val hourMillis = 60L * 60L * 1000L
+    val targetTileValues = CollectSink.values.toScala
+      .map(_.putRequest)
+      .filter(request => tileStart(request.tsMillis.get, hourMillis) == targetTileStart)
+      .map { request =>
+        val timestampedTile =
+          avroConvertPutRequestToTimestampedTile(request, groupByServingInfoParsed)
+        avroConvertTimestampedTileToTimestampedIR(timestampedTile, groupByServingInfoParsed).ir.head
+          .asInstanceOf[Double]
+      }
+
+    assert(targetTileValues.nonEmpty)
+    assertEquals(2.0, targetTileValues.max, 0.0)
   }
 }

--- a/flink/src/test/scala/ai/chronon/flink/test/FlinkTestUtils.scala
+++ b/flink/src/test/scala/ai/chronon/flink/test/FlinkTestUtils.scala
@@ -45,6 +45,21 @@ class WatermarkedE2EEventSource(mockEvents: Seq[E2ETestEvent]) extends FlinkSour
   }
 }
 
+class ShiftedWatermarkedE2EEventSource(mockEvents: Seq[E2ETestEvent], shiftMillis: Long)
+    extends FlinkSource[E2ETestEvent] {
+  def watermarkStrategy: WatermarkStrategy[E2ETestEvent] =
+    WatermarkStrategy
+      .forBoundedOutOfOrderness[E2ETestEvent](Duration.ofSeconds(5))
+      .withTimestampAssigner(new SerializableTimestampAssigner[E2ETestEvent] {
+        override def extractTimestamp(event: E2ETestEvent, previousElementTimestamp: Long): Long =
+          event.created + shiftMillis
+      })
+  override def getDataStream(topic: String, groupName: String)(env: StreamExecutionEnvironment,
+                                                               parallelism: Int): DataStream[E2ETestEvent] = {
+    env.fromCollection(mockEvents).assignTimestampsAndWatermarks(watermarkStrategy)
+  }
+}
+
 class MockAsyncKVStoreWriter(mockResults: Seq[Boolean], onlineImpl: Api, featureGroup: String)
     extends AsyncKVStoreWriter(onlineImpl, featureGroup) {
   override def getKVStore: KVStore = {
@@ -106,7 +121,9 @@ object FlinkTestUtils {
       PartitionSpec(format = "yyyy-MM-dd", spanMillis = WindowUtils.Day.millis)
     )
   }
-  def makeGroupBy(keyColumns: Seq[String], filters: Seq[String] = Seq.empty): GroupBy =
+  def makeGroupBy(keyColumns: Seq[String],
+                  filters: Seq[String] = Seq.empty,
+                  windows: Seq[Window] = Seq(new Window(1, TimeUnit.DAYS))): GroupBy =
     Builders.GroupBy(
       sources = Seq(
         Builders.Source.events(
@@ -129,9 +146,7 @@ object FlinkTestUtils {
         Builders.Aggregation(
           operation = Operation.SUM,
           inputColumn = "double_val",
-          windows = Seq(
-            new Window(1, TimeUnit.DAYS)
-          )
+          windows = windows
         )
       ),
       metaData = Builders.MetaData(


### PR DESCRIPTION
## Summary
- assign event-time watermarks from Chronon's evaluated `Constants.TimeColumn` immediately after Spark expression evaluation in the tiled Flink path
- add a reusable Spark-expression-row watermark strategy with default out-of-orderness/idleness settings
- add an integration regression where source timestamps are shifted across an hourly boundary, while evaluated Chronon event time should keep the rows in the original tile

## Why
Tiled aggregation should window rows using the same Chronon event time that `TiledAvroCodecFn` later uses when writing tile requests. If Flink keeps source-assigned timestamps through Spark expression evaluation, source timestamp skew can place a row in a different Flink tumbling window than its Chronon tile timestamp.

## Failure mode
Before this change, the tiled path kept the source watermark/timestamp through Spark expression evaluation. That can let the Flink window used for accumulation diverge from the Chronon event timestamp used for the tile write.

```text
Chronon event time after Spark expression eval

12:00                          13:00                          14:00
|------------------------------|------------------------------|
 row 001 ... row 199       row 200
 ts in [12:00, 13:00)      ts=12:59:58

Expected Chronon tile target:
  All 200 rows belong to the [12:00, 13:00) Chronon tile.
  The tile should accumulate to value = 200.

What the old path can do when source/Flink record time is skewed:

12:00                          13:00                          14:00
|------------------------------|------------------------------|
 row 001 ... row 199
 source_time in [12:00, 13:00)
                                row 200
                                source_time=13:00:08
                                event ts still 12:59:58

Old Flink accumulation:
  [12:00, 13:00) Flink window accumulates row 001 ... row 199
    -> emits Chronon tile [12:00, 13:00), value = 199

  [13:00, 14:00) Flink window starts fresh and accumulates only row 200
    -> emits a smaller partial aggregate, value = 1

But tile writes are encoded with Chronon event time:
  first write:  Flink [12:00, 13:00) -> Chronon [12:00, 13:00), value = 199
  later write:  Flink [13:00, 14:00) -> Chronon [12:00, 13:00), value = 1

Incorrect result:
  The later, smaller partial tile has the same Chronon tile key as the fuller
  tile. In a last-write-wins store, the later write can overwrite the high
  value, so readers see value = 1 instead of the accumulated value = 200.
```

This change reassigns watermarks from `Constants.TimeColumn` after Spark expression evaluation, before `keyBy` and the tumbling event-time window. With that ordering, Flink windowing and Chronon tile writes use the same event-time basis.

```text
After this change:

Chronon event time / Flink event time

12:00                          13:00                          14:00
|------------------------------|------------------------------|
 row 001 ... row 199       row 200
 ts in [12:00, 13:00)      ts=12:59:58

Fixed Flink accumulation:
  [12:00, 13:00) Flink window accumulates row 001 ... row 200
    -> emits Chronon tile [12:00, 13:00), value = 200
```

## Validation
- PASS: `PATH=/tmp/chronon-oss-python-build-venv/bin:/opt/homebrew/bin:/usr/local/bin:$PATH JAVA_HOME=/Users/mickjermsurawong/Library/Java/JavaVirtualMachines/corretto-17.0.13/Contents/Home /usr/local/bin/sbt -batch 'flink/Test/compile'`
- BLOCKED: `/usr/local/bin/bazel test //flink:test --test_filter=ai.chronon.flink.test.FlinkJobIntegrationTest` did not compile locally because Bazel external dependency resolution failed on `org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde`.
- BLOCKED: targeted SBT test execution compiled and started the Flink integration suite, but Spark failed to initialize a local Netty socket with `java.net.SocketException: Operation not permitted` in this desktop environment, even with loopback binding and Java 17 module opens.
