### PR TITLE
[Chronon] Separate logging failure from blocking fetching, make chronon code able to handle struct for logging

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Row.scala
+++ b/api/src/main/scala/ai/chronon/api/Row.scala
@@ -165,6 +165,29 @@ object Row {
               dataType,
               schemaTraverser.map(_.currentNode)
             )
+          case map: collection.Map[_, _] =>
+            // Struct values can arrive as a Map keyed by field name (e.g. nested rows surfaced
+            // through Spark SQL transforms). Look up each declared field by name so the values
+            // are emitted in struct-declared order; missing keys are emitted as null.
+            composer(
+              fields.iterator.map { f =>
+                edit(map.asInstanceOf[collection.Map[String, Any]].getOrElse(f.name, null),
+                     f.fieldType,
+                     getFieldSchema(f))
+              },
+              dataType,
+              schemaTraverser.map(_.currentNode)
+            )
+          case map: util.Map[_, _] =>
+            val jmap = map.asInstanceOf[util.Map[String, Any]]
+            composer(
+              fields.iterator.map { f =>
+                val v = if (jmap.containsKey(f.name)) jmap.get(f.name) else null
+                edit(v, f.fieldType, getFieldSchema(f))
+              },
+              dataType,
+              schemaTraverser.map(_.currentNode)
+            )
           case value: Any =>
             assert(extraneousRecord != null, s"No handler for $value of class ${value.getClass}")
             composer(

--- a/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
+++ b/api/src/test/scala/ai/chronon/api/test/ExtensionsTest.scala
@@ -252,15 +252,17 @@ class ExtensionsTest {
   @Test
   def leftKeyColsIncludesExternalPartKeyMappings(): Unit = {
     val metadata = Builders.MetaData(name = "test", team = "team")
-    val groupBy = Builders.GroupBy(
-      sources = Seq(Builders.Source.events(query = null, table = "db.gb_table")),
-      keyColumns = Seq("right_key"),
-      metaData = metadata)
-    val externalSource = Builders.ExternalSource(metadata, keySchema = IntType, valueSchema = LongType, offlineGroupBy = groupBy)
+    val groupBy = Builders.GroupBy(sources = Seq(Builders.Source.events(query = null, table = "db.gb_table")),
+                                   keyColumns = Seq("right_key"),
+                                   metaData = metadata)
+    val externalSource =
+      Builders.ExternalSource(metadata, keySchema = IntType, valueSchema = LongType, offlineGroupBy = groupBy)
 
     val join = Builders.Join(
       left = Builders.Source.events(query = null, table = "db.join_table"),
-      externalParts = Seq(Builders.ExternalPart(externalSource = externalSource, keyMapping = Map("left_key" -> "right_key"), prefix = "ext"))
+      externalParts = Seq(
+        Builders
+          .ExternalPart(externalSource = externalSource, keyMapping = Map("left_key" -> "right_key"), prefix = "ext"))
     )
 
     assertTrue(join.leftKeyCols.contains("left_key"))

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -45,6 +45,7 @@ import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.ScalaJavaConversions.{IteratorOps, JListOps, JMapOps}
+import scala.util.control.ControlThrowable
 import scala.util.{Failure, Random, Success, Try}
 
 object Fetcher {
@@ -453,6 +454,24 @@ class Fetcher(val kvStore: KVStore,
   }
 
   private def logResponse(resp: ResponseWithContext): ResponseWithContext = {
+    // Wrapping logging with try catch to separate logging failure from the user-facing fetch response.
+    try {
+      logResponseInternal(resp)
+    } catch {
+      case e: VirtualMachineError  => throw e
+      case e: ThreadDeath          => throw e
+      case e: InterruptedException => throw e
+      case e: LinkageError         => throw e
+      case e: ControlThrowable     => throw e
+      case e: Throwable =>
+        val loggingContext = resp.request.context.getOrElse(resp.ctx).withSuffix("logging_request")
+        loggingContext.incrementException(e)(logger)
+        logger.error(s"Logging failed for ${resp.request.name} due to: ${e.traceString}")
+        resp
+    }
+  }
+
+  private def logResponseInternal(resp: ResponseWithContext): ResponseWithContext = {
     val loggingStartTs = System.currentTimeMillis()
     val loggingContext = resp.request.context.getOrElse(resp.ctx).withSuffix("logging_request")
     val loggingTs = resp.request.atMillis.getOrElse(resp.requestStartTs)

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -45,7 +45,7 @@ import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.ScalaJavaConversions.{IteratorOps, JListOps, JMapOps}
-import scala.util.control.ControlThrowable
+import scala.util.control.NonFatal
 import scala.util.{Failure, Random, Success, Try}
 
 object Fetcher {
@@ -453,17 +453,13 @@ class Fetcher(val kvStore: KVStore,
     tryOnce(null, tries, totalTries = tries)
   }
 
-  private def logResponse(resp: ResponseWithContext): ResponseWithContext = {
+  private[online] def logResponse(resp: ResponseWithContext): ResponseWithContext = {
     // Wrapping logging with try catch to separate logging failure from the user-facing fetch response.
+    // NonFatal also catches AssertionError (Error subclass) while letting true fatals propagate.
     try {
       logResponseInternal(resp)
     } catch {
-      case e: VirtualMachineError  => throw e
-      case e: ThreadDeath          => throw e
-      case e: InterruptedException => throw e
-      case e: LinkageError         => throw e
-      case e: ControlThrowable     => throw e
-      case e: Throwable =>
+      case NonFatal(e) =>
         val loggingContext = resp.request.context.getOrElse(resp.ctx).withSuffix("logging_request")
         loggingContext.incrementException(e)(logger)
         logger.error(s"Logging failed for ${resp.request.name} due to: ${e.traceString}")
@@ -471,7 +467,7 @@ class Fetcher(val kvStore: KVStore,
     }
   }
 
-  private def logResponseInternal(resp: ResponseWithContext): ResponseWithContext = {
+  protected def logResponseInternal(resp: ResponseWithContext): ResponseWithContext = {
     val loggingStartTs = System.currentTimeMillis()
     val loggingContext = resp.request.context.getOrElse(resp.ctx).withSuffix("logging_request")
     val loggingTs = resp.request.atMillis.getOrElse(resp.requestStartTs)

--- a/online/src/test/scala/ai/chronon/online/FetcherLogResponseTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherLogResponseTest.scala
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online
+
+import ai.chronon.online.Fetcher.{Request, ResponseWithContext}
+import org.junit.Assert.{assertSame, fail}
+import org.junit.{Before, Test}
+import org.mockito.Answers
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * Verifies that Fetcher.logResponse never lets logging-side failures escape into the
+  * user-facing fetch path. The original oncall hit an AssertionError thrown from
+  * Row.to during avro encoding for the logging sample; that error (Error subclass) was
+  * fatal-typed enough to bypass the surrounding scala.util.Try wrappers and fail the
+  * fetch. logResponse now catches NonFatal explicitly and returns the original response.
+  */
+class FetcherLogResponseTest extends MockitoSugar with MockitoHelper {
+
+  private var kvStore: KVStore = _
+
+  @Before
+  def setup(): Unit = {
+    kvStore = mock[KVStore](Answers.RETURNS_DEEP_STUBS)
+    when(kvStore.executionContext).thenReturn(ExecutionContext.global)
+  }
+
+  private def buildFetcher(throwInLog: => Throwable): Fetcher =
+    new Fetcher(kvStore = kvStore, metaDataSet = "test_metadata") {
+      override protected def logResponseInternal(resp: ResponseWithContext): ResponseWithContext =
+        throw throwInLog
+    }
+
+  private def buildResponse(): ResponseWithContext =
+    ResponseWithContext(
+      request = Request(name = "test_join", keys = Map("user_id" -> Long.box(1L))),
+      ctx = Metrics.Context(Metrics.Environment.JoinFetching),
+      requestStartTs = System.currentTimeMillis(),
+      baseValues = Map("foo" -> "bar")
+    )
+
+  @Test
+  def logResponseSwallowsAssertionErrorAndReturnsOriginalResponse(): Unit = {
+    // AssertionError extends Error, so it bypasses scala.util.Try, but is NonFatal —
+    // logResponse must catch it and return the input unchanged so the fetch succeeds.
+    val fetcher = buildFetcher(new AssertionError("boom from Row.to"))
+    val resp = buildResponse()
+    val result = fetcher.logResponse(resp)
+    assertSame(resp, result)
+  }
+
+  @Test
+  def logResponseSwallowsRuntimeException(): Unit = {
+    val fetcher = buildFetcher(new RuntimeException("encode failed"))
+    val resp = buildResponse()
+    val result = fetcher.logResponse(resp)
+    assertSame(resp, result)
+  }
+
+  @Test
+  def logResponseRethrowsInterruptedException(): Unit = {
+    // Cooperative-cancellation signal — must NOT be swallowed.
+    val fetcher = buildFetcher(new InterruptedException("cancel me"))
+    try {
+      fetcher.logResponse(buildResponse())
+      fail("Expected InterruptedException to propagate")
+    } catch {
+      case _: InterruptedException => // expected
+    } finally {
+      // Clear interrupted flag in case it leaked onto the test thread.
+      Thread.interrupted()
+    }
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/GroupByServingInfoParsedTest.scala
+++ b/online/src/test/scala/ai/chronon/online/GroupByServingInfoParsedTest.scala
@@ -35,16 +35,20 @@ class GroupByServingInfoParsedTest {
     */
   @Test
   def testSelectedChrononSchemaStripsRepeatedNameSuffix(): Unit = {
-    val filterDataStruct = StructType("FilterData", Array(
-      StructField("session_id", StringType),
-      StructField("category", StringType),
-      StructField("timestamp", LongType) // inner field that collides with the outer column
-    ))
+    val filterDataStruct = StructType(
+      "FilterData",
+      Array(
+        StructField("session_id", StringType),
+        StructField("category", StringType),
+        StructField("timestamp", LongType) // inner field that collides with the outer column
+      )
+    )
 
-    val selectedChrononType = StructType("Value", Array(
-      StructField("filter_data", filterDataStruct),
-      StructField("timestamp", LongType)
-    ))
+    val selectedChrononType = StructType("Value",
+                                         Array(
+                                           StructField("filter_data", filterDataStruct),
+                                           StructField("timestamp", LongType)
+                                         ))
 
     // Serialize to Avro — the shared nameSet causes the outer "timestamp" to be renamed.
     val selectedAvroSchemaStr = AvroConversions.fromChrononSchema(selectedChrononType).toString()


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

  - Isolate logging failures from the user-facing fetch path in `Fetcher.logResponse`. The existing `Try`-based guards only catch `NonFatal`, so fatal-typed throwables (e.g. `AssertionError` from `Row.to`) bypassed them and    
  failed the fetch. Wrap the body in an outer try/catch that re-throws true fatals (`VirtualMachineError`, `ThreadDeath`, `InterruptedException`, `LinkageError`, `ControlThrowable`) and swallows everything else with the        
  existing exception metric + error log.
  - Handle struct values that arrive as a `Map[String, Any]` in `Row.to`. Nested rows surfaced through Spark SQL transforms (e.g. `trip_reservation_data.reservation_details` in `ai_signals_platform/trip.user_history.v3`) reach 
  the avro encoder as `scala.collection.immutable.HashMap`, which previously hit `assert(extraneousRecord != null, ...)` because only `Array[Any]` and `util.ArrayList[Any]` were handled. Add `collection.Map[_, _]` and          
  `util.Map[_, _]` cases that emit values in struct-declared order, defaulting missing keys to `null`.


## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

Tested against the user config in gateway machine with sampling = 100.0, fetching succeeded

```
SPARK_VERSION=3.2.1 python3 ~/.local/bin/run.py --mode=fetch -k '{"id_guest":xxxxx}' --conf-path production/joins/ai_signals_platform/trip.user_history.v3 -t join --chronon-jar ~/test/chronon-embedded.jar
```

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @yuli-han 
