### PR TITLE
Add configurable left-time-range gating for join backfill

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -282,7 +282,7 @@ class Join(joinConf: api.Join,
     // info to filter records that need backfills vs can be waived from backfills
     val bootstrapCoveringSets = findBootstrapSetCoverings(bootstrapDf, bootstrapInfo, leftRange)
 
-    val leftTimeRangeOpt = if (leftTaggedDf.schema.fieldNames.contains(Constants.TimePartitionColumn)) {
+    val leftTimeRangeOpt = if (tableUtils.checkLeftTimeRange && leftTaggedDf.schema.fieldNames.contains(Constants.TimePartitionColumn)) {
       val leftTimePartitionMinMax = leftTaggedDf.range[String](Constants.TimePartitionColumn)
       Some(PartitionRange(leftTimePartitionMinMax._1, leftTimePartitionMinMax._2)(tableUtils))
     } else {

--- a/spark/src/main/scala/ai/chronon/spark/Join.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Join.scala
@@ -282,12 +282,13 @@ class Join(joinConf: api.Join,
     // info to filter records that need backfills vs can be waived from backfills
     val bootstrapCoveringSets = findBootstrapSetCoverings(bootstrapDf, bootstrapInfo, leftRange)
 
-    val leftTimeRangeOpt = if (tableUtils.checkLeftTimeRange && leftTaggedDf.schema.fieldNames.contains(Constants.TimePartitionColumn)) {
-      val leftTimePartitionMinMax = leftTaggedDf.range[String](Constants.TimePartitionColumn)
-      Some(PartitionRange(leftTimePartitionMinMax._1, leftTimePartitionMinMax._2)(tableUtils))
-    } else {
-      None
-    }
+    val leftTimeRangeOpt =
+      if (tableUtils.checkLeftTimeRange && leftTaggedDf.schema.fieldNames.contains(Constants.TimePartitionColumn)) {
+        val leftTimePartitionMinMax = leftTaggedDf.range[String](Constants.TimePartitionColumn)
+        Some(PartitionRange(leftTimePartitionMinMax._1, leftTimePartitionMinMax._2)(tableUtils))
+      } else {
+        None
+      }
 
     implicit val executionContext: ExecutionContextExecutorService =
       ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(tableUtils.joinPartParallelism))

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -388,6 +388,8 @@ case class TableUtils(sparkSession: SparkSession) {
       None
   }.get
 
+  val checkLeftTimeRange: Boolean =
+    sparkSession.conf.get("spark.chronon.join.backfill.left_time_range.enabled", "true").toBoolean
   val joinPartParallelism: Int = sparkSession.conf.get("spark.chronon.join.part.parallelism", "1").toInt
   val aggregationParallelism: Int = sparkSession.conf.get("spark.chronon.group_by.parallelism", "1000").toInt
   val maxWait: Int = sparkSession.conf.get("spark.chronon.wait.hours", "48").toInt


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Added spark.chronon.join.backfill.left_time_range.enabled (default true) to TableUtils. When disabled, leftTimeRangeOpt is forced to None in Join.scala, causing computeRightTable to use leftRange.shift(-1) instead of the time-range-aware scan.

Trade-off: true preserves correct behavior for late-arriving events; false prevents future-timestamp blowup but introduces leakage — late events get features from a snapshot 1 day after their partition date rather than their actual event time.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
avoid query future ds too far away.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

