### PR TITLE
Fix broadcast fetch failures when CatalystUtil initializes on executor JVMs in chained streaming GroupBys

### DIFF
--- a/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.{
   RDDScanExec,
   WholeStageCodegenExec
 }
+import org.apache.spark.SparkEnv
 import org.apache.spark.sql.{SparkSession, types}
 
 import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap}
@@ -49,6 +50,20 @@ object CatalystUtil {
   }
 
   lazy val session: SparkSession = {
+    // On executor JVMs, creating a new SparkSession via builder().master("local[*]").getOrCreate()
+    // starts a second SparkContext which registers a new BlockManager as "driver", overwriting
+    // the cluster's BlockManager routing table and causing broadcast fetch failures on all
+    // executors.
+    //
+    // SparkEnv.get is an AtomicReference set on both driver and executor JVMs during
+    // initialization — unlike getActiveSession()'s InheritableThreadLocal it is accessible
+    // from any thread including Spark task threads. SparkContext is NOT present on executors
+    // (only the driver creates one), so we cannot use SparkContext.getOrCreate().
+    //
+    // On executor JVMs we create a local[*] session but immediately restore the original
+    // SparkEnv so the new SparkContext's registration does not permanently overwrite it.
+    // The local session is used only for Catalyst planning/codegen and never submits tasks.
+    val savedEnv = SparkEnv.get
     val spark = SparkSession
       .builder()
       .appName(s"catalyst_test_${Thread.currentThread().toString}")
@@ -56,10 +71,15 @@ object CatalystUtil {
       // This serving path only uses Spark for Catalyst planning/codegen, not for long-lived RDD or shuffle cleanup.
       // Disabling reference tracking avoids the ContextCleaner thread's periodic System.gc() calls in the JVM.
       .config("spark.cleaner.referenceTracking", "false")
-      .config("spark.sql.session.timeZone", "UTC")
-      .config("spark.sql.adaptive.enabled", "false")
-      .config("spark.sql.legacy.timeParserPolicy", "LEGACY")
       .getOrCreate()
+    if (savedEnv != null && (SparkEnv.get ne savedEnv)) {
+      // A new local SparkContext replaced the executor's SparkEnv. Restore it immediately
+      // to prevent broadcast block routing corruption in the cluster.
+      SparkEnv.set(savedEnv)
+    }
+    spark.conf.set("spark.sql.adaptive.enabled", "false")
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
+    spark.conf.set("spark.sql.legacy.timeParserPolicy", "LEGACY")
     assert(spark.sessionState.conf.wholeStageEnabled)
     spark
   }

--- a/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
+++ b/online/src/main/scala/ai/chronon/online/CatalystUtil.scala
@@ -50,19 +50,10 @@ object CatalystUtil {
   }
 
   lazy val session: SparkSession = {
-    // On executor JVMs, creating a new SparkSession via builder().master("local[*]").getOrCreate()
-    // starts a second SparkContext which registers a new BlockManager as "driver", overwriting
-    // the cluster's BlockManager routing table and causing broadcast fetch failures on all
-    // executors.
-    //
-    // SparkEnv.get is an AtomicReference set on both driver and executor JVMs during
-    // initialization — unlike getActiveSession()'s InheritableThreadLocal it is accessible
-    // from any thread including Spark task threads. SparkContext is NOT present on executors
-    // (only the driver creates one), so we cannot use SparkContext.getOrCreate().
-    //
-    // On executor JVMs we create a local[*] session but immediately restore the original
-    // SparkEnv so the new SparkContext's registration does not permanently overwrite it.
-    // The local session is used only for Catalyst planning/codegen and never submits tasks.
+    // On executor JVMs, master("local[*]") starts a second SparkContext which overwrites the
+    // cluster's BlockManager routing table, causing broadcast fetch failures on all executors.
+    // Save and restore SparkEnv to undo that side effect while still using the local session
+    // for Catalyst planning/codegen. On driver/test JVMs savedEnv is null or unchanged — no-op.
     val savedEnv = SparkEnv.get
     val spark = SparkSession
       .builder()
@@ -73,8 +64,6 @@ object CatalystUtil {
       .config("spark.cleaner.referenceTracking", "false")
       .getOrCreate()
     if (savedEnv != null && (SparkEnv.get ne savedEnv)) {
-      // A new local SparkContext replaced the executor's SparkEnv. Restore it immediately
-      // to prevent broadcast block routing corruption in the cluster.
       SparkEnv.set(savedEnv)
     }
     spark.conf.set("spark.sql.adaptive.enabled", "false")


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
**Problem**

When running a double-chained streaming GroupBy — where a GroupBy's source is a Join, and that Join's right-parts include GroupBys that themselves have non-trivial SQL derivations (e.g. CONCAT_WS, CASE WHEN, etc.) — the streaming job fails immediately with:

`Failed to get broadcast_1_piece0 of broadcast_1 across all executors.`

**Root Cause**

CatalystUtil.session is a lazy val that spins up a local[*] SparkSession, fine on the driver, but dangerous on executors. 

In the chained streaming path, GroupByServingInfoParsed.deriveFunc is a @transient lazy val that re-initializes after deserialization, and for GroupBys with non-trivial derivations, that re-initialization hits CatalystUtil.session.

When local[*] starts on an executor JVM, it creates a second SparkContext that registers itself as "driver" in the BlockManager routing table, overwriting the real driver's address and causing all broadcast fetches to fail.


**Fix**
Save SparkEnv.get (an AtomicReference, accessible from any thread) before creating the local session, then restore it immediately after. This undoes the SparkEnv overwrite caused by the new local[*] SparkContext before any tasks attempt to fetch broadcast blocks.

```
scalaval savedEnv = SparkEnv.get
val spark = SparkSession.builder().master("local[*]") ... .getOrCreate()
if (savedEnv != null && (SparkEnv.get ne savedEnv)) {
  SparkEnv.set(savedEnv)
}
```

The local session is still created (CatalystUtil needs it for Catalyst planning and codegen), but the executor's real SparkEnv is restored before any damage propagates. On unit test JVMs savedEnv is null, so the restore is a no-op — all existing tests continue to pass.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

Integration tested
## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @Shiyinghaha 
