### PR TITLE
Guarantee write idempotency - fix duplicate and missing rows for lost executors

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -762,10 +762,14 @@ case class TableUtils(sparkSession: SparkSession) {
       // finalized shuffle parallelism
       val shuffleParallelism = Math.max(dailyFileCount * nonZeroTablePartitionCount, minWriteShuffleParallelism)
       val saltCol = "random_partition_salt"
-      // Use deterministic hash instead of rand() to ensure retried Spark tasks produce
-      // the same file assignment. Non-deterministic rand() causes duplicate rows when
-      // executors fail during writes and shuffle partitions are recomputed.
-      val hashInputCols = df.columns.map(col(_))
+      // Deterministic salt: rand() causes duplicate rows when Spark retries tasks during writes.
+      val hashInputCols = df.schema.fields
+        .filterNot(f => f.dataType.isInstanceOf[MapType] ||
+          f.dataType.isInstanceOf[ArrayType] || f.dataType.isInstanceOf[StructType])
+        .map(f => col(f.name))
+      require(hashInputCols.nonEmpty,
+        s"No hashable columns found for write salt in table $tableName. " +
+          s"All columns are complex types (Map/Array/Struct).")
       val saltedDf = df.withColumn(saltCol, pmod(hash(hashInputCols: _*), lit(dailyFileCount + 1)))
 
       logger.info(

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -764,12 +764,13 @@ case class TableUtils(sparkSession: SparkSession) {
       val saltCol = "random_partition_salt"
       // Deterministic salt: rand() causes duplicate rows when Spark retries tasks during writes.
       val hashInputCols = df.schema.fields
-        .filterNot(f => f.dataType.isInstanceOf[MapType] ||
-          f.dataType.isInstanceOf[ArrayType] || f.dataType.isInstanceOf[StructType])
+        .filterNot(f =>
+          f.dataType.isInstanceOf[MapType] ||
+            f.dataType.isInstanceOf[ArrayType] || f.dataType.isInstanceOf[StructType])
         .map(f => col(f.name))
       require(hashInputCols.nonEmpty,
-        s"No hashable columns found for write salt in table $tableName. " +
-          s"All columns are complex types (Map/Array/Struct).")
+              s"No hashable columns found for write salt in table $tableName. " +
+                s"All columns are complex types (Map/Array/Struct).")
       val saltedDf = df.withColumn(saltCol, pmod(hash(hashInputCols: _*), lit(dailyFileCount + 1)))
 
       logger.info(

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -762,7 +762,11 @@ case class TableUtils(sparkSession: SparkSession) {
       // finalized shuffle parallelism
       val shuffleParallelism = Math.max(dailyFileCount * nonZeroTablePartitionCount, minWriteShuffleParallelism)
       val saltCol = "random_partition_salt"
-      val saltedDf = df.withColumn(saltCol, round(rand() * (dailyFileCount + 1)))
+      // Use deterministic hash instead of rand() to ensure retried Spark tasks produce
+      // the same file assignment. Non-deterministic rand() causes duplicate rows when
+      // executors fail during writes and shuffle partitions are recomputed.
+      val hashInputCols = df.columns.map(col(_))
+      val saltedDf = df.withColumn(saltCol, pmod(hash(hashInputCols: _*), lit(dailyFileCount + 1)))
 
       logger.info(
         s"repartitioning data for table $tableName by $shuffleParallelism spark tasks into $tablePartitionCount table partitions and $dailyFileCount files per partition")


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
The repartitionAndWriteInternal method uses `rand()` to generate a salt column for distributing rows across output files before writing. When Spark task retries occur during the write (e.g., due to executor        
  failures), the shuffle is recomputed with different rand() values, causing the same rows to be assigned to different output files. Both the original and retried tasks' files can be committed, resulting in        
  duplicate rows in the output table while an equal number of rows are lost — netting to the same total row count but with corrupted data.
                                                                                                                                                                                                                      
  The existing uniqueness check validates the DataFrame before the write and cannot detect duplicates introduced during the write itself.  

  **Fix**: Replace rand() with a deterministic hash() over the DataFrame columns, ensuring retried tasks produce the same file assignment.                                                                                

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
We need to guarantee the Idempotency for the write step. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@hzding621 @Shiyinghaha @yuli-han 
