### PR TITLE
[GroupBy] Add spark conf flag to resolve ChrononRunDs from queryRange

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -662,17 +662,30 @@ object GroupBy {
     // chronon run ds macro is only supported for group bys
     // Use intersectedRange for validation when available, since it represents the actual data being scanned.
     // This allows bootstrap phase to work with multi-day queryRange as long as the intersectedRange is single day.
+    // When spark.chronon.group_by.use_query_range_for_run_ds is true and queryRange is a single day,
+    // resolve ChrononRunDs from queryRange.start instead of intersectedRange.
+    val useQueryRangeForRunDs = tableUtils.sparkSession.conf
+      .get("spark.chronon.group_by.use_query_range_for_run_ds", "false")
+      .toBoolean
     val selects = Option(source.query.selects)
       .map(_.toScala.map(keyValue => {
         if (keyValue._2.contains(Constants.ChrononRunDs)) {
-          assert(
-            intersectedRange.isDefined && intersectedRange.get.isSingleDay,
-            s"ChrononRunDs is only supported for single day queries. " +
-              s"intersectedRange: ${intersectedRange.map(r => s"${r.start} to ${r.end}").getOrElse("undefined")}, " +
-              s"queryRange: ${queryRange.start} to ${queryRange.end}"
-          )
-          // Python configs already have quotes around the macro, so no need for quotes here
-          val parametricMacro = ParametricMacro(Constants.ChrononRunDs, _ => intersectedRange.get.start)
+          val parametricMacro = if (useQueryRangeForRunDs) {
+            assert(
+              queryRange.isSingleDay,
+              s"ChrononRunDs with use_query_range_for_run_ds is only supported for single day queries. " +
+                s"queryRange: ${queryRange.start} to ${queryRange.end}"
+            )
+            ParametricMacro(Constants.ChrononRunDs, _ => s"'${queryRange.start}'")
+          } else {
+            assert(
+              intersectedRange.isDefined && intersectedRange.get.isSingleDay,
+              s"ChrononRunDs is only supported for single day queries. " +
+                s"intersectedRange: ${intersectedRange.map(r => s"${r.start} to ${r.end}").getOrElse("undefined")}, " +
+                s"queryRange: ${queryRange.start} to ${queryRange.end}"
+            )
+            ParametricMacro(Constants.ChrononRunDs, _ => intersectedRange.get.start)
+          }
           (keyValue._1, parametricMacro.replace(keyValue._2))
         } else {
           keyValue

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinTest.scala
@@ -668,6 +668,31 @@ class JoinTest {
   }
 
   @Test
+  def testChrononRunDsWithQueryRangeFlag(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    spark.conf.set("spark.chronon.group_by.use_query_range_for_run_ds", "true")
+    val tableUtils = TableUtils(spark)
+    val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
+    tableUtils.createDatabase(namespace)
+
+    val groupBy = getGroupByForIncrementalSourceTest()
+    val queryRange = PartitionRange("2021-01-02", "2021-01-02")(tableUtils)
+    val rendered = renderDataSourceQuery(
+      groupBy,
+      groupBy.sources.toScala.head,
+      Seq("id"),
+      queryRange,
+      tableUtils,
+      None,
+      groupBy.inferredAccuracy,
+      tableUtils.partitionColumn
+    )
+    assert(rendered.contains("'2021-01-02'"),
+      s"Expected rendered query to contain queryRange.start '2021-01-02' but got: $rendered")
+  }
+
+  @Test
   def testVersioning(): Unit = {
     val spark: SparkSession =
       SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)


### PR DESCRIPTION
## Summary
Add opt-in Spark conf flag to resolve `ChrononRunDs` macro from `queryRange` instead of `intersectedRange` in GroupBy source query rendering.
## Why / Goal
Currently, the `ChrononRunDs` macro in `renderDataSourceQuery` is resolved using `intersectedRange.start`, which requires the intersected range to be defined and single-day. This works for most cases but is limiting when callers need the macro to reflect the `queryRange` directly (e.g., when the query date and the scanned data range diverge).
This change introduces a Spark conf flag `spark.chronon.group_by.use_query_range_for_run_ds` (default `false`) that, when enabled, resolves `ChrononRunDs` from `queryRange.start` (with SQL string quotes) instead of `intersectedRange.start`. The existing default behavior is fully preserved when the flag is not set.
## Test Plan
- [x] Added Unit Tests — `testChrononRunDsWithQueryRangeFlag` in `JoinTest.scala` validates the flag-enabled path renders `queryRange.start` into the query
- [x] Covered by existing CI — existing `testSourceQueryRender` continues to cover the default (flag-off) path
- [ ] Integration tested