### PR TITLE
[BugFix] Warn when partitions are silently skipped due to skipFirstHole

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -144,7 +144,7 @@ object Driver {
     val runFirstHole: ScallopOption[Boolean] =
       opt[Boolean](required = false,
                    default = Some(false),
-                   descr = "Skip the first unfilled partition range if some future partitions have been populated.")
+                   descr = "By default, Chronon skips partitions earlier than your earliest existing output partition, assuming the gap is due to retention policy. Use this flag to override that behavior and backfill those earlier partitions.")
 
     val useDeltaCatalog: ScallopOption[Boolean] =
       opt[Boolean](required = false, default = Some(false), descr = "Enable the use of the delta lake catalog")

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -142,9 +142,12 @@ object Driver {
     val confPath: ScallopOption[String] = opt[String](required = true, descr = "Path to conf")
 
     val runFirstHole: ScallopOption[Boolean] =
-      opt[Boolean](required = false,
-                   default = Some(false),
-                   descr = "By default, Chronon skips partitions earlier than your earliest existing output partition, assuming the gap is due to retention policy. Use this flag to override that behavior and backfill those earlier partitions.")
+      opt[Boolean](
+        required = false,
+        default = Some(false),
+        descr =
+          "By default, Chronon skips partitions earlier than your earliest existing output partition, assuming the gap is due to retention policy. Use this flag to override that behavior and backfill those earlier partitions."
+      )
 
     val useDeltaCatalog: ScallopOption[Boolean] =
       opt[Boolean](required = false, default = Some(false), descr = "Enable the use of the delta lake catalog")

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -899,6 +899,15 @@ case class TableUtils(sparkSession: SparkSession) {
     }
     val fillablePartitions =
       if (skipFirstHole) {
+        val skipped = validPartitionRange.partitions.toSet.filter(_ < cutoffPartition)
+        if (skipped.nonEmpty) {
+          logger.warn(s"""
+                     |Skipping ${skipped.size} partition(s) earlier than the earliest existing output partition ($cutoffPartition).
+                     |Chronon assumes these were dropped by the retention policy.
+                     |Skipped partitions: ${skipped.toSeq.sorted.prettyInline}
+                     |To backfill these partitions, re-run with the --run-first-hole flag.
+                     |""".stripMargin)
+        }
         validPartitionRange.partitions.toSet.filter(_ >= cutoffPartition)
       } else {
         validPartitionRange.partitions.toSet


### PR DESCRIPTION
## Problem

When `skipFirstHole=true` (the default), Chronon silently skips partitions earlier than the earliest existing output partition, assuming the gap is due to retention policy. Users doing backfills have no way to know their partitions were dropped — there's only a quiet `logger.info` in the unfilled range summary, and no pointer to the fix.

The fix is `--run-first-hole`, but that flag is undiscoverable: it doesn't appear in `--help` output, and its current description (`"Skip the first unfilled partition range if some future partitions have been populated."`) is misleading — it implies the flag *skips* partitions, when it actually *prevents* skipping.

## Changes

### `TableUtils.scala`
Add a `logger.warn` when `skipFirstHole=true` causes partitions to be silently excluded. The warning names the skipped dates and points to `--run-first-hole`.

### `Driver.scala`
Rewrite the `--run-first-hole` description to accurately describe the default behavior and when to use the flag.

## Testing

This is a logging-only change with no behavioral impact. The warning fires only when `skipFirstHole=true` (default) and the requested range includes partitions earlier than the earliest existing output partition — the exact scenario that causes silent data gaps.

Existing tests are unaffected. The logic `validPartitionRange.partitions.toSet.filter(_ >= cutoffPartition)` is unchanged.