### PR TITLE
[Chronon] Tag all Chronon-generated tables and add table type

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -67,4 +67,29 @@ object Constants {
   val chrononArchiveFlag: String = "chronon_archived"
   val ChainingRequestTs: String = "chaining_request_ts"
   val ChainingFetchTs: String = "chaining_fetch_ts"
+
+  // Table tagging: every Chronon-generated table/view carries these two properties.
+  val ChrononGenerated: String = "chronon_generated"
+  val ChrononTableType: String = "chronon_table_type"
+
+  // Values for ChrononTableType
+  object TableType {
+    val GroupBy: String = "group_by"
+    val Join: String = "join"
+    val JoinPart: String = "join_part"
+    val Bootstrap: String = "bootstrap"
+    val Upload: String = "upload"
+    val Logged: String = "logged"
+    val Consistency: String = "consistency"
+    val ConsistencyUpload: String = "consistency_upload"
+    val DailyStats: String = "daily_stats"
+    val DailyStatsUpload: String = "daily_stats_upload"
+    val Schema: String = "schema"
+    val Label: String = "label"
+    val LabelView: String = "label_view"
+    val StagingQuery: String = "staging_query"
+    val StagingQueryView: String = "staging_query_view"
+    val Comparison: String = "comparison"
+    val ComparisonStats: String = "comparison_stats"
+  }
 }

--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -86,9 +86,7 @@ object Constants {
     val DailyStatsUpload: String = "daily_stats_upload"
     val Schema: String = "schema"
     val Label: String = "label"
-    val LabelView: String = "label_view"
     val StagingQuery: String = "staging_query"
-    val StagingQueryView: String = "staging_query_view"
     val Comparison: String = "comparison"
     val ComparisonStats: String = "comparison_stats"
   }

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -772,25 +772,29 @@ class Analyzer(tableUtils: TableUtils,
   private def exportGroupBySchema(analyzeGroupByResult: AnalyzeGroupByResult,
                                   groupByConf: api.GroupBy,
                                   partition: String): Unit = {
-    exportSchema(analyzeGroupByResult.keySchema,
-                 analyzeGroupByResult.valueSchema,
-                 groupByConf.metaData.schemaTable,
-                 partition,
-                 Option(groupByConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
-                   Constants.ChrononGenerated -> "true",
-                   Constants.ChrononTableType -> Constants.TableType.Schema
-                 ))
+    exportSchema(
+      analyzeGroupByResult.keySchema,
+      analyzeGroupByResult.valueSchema,
+      groupByConf.metaData.schemaTable,
+      partition,
+      Option(groupByConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
+        Constants.ChrononGenerated -> "true",
+        Constants.ChrononTableType -> Constants.TableType.Schema
+      )
+    )
   }
 
   private def exportJoinSchema(analyzeJoinResult: AnalyzeJoinResult, joinConf: api.Join, partition: String): Unit = {
-    exportSchema(analyzeJoinResult.keySchema,
-                 analyzeJoinResult.finalOutputSchema,
-                 joinConf.metaData.schemaTable,
-                 partition,
-                 Option(joinConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
-                   Constants.ChrononGenerated -> "true",
-                   Constants.ChrononTableType -> Constants.TableType.Schema
-                 ))
+    exportSchema(
+      analyzeJoinResult.keySchema,
+      analyzeJoinResult.finalOutputSchema,
+      joinConf.metaData.schemaTable,
+      partition,
+      Option(joinConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
+        Constants.ChrononGenerated -> "true",
+        Constants.ChrononTableType -> Constants.TableType.Schema
+      )
+    )
   }
 
   private def exportSchema(keySchema: Seq[(String, DataType)],

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -776,7 +776,10 @@ class Analyzer(tableUtils: TableUtils,
                  analyzeGroupByResult.valueSchema,
                  groupByConf.metaData.schemaTable,
                  partition,
-                 groupByConf.metaData.tableProps)
+                 Option(groupByConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
+                   Constants.ChrononGenerated -> "true",
+                   Constants.ChrononTableType -> Constants.TableType.Schema
+                 ))
   }
 
   private def exportJoinSchema(analyzeJoinResult: AnalyzeJoinResult, joinConf: api.Join, partition: String): Unit = {
@@ -784,7 +787,10 @@ class Analyzer(tableUtils: TableUtils,
                  analyzeJoinResult.finalOutputSchema,
                  joinConf.metaData.schemaTable,
                  partition,
-                 joinConf.metaData.tableProps)
+                 Option(joinConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
+                   Constants.ChrononGenerated -> "true",
+                   Constants.ChrononTableType -> Constants.TableType.Schema
+                 ))
   }
 
   private def exportSchema(keySchema: Seq[(String, DataType)],

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -710,8 +710,11 @@ object GroupBy {
     val overrideStart = effectiveOverrideStartPartition.getOrElse(groupByConf.backfillStartDate)
     val outputTable = groupByConf.metaData.outputTable
     val tableProps = Option(groupByConf.metaData.tableProperties)
-      .map(_.toScala)
-      .orNull
+      .map(_.toScala.toMap)
+      .getOrElse(Map.empty) ++ Map(
+      Constants.ChrononGenerated -> "true",
+      Constants.ChrononTableType -> Constants.TableType.GroupBy
+    )
     val inputTables = groupByConf.getSources.toScala.map(_.table)
     val inputPartitionColumns = groupByConf.getSources.toScala
       .map(s => s.table -> Option(s.query.partitionColumn))

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -250,11 +250,13 @@ object GroupByUpload {
     kvDf
       .union(metaDf)
       .withColumn("ds", lit(endDs))
-      .saveUnPartitioned(groupByConf.metaData.uploadTable,
-                         Option(groupByConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
-                           Constants.ChrononGenerated -> "true",
-                           Constants.ChrononTableType -> Constants.TableType.Upload
-                         ))
+      .saveUnPartitioned(
+        groupByConf.metaData.uploadTable,
+        Option(groupByConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
+          Constants.ChrononGenerated -> "true",
+          Constants.ChrononTableType -> Constants.TableType.Upload
+        )
+      )
 
     val kvDfReloaded = tableUtils.sparkSession
       .table(groupByConf.metaData.uploadTable)

--- a/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupByUpload.scala
@@ -250,7 +250,11 @@ object GroupByUpload {
     kvDf
       .union(metaDf)
       .withColumn("ds", lit(endDs))
-      .saveUnPartitioned(groupByConf.metaData.uploadTable, groupByConf.metaData.tableProps)
+      .saveUnPartitioned(groupByConf.metaData.uploadTable,
+                         Option(groupByConf.metaData.tableProps).getOrElse(Map.empty) ++ Map(
+                           Constants.ChrononGenerated -> "true",
+                           Constants.ChrononTableType -> Constants.TableType.Upload
+                         ))
 
     val kvDfReloaded = tableUtils.sparkSession
       .table(groupByConf.metaData.uploadTable)

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -546,7 +546,9 @@ class Join(joinConf: api.Join,
         val enrichedDf = padExternalFields(joinedDf, bootstrapInfo)
 
         // set autoExpand = true since log table could be a bootstrap part
-        enrichedDf.save(bootstrapTable, tableProps, autoExpand = true)
+        enrichedDf.save(bootstrapTable,
+                        tableProps + (Constants.ChrononTableType -> Constants.TableType.Bootstrap),
+                        autoExpand = true)
       })
 
     val elapsedMins = (System.currentTimeMillis() - startMillis) / (60 * 1000)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -68,7 +68,9 @@ abstract class JoinBase(joinConf: api.Join,
       Constants.SemanticHashOptionsKey -> gson.toJson(
         Map(
           Constants.SemanticHashExcludeTopic -> "true"
-        ).toJava)
+        ).toJava),
+      Constants.ChrononGenerated -> "true",
+      Constants.ChrononTableType -> Constants.TableType.Join
     )
 
   def joinWithLeft(leftDf: DataFrame, rightDf: DataFrame, joinPart: JoinPart): DataFrame = {
@@ -206,7 +208,9 @@ abstract class JoinBase(joinConf: api.Join,
             // Cache join part data into intermediate table
             if (filledDf.isDefined) {
               logger.info(s"Writing to join part table: $partTable for partition range $unfilledRange")
-              filledDf.get.save(partTable, tableProps, sortByCols = joinPart.groupBy.keyColumns.toScala)
+              filledDf.get.save(partTable,
+                                tableProps + (Constants.ChrononTableType -> Constants.TableType.JoinPart),
+                                sortByCols = joinPart.groupBy.keyColumns.toScala)
             } else {
               logger.info(s"Skipping $partTable because no data in computed joinPart.")
             }

--- a/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
@@ -105,9 +105,7 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
         tableUtils = tableUtils,
         viewProperties = Map(
           Constants.LabelViewPropertyKeyLabelTable -> outputLabelTable,
-          Constants.LabelViewPropertyFeatureTable -> joinConf.metaData.outputTable,
-          Constants.ChrononGenerated -> "true",
-          Constants.ChrononTableType -> Constants.TableType.LabelView
+          Constants.LabelViewPropertyFeatureTable -> joinConf.metaData.outputTable
         )
       )
       logger.info(s"Final labeled view created: ${joinConf.metaData.outputFinalView}")

--- a/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
@@ -136,13 +136,15 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
         logger.info(s"Computing label join for range: $range  Label DS: ${labelDS.getOrElse(today)} $progress")
         JoinUtils.leftDf(joinConf, range, tableUtils).map { leftDfInRange =>
           computeRange(leftDfInRange, range, sanitizedLabelDs)
-            .save(outputLabelTable,
-                  confTableProps ++ Map(
-                    Constants.ChrononGenerated -> "true",
-                    Constants.ChrononTableType -> Constants.TableType.Label
-                  ),
-                  Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
-                  true)
+            .save(
+              outputLabelTable,
+              confTableProps ++ Map(
+                Constants.ChrononGenerated -> "true",
+                Constants.ChrononTableType -> Constants.TableType.Label
+              ),
+              Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
+              true
+            )
           val elapsedMins = (System.currentTimeMillis() - startMillis) / (60 * 1000)
           metrics.gauge(Metrics.Name.LatencyMinutes, elapsedMins)
           metrics.gauge(Metrics.Name.PartitionCount, range.partitions.length)

--- a/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LabelJoin.scala
@@ -103,8 +103,12 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
         rightTable = outputLabelTable,
         joinKeys = labelJoinConf.rowIdentifier(joinConf.rowIds, tableUtils.partitionColumn),
         tableUtils = tableUtils,
-        viewProperties = Map(Constants.LabelViewPropertyKeyLabelTable -> outputLabelTable,
-                             Constants.LabelViewPropertyFeatureTable -> joinConf.metaData.outputTable)
+        viewProperties = Map(
+          Constants.LabelViewPropertyKeyLabelTable -> outputLabelTable,
+          Constants.LabelViewPropertyFeatureTable -> joinConf.metaData.outputTable,
+          Constants.ChrononGenerated -> "true",
+          Constants.ChrononTableType -> Constants.TableType.LabelView
+        )
       )
       logger.info(s"Final labeled view created: ${joinConf.metaData.outputFinalView}")
       JoinUtils.createLatestLabelView(joinConf.metaData.outputLatestLabelView,
@@ -133,7 +137,10 @@ class LabelJoin(joinConf: api.Join, tableUtils: TableUtils, labelDS: String) {
         JoinUtils.leftDf(joinConf, range, tableUtils).map { leftDfInRange =>
           computeRange(leftDfInRange, range, sanitizedLabelDs)
             .save(outputLabelTable,
-                  confTableProps,
+                  confTableProps ++ Map(
+                    Constants.ChrononGenerated -> "true",
+                    Constants.ChrononTableType -> Constants.TableType.Label
+                  ),
                   Seq(Constants.LabelPartitionColumn, tableUtils.partitionColumn),
                   true)
           val elapsedMins = (System.currentTimeMillis() - startMillis) / (60 * 1000)

--- a/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
@@ -232,8 +232,11 @@ class LogFlattenerJob(session: SparkSession,
       logger.info(flattenedDf.schema.pretty)
       tableUtils.insertPartitions(flattenedDf,
                                   joinConf.metaData.loggedTable,
-                                  tableProperties =
-                                    joinTblProps ++ schemaTblProps ++ Map(Constants.ChrononLogTable -> true.toString),
+                                  tableProperties = joinTblProps ++ schemaTblProps ++ Map(
+                                    Constants.ChrononLogTable -> true.toString,
+                                    Constants.ChrononGenerated -> "true",
+                                    Constants.ChrononTableType -> Constants.TableType.Logged
+                                  ),
                                   autoExpand = true)
 
       val inputRowCount = rawDf.count()

--- a/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
@@ -230,14 +230,16 @@ class LogFlattenerJob(session: SparkSession,
       val schemaTblProps = buildTableProperties(schemaStringsMap)
       logger.info("======= Log table schema =======")
       logger.info(flattenedDf.schema.pretty)
-      tableUtils.insertPartitions(flattenedDf,
-                                  joinConf.metaData.loggedTable,
-                                  tableProperties = joinTblProps ++ schemaTblProps ++ Map(
-                                    Constants.ChrononLogTable -> true.toString,
-                                    Constants.ChrononGenerated -> "true",
-                                    Constants.ChrononTableType -> Constants.TableType.Logged
-                                  ),
-                                  autoExpand = true)
+      tableUtils.insertPartitions(
+        flattenedDf,
+        joinConf.metaData.loggedTable,
+        tableProperties = joinTblProps ++ schemaTblProps ++ Map(
+          Constants.ChrononLogTable -> true.toString,
+          Constants.ChrononGenerated -> "true",
+          Constants.ChrononTableType -> Constants.TableType.Logged
+        ),
+        autoExpand = true
+      )
 
       val inputRowCount = rawDf.count()
       // read from output table to avoid recomputation

--- a/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
+++ b/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
@@ -17,6 +17,7 @@
 package ai.chronon.spark
 
 import ai.chronon.api
+import ai.chronon.api.Constants
 import ai.chronon.api.Extensions._
 import ai.chronon.api.ParametricMacro
 import ai.chronon.spark.Extensions._

--- a/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
+++ b/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
@@ -35,7 +35,10 @@ class StagingQuery(stagingQueryConf: api.StagingQuery, endPartition: String, tab
     s"${stagingQueryConf.metaData.outputNamespace}.${StagingQuery.SIGNAL_PARTITIONS_TABLE_NAME}"
   private val tableProps = Option(stagingQueryConf.metaData.tableProperties)
     .map(_.toScala.toMap)
-    .orNull
+    .getOrElse(Map.empty) ++ Map(
+    Constants.ChrononGenerated -> "true",
+    Constants.ChrononTableType -> Constants.TableType.StagingQuery
+  )
 
   private val partitionCols: Seq[String] = Seq(tableUtils.partitionColumn) ++
     Option(stagingQueryConf.metaData.customJsonLookUp(key = "additional_partition_cols"))
@@ -138,6 +141,10 @@ class StagingQuery(stagingQueryConf: api.StagingQuery, endPartition: String, tab
 
     val createViewSql = s"CREATE OR REPLACE VIEW $outputTable AS $processedQuery"
     tableUtils.sql(createViewSql)
+    tableUtils.alterTableProperties(
+      outputTable,
+      tableProps + (Constants.ChrononTableType -> Constants.TableType.StagingQueryView)
+    )
     logger.info(s"Created staging query view: $outputTable")
 
     writeSignalPartitionMetadata(outputTable)

--- a/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
+++ b/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
@@ -140,12 +140,7 @@ class StagingQuery(stagingQueryConf: api.StagingQuery, endPartition: String, tab
     // Process macros but not start_date/end_date since they're not in query
     val processedQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, null, null, endPartition)
 
-    val viewProps = tableProps + (Constants.ChrononTableType -> Constants.TableType.StagingQueryView)
-    val propertiesFragment = viewProps
-      .map { case (k, v) => s"'$k' = '$v'" }
-      .mkString(", ")
-    val createViewSql =
-      s"CREATE OR REPLACE VIEW $outputTable TBLPROPERTIES ($propertiesFragment) AS $processedQuery"
+    val createViewSql = s"CREATE OR REPLACE VIEW $outputTable AS $processedQuery"
     tableUtils.sql(createViewSql)
     logger.info(s"Created staging query view: $outputTable")
 

--- a/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
+++ b/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
@@ -140,12 +140,13 @@ class StagingQuery(stagingQueryConf: api.StagingQuery, endPartition: String, tab
     // Process macros but not start_date/end_date since they're not in query
     val processedQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, null, null, endPartition)
 
-    val createViewSql = s"CREATE OR REPLACE VIEW $outputTable AS $processedQuery"
+    val viewProps = tableProps + (Constants.ChrononTableType -> Constants.TableType.StagingQueryView)
+    val propertiesFragment = viewProps
+      .map { case (k, v) => s"'$k' = '$v'" }
+      .mkString(", ")
+    val createViewSql =
+      s"CREATE OR REPLACE VIEW $outputTable TBLPROPERTIES ($propertiesFragment) AS $processedQuery"
     tableUtils.sql(createViewSql)
-    tableUtils.alterTableProperties(
-      outputTable,
-      tableProps + (Constants.ChrononTableType -> Constants.TableType.StagingQueryView)
-    )
     logger.info(s"Created staging query view: $outputTable")
 
     writeSignalPartitionMetadata(outputTable)

--- a/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
@@ -75,25 +75,29 @@ class CompareJob(
     logger.info("Saving comparison output..")
     logger.info(
       s"Comparison schema ${compareDf.schema.fields.map(sb => (sb.name, sb.dataType)).toMap.mkString("\n - ")}")
-    tableUtils.insertUnPartitioned(compareDf,
-                                   comparisonTableName,
-                                   Option(tableProps).getOrElse(Map.empty) ++ Map(
-                                     Constants.ChrononGenerated -> "true",
-                                     Constants.ChrononTableType -> Constants.TableType.Comparison
-                                   ),
-                                   saveMode = SaveMode.Overwrite)
+    tableUtils.insertUnPartitioned(
+      compareDf,
+      comparisonTableName,
+      Option(tableProps).getOrElse(Map.empty) ++ Map(
+        Constants.ChrononGenerated -> "true",
+        Constants.ChrononTableType -> Constants.TableType.Comparison
+      ),
+      saveMode = SaveMode.Overwrite
+    )
 
     // Save the metrics table
     logger.info("Saving metrics output..")
     val metricsDf = metricsTimedKvRdd.toFlatDf
     logger.info(s"Metrics schema ${metricsDf.schema.fields.map(sb => (sb.name, sb.dataType)).toMap.mkString("\n - ")}")
-    tableUtils.insertUnPartitioned(metricsDf,
-                                   metricsTableName,
-                                   Option(tableProps).getOrElse(Map.empty) ++ Map(
-                                     Constants.ChrononGenerated -> "true",
-                                     Constants.ChrononTableType -> Constants.TableType.ComparisonStats
-                                   ),
-                                   saveMode = SaveMode.Overwrite)
+    tableUtils.insertUnPartitioned(
+      metricsDf,
+      metricsTableName,
+      Option(tableProps).getOrElse(Map.empty) ++ Map(
+        Constants.ChrononGenerated -> "true",
+        Constants.ChrononTableType -> Constants.TableType.ComparisonStats
+      ),
+      saveMode = SaveMode.Overwrite
+    )
 
     logger.info("Printing basic comparison results..")
     logger.info("(Note: This is just an estimation and not a detailed analysis of results)")

--- a/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/CompareJob.scala
@@ -75,13 +75,25 @@ class CompareJob(
     logger.info("Saving comparison output..")
     logger.info(
       s"Comparison schema ${compareDf.schema.fields.map(sb => (sb.name, sb.dataType)).toMap.mkString("\n - ")}")
-    tableUtils.insertUnPartitioned(compareDf, comparisonTableName, tableProps, saveMode = SaveMode.Overwrite)
+    tableUtils.insertUnPartitioned(compareDf,
+                                   comparisonTableName,
+                                   Option(tableProps).getOrElse(Map.empty) ++ Map(
+                                     Constants.ChrononGenerated -> "true",
+                                     Constants.ChrononTableType -> Constants.TableType.Comparison
+                                   ),
+                                   saveMode = SaveMode.Overwrite)
 
     // Save the metrics table
     logger.info("Saving metrics output..")
     val metricsDf = metricsTimedKvRdd.toFlatDf
     logger.info(s"Metrics schema ${metricsDf.schema.fields.map(sb => (sb.name, sb.dataType)).toMap.mkString("\n - ")}")
-    tableUtils.insertUnPartitioned(metricsDf, metricsTableName, tableProps, saveMode = SaveMode.Overwrite)
+    tableUtils.insertUnPartitioned(metricsDf,
+                                   metricsTableName,
+                                   Option(tableProps).getOrElse(Map.empty) ++ Map(
+                                     Constants.ChrononGenerated -> "true",
+                                     Constants.ChrononTableType -> Constants.TableType.ComparisonStats
+                                   ),
+                                   saveMode = SaveMode.Overwrite)
 
     logger.info("Printing basic comparison results..")
     logger.info("(Note: This is just an estimation and not a detailed analysis of results)")

--- a/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
@@ -130,11 +130,18 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
       logger.info(s"output schema ${outputDf.schema.fields.map(sb => (sb.name, sb.dataType)).toMap.mkString("\n - ")}")
       tableUtils.insertPartitions(outputDf,
                                   joinConf.metaData.consistencyTable,
-                                  tableProperties = tblProperties,
+                                  tableProperties = tblProperties ++ Map(
+                                    Constants.ChrononGenerated -> "true",
+                                    Constants.ChrononTableType -> Constants.TableType.Consistency
+                                  ),
                                   autoExpand = true)
       metricsKvRdd.toAvroDf
         .withTimeBasedColumn(tableUtils.partitionColumn)
-        .save(joinConf.metaData.consistencyUploadTable, tblProperties)
+        .save(joinConf.metaData.consistencyUploadTable,
+              tblProperties ++ Map(
+                Constants.ChrononGenerated -> "true",
+                Constants.ChrononTableType -> Constants.TableType.ConsistencyUpload
+              ))
       metrics
     }
     DataMetrics(allMetrics.flatMap(_.series))

--- a/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/ConsistencyJob.scala
@@ -128,20 +128,24 @@ class ConsistencyJob(session: SparkSession, joinConf: Join, endDate: String) ext
       logger.info("Saving output.")
       val outputDf = metricsKvRdd.toFlatDf.withTimeBasedColumn("ds")
       logger.info(s"output schema ${outputDf.schema.fields.map(sb => (sb.name, sb.dataType)).toMap.mkString("\n - ")}")
-      tableUtils.insertPartitions(outputDf,
-                                  joinConf.metaData.consistencyTable,
-                                  tableProperties = tblProperties ++ Map(
-                                    Constants.ChrononGenerated -> "true",
-                                    Constants.ChrononTableType -> Constants.TableType.Consistency
-                                  ),
-                                  autoExpand = true)
+      tableUtils.insertPartitions(
+        outputDf,
+        joinConf.metaData.consistencyTable,
+        tableProperties = tblProperties ++ Map(
+          Constants.ChrononGenerated -> "true",
+          Constants.ChrononTableType -> Constants.TableType.Consistency
+        ),
+        autoExpand = true
+      )
       metricsKvRdd.toAvroDf
         .withTimeBasedColumn(tableUtils.partitionColumn)
-        .save(joinConf.metaData.consistencyUploadTable,
-              tblProperties ++ Map(
-                Constants.ChrononGenerated -> "true",
-                Constants.ChrononTableType -> Constants.TableType.ConsistencyUpload
-              ))
+        .save(
+          joinConf.metaData.consistencyUploadTable,
+          tblProperties ++ Map(
+            Constants.ChrononGenerated -> "true",
+            Constants.ChrononTableType -> Constants.TableType.ConsistencyUpload
+          )
+        )
       metrics
     }
     DataMetrics(allMetrics.flatMap(_.series))

--- a/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
@@ -81,18 +81,22 @@ class SummaryJob(session: SparkSession, joinConf: Join, endDate: String) extends
           // Build upload table for stats store.
           summaryKvRdd.toAvroDf
             .withTimeBasedColumn(tableUtils.partitionColumn)
-            .save(uploadTable,
-                  Option(tableProps).getOrElse(Map.empty) ++ Map(
-                    Constants.ChrononGenerated -> "true",
-                    Constants.ChrononTableType -> Constants.TableType.DailyStatsUpload
-                  ))
+            .save(
+              uploadTable,
+              Option(tableProps).getOrElse(Map.empty) ++ Map(
+                Constants.ChrononGenerated -> "true",
+                Constants.ChrononTableType -> Constants.TableType.DailyStatsUpload
+              )
+            )
           stats
             .addDerivedMetrics(summaryKvRdd.toFlatDf, aggregator)
-            .save(outputTable,
-                  Option(tableProps).getOrElse(Map.empty) ++ Map(
-                    Constants.ChrononGenerated -> "true",
-                    Constants.ChrononTableType -> Constants.TableType.DailyStats
-                  ))
+            .save(
+              outputTable,
+              Option(tableProps).getOrElse(Map.empty) ++ Map(
+                Constants.ChrononGenerated -> "true",
+                Constants.ChrononTableType -> Constants.TableType.DailyStats
+              )
+            )
           logger.info(s"Finished range [${index + 1}/${stepRanges.size}].")
       }
     }

--- a/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/stats/SummaryJob.scala
@@ -81,10 +81,18 @@ class SummaryJob(session: SparkSession, joinConf: Join, endDate: String) extends
           // Build upload table for stats store.
           summaryKvRdd.toAvroDf
             .withTimeBasedColumn(tableUtils.partitionColumn)
-            .save(uploadTable, tableProps)
+            .save(uploadTable,
+                  Option(tableProps).getOrElse(Map.empty) ++ Map(
+                    Constants.ChrononGenerated -> "true",
+                    Constants.ChrononTableType -> Constants.TableType.DailyStatsUpload
+                  ))
           stats
             .addDerivedMetrics(summaryKvRdd.toFlatDf, aggregator)
-            .save(outputTable, tableProps)
+            .save(outputTable,
+                  Option(tableProps).getOrElse(Map.empty) ++ Map(
+                    Constants.ChrononGenerated -> "true",
+                    Constants.ChrononTableType -> Constants.TableType.DailyStats
+                  ))
           logger.info(s"Finished range [${index + 1}/${stepRanges.size}].")
       }
     }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Adds two new table properties to every Chronon-generated table and view:
- chronon_generated=true: marks the table as Chronon-managed
- chronon_table_type=<type>: identifies the role of the table (group_by, join, join_part, bootstrap, upload, logged, consistency, consistency_upload, daily_stats, daily_stats_upload, schema, label, label_view, staging_query, staging_query_view, comparison, comparison_stats)

Properties are set via the existing alterTableProperties mechanism, so existing tables are retroactively tagged on their next job run.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@Shiyinghaha @pengyu-hou 
