### PR TITLE
default table write format to Iceberg

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -181,8 +181,8 @@ case class DefaultFormatProvider(sparkSession: SparkSession) extends FormatProvi
       case (true, _) => Iceberg
       // else if there is a write format we pick that
       case (false, Some(format)) => format
-      // fallback to hive (parquet)
-      case (false, None) => Hive
+      // fallback to iceberg
+      case (false, None) => Iceberg
     }
   }
 }


### PR DESCRIPTION
Change the fallback write format in DefaultFormatProvider from Hive to Iceberg. This ensures all Chronon batch feature DAGs (group_by backfills, join backfills, etc.) write to Iceberg tables by default, eliminating the ~15k weekly Hive tmp table creations for ML feature pipelines.

The existing override paths remain unchanged:
- spark.chronon.table_write.iceberg=true → Iceberg (unchanged)
- spark.chronon.table_write.format=hive/iceberg/delta → explicit override (unchanged)

## Summary
Default to iceberg when no format is specified.

## Why / Goal
Iceberg migration

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ No] Added Unit Tests
- [ May be , will know once CI runs] Covered by existing CI
- [No ] Integration tested

## Checklist
- [No ] Documentation update

## Reviewers

