### PR TITLE
Fix decode exception logging and null-check ordering in JoinSourceRunner

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -314,16 +314,19 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
           streamDecoder.decode(arr)
         } catch {
           case ex: Throwable =>
-            logger.info(s"Error while decoding streaming events from stream: ${dataStream.topicInfo.name}")
-            ex.printStackTrace()
+            logger.error(s"Error while decoding streaming events from stream: ${dataStream.topicInfo.name}", ex)
             ingressContext.incrementException(ex)
             null
         }
       }
       .filter { mutation =>
-        lazy val bothNull = mutation.before != null && mutation.after != null
-        lazy val bothSame = mutation.before sameElements mutation.after
-        (mutation != null) && (!bothNull || !bothSame)
+        if (mutation == null) {
+          false
+        } else {
+          lazy val bothNull = mutation.before != null && mutation.after != null
+          lazy val bothSame = mutation.before sameElements mutation.after
+          !bothNull || !bothSame
+        }
       }
     val streamSchema = SparkConversions.fromChrononSchema(streamDecoder.schema)
     val streamSchemaEncoder = EncoderUtil(streamSchema)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Use logger.error with the exception object for decode failures so the stack trace routes through SLF4J rather than going to stderr via printStackTrace. Also restructure the mutation filter to check null before accessing mutation fields, avoiding a latent NPE.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Surface the error 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@Shiyinghaha @yuli-han 
