### PR TITLE
Fail temporal fetch when streaming KV reads fail

### DIFF
--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -496,8 +496,15 @@ class FetcherBase(kvStore: KVStore,
                   case Some(cachedResponse: CachedBatchResponse) => cachedResponse
                 }
 
-              val streamingResponsesOpt =
-                streamingRequestOpt.map(responsesMap.getOrElse(_, Success(Seq.empty)).getOrElse(Seq.empty))
+              val streamingResponsesOpt = streamingRequestOpt.map { streamingRequest =>
+                responsesMap
+                  .getOrElse(
+                    streamingRequest,
+                    Failure(new IllegalStateException(
+                      s"Couldn't find corresponding response for $streamingRequest in responseMap"))
+                  )
+                  .get
+              }
               val queryTs = request.atMillis.getOrElse(System.currentTimeMillis())
               val groupByResponse: Option[Map[String, AnyRef]] =
                 try {

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -883,6 +883,57 @@ class FetcherTest extends TestCase {
     exceptionKeys.foreach(k => assertTrue(responseMap.contains(k)))
   }
 
+  def testTemporalGroupByStreamingFailurePropagates(): Unit = {
+    val namespace = "test_temporal_group_by_streaming_failure"
+    val spark: SparkSession = createSparkSession()
+    val joinConf = generateMutationData(namespace, Some(spark))
+    val groupByConf = joinConf.joinParts.toScala.head.groupBy
+    val endDs = "2021-04-10"
+    val tableUtils = TableUtils(spark)
+    val kvStoreFunc = () => OnlineUtils.buildInMemoryKVStore("FetcherTest#testTemporalGroupByStreamingFailure")
+    val inMemoryKvStore = kvStoreFunc()
+    OnlineUtils.serve(tableUtils, inMemoryKvStore, kvStoreFunc, namespace, endDs, groupByConf, dropDsOnWrite = true)
+
+    val spyKvStore = spy(inMemoryKvStore)
+
+    @transient var spyRef = spyKvStore
+    val kvStoreWrapper = new KVStore with Serializable {
+      override def multiGet(requests: collection.Seq[KVStore.GetRequest]): Future[collection.Seq[KVStore.GetResponse]] =
+        spyRef.multiGet(requests)
+      override def multiPut(putRequests: collection.Seq[KVStore.PutRequest]): Future[collection.Seq[Boolean]] =
+        spyRef.multiPut(putRequests)
+      override def bulkPut(sourceOfflineTable: String, destinationOnlineDataSet: String, partition: String): Unit =
+        spyRef.bulkPut(sourceOfflineTable, destinationOnlineDataSet, partition)
+      override def create(dataset: String): Unit =
+        spyRef.create(dataset)
+    }
+
+    val mockApi = new MockApi(() => kvStoreWrapper, namespace)
+    @transient lazy val fetcher = mockApi.buildFetcher()
+
+    assertTrue(fetcher.getGroupByServingInfo(groupByConf.metaData.name).isSuccess)
+
+    when(spyKvStore.multiGet(any()))
+      .thenAnswer((invocation: org.mockito.invocation.InvocationOnMock) => {
+        val requests = invocation.getArgument[Seq[KVStore.GetRequest]](0)
+        Future.successful(
+          requests.map { req =>
+            if (req.afterTsMillis.isDefined) {
+              KVStore.GetResponse(req, Failure(new RuntimeException("kvstore error")))
+            } else {
+              Await.result(inMemoryKvStore.multiGet(Seq(req)), Duration(10, SECONDS)).head
+            }
+          }
+        )
+      })
+
+    val request = Seq(Request(groupByConf.metaData.name, Map("listing_id" -> 1L.asInstanceOf[AnyRef])))
+    val response = Await.result(fetcher.fetchGroupBys(request), Duration(10, SECONDS)).head
+
+    assertTrue(response.values.isFailure)
+    assertEquals("kvstore error", response.values.failed.get.getMessage)
+  }
+
   def testGroupByServingInfoTtlCacheRefresh(): Unit = {
     val namespace = "test_group_by_serving_info_ttl_cache_refresh"
     val spark: SparkSession = createSparkSession()


### PR DESCRIPTION
Addresses #1124.

## Summary
- fail TEMPORAL GroupBy fetches when the streaming KV request fails or is missing instead of treating it like empty streaming data
- add a regression test for the mixed case where the batch KV read succeeds but the streaming KV read fails

## Why
`FetcherBase` currently collapses a failed streaming KV response into `Seq.empty`. That makes a real streaming read failure look the same as "there just wasn't any streaming data", which can let a TEMPORAL fetch succeed with batch-only values.

This change takes the stricter path: if the streaming side fails, the TEMPORAL fetch fails too.

## Validation
- attempted `/tmp/bazelisk test //spark:test --test_filter=ai.chronon.spark.test.FetcherTest#testTemporalGroupByStreamingFailurePropagates`
- Bazel analysis was blocked by an external dependency fetch failure for `org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde`