### PR TITLE
Add incremental SNAPSHOT GroupBy aggregation

### DIFF
--- a/aggregator/src/main/scala/ai/chronon/aggregator/row/RowAggregator.scala
+++ b/aggregator/src/main/scala/ai/chronon/aggregator/row/RowAggregator.scala
@@ -70,6 +70,11 @@ class RowAggregator(val inputSchema: Seq[(String, DataType)], val aggregationPar
     .toArray
     .zip(columnAggregators.map(_.irType))
 
+  val incrementalOutputSchema: Array[(String, DataType)] = aggregationParts
+    .map(_.incrementalOutputColumnName)
+    .toArray
+    .zip(columnAggregators.map(_.irType))
+
   val outputSchema: Array[(String, DataType)] = aggregationParts
     .map(_.outputColumnName)
     .toArray

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -390,6 +390,7 @@ def GroupBy(
     historical_backfill: Optional[bool] = None,
     deprecation_date: Optional[str] = None,
     description: Optional[str] = None,
+    is_incremental: Optional[bool] = None,
     **kwargs,
 ) -> ttypes.GroupBy:
     """
@@ -608,6 +609,7 @@ def GroupBy(
         backfillStartDate=backfill_start_date,
         accuracy=accuracy,
         derivations=derivations,
+        isIncremental=is_incremental,
     )
     validate_group_by(group_by)
     return group_by

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -255,6 +255,16 @@ def validate_group_by(group_by: ttypes.GroupBy):
             if contains_windowed_aggregation(aggregations):
                 assert query.timeColumn, "Please specify timeColumn for entity source with windowed aggregations"
 
+    # is_incremental currently only supports SNAPSHOT accuracy with event sources.
+    # (Temporal accuracy and entity sources may be supported later.)
+    if group_by.isIncremental:
+        assert group_by.accuracy == Accuracy.SNAPSHOT, (
+            "is_incremental is only supported for SNAPSHOT accuracy group bys"
+        )
+        assert all([s.events for s in sources]), (
+            "is_incremental is only supported for event sources"
+        )
+
     column_set = None
     # all sources should select the same columns
     for i, source in enumerate(sources[1:]):

--- a/api/py/ai/chronon/group_by.py
+++ b/api/py/ai/chronon/group_by.py
@@ -258,12 +258,15 @@ def validate_group_by(group_by: ttypes.GroupBy):
     # is_incremental currently only supports SNAPSHOT accuracy with event sources.
     # (Temporal accuracy and entity sources may be supported later.)
     if group_by.isIncremental:
-        assert group_by.accuracy == Accuracy.SNAPSHOT, (
-            "is_incremental is only supported for SNAPSHOT accuracy group bys"
-        )
         assert all([s.events for s in sources]), (
             "is_incremental is only supported for event sources"
         )
+        # accuracy is optional: when unset it is inferred as SNAPSHOT unless a streaming
+        # source is present (which infers TEMPORAL). Accept the inferred-SNAPSHOT case.
+        is_snapshot = group_by.accuracy == Accuracy.SNAPSHOT or (
+            group_by.accuracy is None and not any([utils.is_streaming(s) for s in sources])
+        )
+        assert is_snapshot, "is_incremental is only supported for SNAPSHOT accuracy group bys"
 
     column_set = None
     # all sources should select the same columns

--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -75,6 +75,7 @@ object Constants {
   // Values for ChrononTableType
   object TableType {
     val GroupBy: String = "group_by"
+    val GroupByIncremental: String = "group_by_incremental"
     val Join: String = "join"
     val JoinPart: String = "join_part"
     val Bootstrap: String = "bootstrap"

--- a/api/src/main/scala/ai/chronon/api/Extensions.scala
+++ b/api/src/main/scala/ai/chronon/api/Extensions.scala
@@ -97,7 +97,7 @@ object Extensions {
     def cleanName: String = metaData.name.sanitize
 
     def outputTable = s"${metaData.outputNamespace}.${metaData.cleanName}"
-
+    def incrementalOutputTable = s"${metaData.outputNamespace}.${metaData.cleanName}_daily_inc"
     def preModelTransformsTable = s"${metaData.outputNamespace}.${metaData.cleanName}_pre_mt"
     def outputLabelTable = s"${metaData.outputNamespace}.${metaData.cleanName}_labels"
     def outputFinalView = s"${metaData.outputNamespace}.${metaData.cleanName}_labeled"
@@ -178,6 +178,10 @@ object Extensions {
 
     def outputColumnName =
       s"${aggregationPart.inputColumn}_$opSuffix${aggregationPart.window.suffix}${bucketSuffix}"
+
+    def incrementalOutputColumnName =
+      s"${aggregationPart.inputColumn}_$opSuffix${bucketSuffix}"
+
   }
 
   implicit class AggregationOps(aggregation: Aggregation) {

--- a/api/thrift/api.thrift
+++ b/api/thrift/api.thrift
@@ -309,6 +309,7 @@ struct GroupBy {
     6: optional string backfillStartDate
     // Optional derivation list
     7: optional list<Derivation> derivations
+    8: optional bool isIncremental
 }
 
 struct JoinPart {

--- a/spark/src/main/scala/ai/chronon/spark/DataRange.scala
+++ b/spark/src/main/scala/ai/chronon/spark/DataRange.scala
@@ -54,6 +54,11 @@ case class PartitionRange(start: String, end: String)(implicit tableUtils: Table
     }
   }
 
+  def daysBetween: Int = {
+    if (start == null || end == null) 0
+    else Stream.iterate(start)(tableUtils.partitionSpec.after).takeWhile(_ <= end).size
+  }
+
   def isSingleDay: Boolean = {
     start == end
   }

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -470,7 +470,8 @@ object Driver {
         tableUtils,
         args.stepDays.toOption,
         args.startPartitionOverride.toOption,
-        !args.runFirstHole()
+        !args.runFirstHole(),
+        Option(args.groupByConf.isIncremental).getOrElse(false)
       )
 
       if (args.shouldExport()) {

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -18,11 +18,12 @@ package ai.chronon.spark
 
 import ai.chronon.aggregator.base.TimeTuple
 import ai.chronon.aggregator.row.RowAggregator
+import ai.chronon.aggregator.windowing.HopsAggregator.HopIr
 import ai.chronon.aggregator.windowing._
 import ai.chronon.api
 import ai.chronon.api.DataModel.{Entities, Events}
 import ai.chronon.api.Extensions._
-import ai.chronon.api.{Accuracy, Constants, DataModel, ParametricMacro}
+import ai.chronon.api.{Accuracy, Constants, DataModel, ParametricMacro, TimeUnit, Window}
 import ai.chronon.online.serde.{RowWrapper, SparkConversions}
 import ai.chronon.spark.Extensions._
 import ai.chronon.spark.catalog.TableUtils
@@ -32,6 +33,8 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.util.sketch.BloomFilter
 import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters._
 
 import java.util
 import scala.collection.{Seq, mutable}
@@ -89,9 +92,17 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
   lazy val aggPartWithSchema = aggregationParts.zip(columnAggregators.map(_.outputType))
 
   lazy val postAggSchema: StructType = {
-    val valueChrononSchema = if (finalize) windowAggregator.outputSchema else windowAggregator.irSchema
+    val valueChrononSchema = if (finalize) {
+      windowAggregator.outputSchema
+    } else {
+      windowAggregator.irSchema
+    }
     SparkConversions.fromChrononSchema(valueChrononSchema)
   }
+
+  @transient lazy val flattenedAgg: RowAggregator =
+    new RowAggregator(selectedSchema, aggregations.flatMap(_.unWindowed))
+  lazy val incrementalSchema: Array[(String, api.DataType)] = flattenedAgg.incrementalOutputSchema
 
   @transient
   protected[spark] lazy val windowAggregator: RowAggregator =
@@ -357,6 +368,30 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
     toDf(outputRdd, Seq(Constants.TimeColumn -> LongType, tableUtils.partitionColumn -> StringType))
   }
 
+  def flattenOutputArrayType(
+      hopsArrays: RDD[(KeyWithHash, HopsAggregator.OutputArrayType)]): RDD[(Array[Any], Array[Any])] = {
+    hopsArrays.flatMap {
+      case (keyWithHash: KeyWithHash, hopsArray: HopsAggregator.OutputArrayType) =>
+        hopsArray.headOption match {
+          case Some(dailyHops) =>
+            dailyHops.map { hopIr =>
+              val timestamp = hopIr.last.asInstanceOf[Long]
+              val normalizedIR = flattenedAgg.normalize(hopIr.dropRight(1))
+              ((keyWithHash.data :+ tableUtils.partitionSpec.at(timestamp) :+ timestamp), normalizedIR)
+            }
+          case None => Iterator.empty
+        }
+    }
+  }
+
+  def convertHopsToDf(hops: RDD[(KeyWithHash, HopsAggregator.OutputArrayType)],
+                      schema: Array[(String, ai.chronon.api.DataType)]): DataFrame = {
+    val hopsDf = flattenOutputArrayType(hops)
+    toDf(hopsDf,
+         Seq(tableUtils.partitionColumn -> StringType, Constants.TimeColumn -> LongType),
+         Some(SparkConversions.fromChrononSchema(schema)))
+  }
+
   // convert raw data into IRs, collected by hopSizes
   // TODO cache this into a table: interface below
   // Class HopsCacher(keySchema, irSchema, resolution) extends RddCacher[(KeyWithHash, HopsOutput)]
@@ -380,9 +415,10 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
   }
 
   protected[spark] def toDf(aggregateRdd: RDD[(Array[Any], Array[Any])],
-                            additionalFields: Seq[(String, DataType)]): DataFrame = {
+                            additionalFields: Seq[(String, DataType)],
+                            schema: Option[StructType] = None): DataFrame = {
     val finalKeySchema = StructType(keySchema ++ additionalFields.map { case (name, typ) => StructField(name, typ) })
-    KvRdd(aggregateRdd, finalKeySchema, postAggSchema).toFlatDf
+    KvRdd(aggregateRdd, finalKeySchema, schema.getOrElse(postAggSchema)).toFlatDf
   }
 
   private def normalizeOrFinalize(ir: Array[Any]): Array[Any] =
@@ -392,6 +428,18 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
       windowAggregator.normalize(ir)
     }
 
+  /**
+    * computes incremental daily table
+    * @param incrementalOutputTable output of the incremental data stored here
+    * @param range date range to calculate daily aggregations
+    * @param tableProps
+    */
+  def computeIncrementalDf(incrementalOutputTable: String, range: PartitionRange, tableProps: Map[String, String]) = {
+
+    val hops = hopsAggregate(range.toTimePoints.min, DailyResolution)
+    val hopsDf: DataFrame = convertHopsToDf(hops, incrementalSchema)
+    hopsDf.save(incrementalOutputTable, tableProps)
+  }
 }
 
 // TODO: truncate queryRange for caching
@@ -463,31 +511,16 @@ object GroupBy {
            bloomMapOpt: Option[util.Map[String, BloomFilter]] = None,
            skewFilter: Option[String] = None,
            finalize: Boolean = true,
-           showDf: Boolean = false): GroupBy = {
+           showDf: Boolean = false,
+           incrementalMode: Boolean = false): GroupBy = {
     logger.info(s"\n----[Processing GroupBy: ${groupByConfOld.metaData.name}]----")
     val groupByConf = replaceJoinSource(groupByConfOld, queryRange, tableUtils, computeDependency, showDf)
-    val inputDf = groupByConf.sources.toScala
-      .map { source =>
-        val partitionColumn = tableUtils.getPartitionColumn(source.query)
-        tableUtils.sqlWithDefaultPartitionColumn(
-          renderDataSourceQuery(
-            groupByConf,
-            source,
-            groupByConf.getKeyColumns.toScala,
-            queryRange,
-            tableUtils,
-            groupByConf.maxWindow,
-            groupByConf.inferredAccuracy,
-            partitionColumn = partitionColumn
-          ),
-          existingPartitionColumn = partitionColumn
-        )
-      }
-      .reduce { (df1, df2) =>
-        // align the columns by name - when one source has select * the ordering might not be aligned
-        val columns1 = df1.schema.fields.map(_.name)
-        df1.union(df2.selectExpr(columns1: _*))
-      }
+    val sourceQueryWindow: Option[Window] =
+      if (incrementalMode) Some(new Window(queryRange.daysBetween, TimeUnit.DAYS)) else groupByConf.maxWindow
+    val backfillQueryRange: PartitionRange =
+      if (incrementalMode) PartitionRange(queryRange.end, queryRange.end)(tableUtils) else queryRange
+    val inputDf =
+      buildSourceDataFrame(groupByConf, backfillQueryRange, sourceQueryWindow, tableUtils, schemaOnly = false)
 
     def doesNotNeedTime = !Option(groupByConf.getAggregations).exists(_.toScala.needsTimestamp)
     def hasValidTimeColumn = inputDf.schema.find(_.name == Constants.TimeColumn).exists(_.dataType == LongType)
@@ -553,15 +586,22 @@ object GroupBy {
         logger.info(s"printing mutation data for groupBy: ${groupByConf.metaData.name}")
         df.prettyPrint()
       }
-
       df
+    }
+
+    //if incrementalMode is enabled, we do not compute finalize values
+    //IR values are stored in the table
+    val finalizeValue = if (incrementalMode) {
+      false
+    } else {
+      finalize
     }
 
     new GroupBy(Option(groupByConf.getAggregations).map(_.toScala).orNull,
                 keyColumns,
                 nullFiltered,
                 mutationDfFn,
-                finalize = finalize)
+                finalize = finalizeValue)
   }
 
   def getIntersectedRange(source: api.Source,
@@ -688,12 +728,220 @@ object GroupBy {
     query
   }
 
+  /**
+    * Builds a unified DataFrame from all sources in the GroupBy configuration.
+    * Used to create input DataFrames with proper schema alignment.
+    *
+    * @param groupByConf the GroupBy configuration
+    * @param range the partition range to query
+    * @param window the window size for querying (None uses maxWindow from config)
+    * @param tableUtils table utilities for partition handling
+    * @param schemaOnly if true, returns empty DataFrame with just schema (uses .limit(0))
+    * @return unified DataFrame from all sources
+    */
+  private def buildSourceDataFrame(
+      groupByConf: api.GroupBy,
+      range: PartitionRange,
+      window: Option[Window],
+      tableUtils: TableUtils,
+      schemaOnly: Boolean = false
+  ): DataFrame = {
+    groupByConf.sources.toScala
+      .map { source =>
+        val partitionColumn = tableUtils.getPartitionColumn(source.query)
+        val df = tableUtils.sqlWithDefaultPartitionColumn(
+          renderDataSourceQuery(
+            groupByConf,
+            source,
+            groupByConf.getKeyColumns.toScala,
+            range,
+            tableUtils,
+            window.orElse(groupByConf.maxWindow),
+            groupByConf.inferredAccuracy,
+            partitionColumn = partitionColumn
+          ),
+          existingPartitionColumn = partitionColumn
+        )
+        if (schemaOnly) df.limit(0) else df
+      }
+      .reduce { (df1, df2) =>
+        // align the columns by name - when one source has select * the ordering might not be aligned
+        val columns1 = df1.schema.fields.map(_.name)
+        df1.union(df2.selectExpr(columns1: _*))
+      }
+  }
+
+  /**
+    * Computes and saves the output of hopsAggregation.
+    * HopsAggregate computes event level data to daily aggregates and saves the output in IR format
+    *
+    * @param groupByConf
+    * @param range
+    * @param tableUtils
+    */
+  def computeIncrementalDf(
+      groupByConf: api.GroupBy,
+      range: PartitionRange,
+      tableUtils: TableUtils,
+      incrementalOutputTable: String
+  ): (PartitionRange, Seq[api.AggregationPart]) = {
+
+    val tableProps: Map[String, String] = Option(groupByConf.metaData.tableProperties)
+      .map(_.toScala)
+      .orNull
+
+    val maxWindow = groupByConf.maxWindow.getOrElse(
+      throw new IllegalArgumentException(
+        s"GroupBy ${groupByConf.metaData.name} has no windowed aggregations. " +
+          "Incremental mode requires at least one windowed aggregation."))
+
+    val incrementalQueryableRange = PartitionRange(
+      tableUtils.partitionSpec.minus(range.start, maxWindow),
+      range.end
+    )(tableUtils)
+
+    logger.info(s"Writing incremental df to $incrementalOutputTable")
+
+    val partitionRangeHoles: Option[Seq[PartitionRange]] = tableUtils.unfilledRanges(
+      incrementalOutputTable,
+      incrementalQueryableRange,
+      skipFirstHole = false
+    )
+
+    val aggregationParts = groupByConf.getAggregations.toScala.flatMap(_.unWindowed)
+
+    partitionRangeHoles.foreach { holes =>
+      holes.foreach { hole =>
+        logger.info(s"Filling hole in incremental table: $hole")
+        val incrementalGroupByBackfill =
+          from(groupByConf, hole, tableUtils, computeDependency = true, incrementalMode = true)
+        incrementalGroupByBackfill.computeIncrementalDf(incrementalOutputTable, hole, tableProps)
+      }
+    }
+
+    (incrementalQueryableRange, aggregationParts)
+  }
+
+  private def convertIncrementalDfToHops(
+      incrementalDf: DataFrame,
+      aggregationParts: Seq[api.AggregationPart],
+      groupByConf: api.GroupBy,
+      tableUtils: TableUtils,
+      inputSchema: Seq[(String, api.DataType)]): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] = {
+
+    val keyColumns = groupByConf.getKeyColumns.toScala
+    val keyBuilder: Row => KeyWithHash =
+      FastHashing.generateKeyBuilder(keyColumns.toArray, incrementalDf.schema)
+
+    incrementalDf.rdd
+      .mapPartitions { rows =>
+        // Reconstruct RowAggregator once per partition on executor
+        // Avoids serializing TimedDispatcher and reduces network overhead
+        val rowAggregator = new RowAggregator(inputSchema, aggregationParts)
+
+        rows.map { row =>
+          //Extract timestamp from partition column
+          val ds = row.getAs[String](tableUtils.partitionColumn)
+          val ts = tableUtils.partitionSpec.epochMillis(ds)
+
+          // Extract normalized IRs from the row
+          // Recursively convert Spark types to Java types that denormalize() expects
+          // This handles nested structures (e.g., FIRST_K: Array<Struct> → ArrayList[Array])
+          def convertSparkToJava(value: Any): Any =
+            value match {
+              case null   => null
+              case r: Row =>
+                // Struct → Array[Any], recursively convert nested values
+                r.toSeq.map(convertSparkToJava).toArray
+              case arr: scala.collection.mutable.WrappedArray[_] =>
+                // Array → ArrayList, recursively convert elements
+                val converted = arr.map(convertSparkToJava)
+                new java.util.ArrayList[Any](converted.toSeq.asJava)
+              case map: scala.collection.Map[_, _] =>
+                // Map → HashMap, recursively convert values
+                val javaMap = new java.util.HashMap[Any, Any]()
+                map.foreach {
+                  case (k, v) =>
+                    javaMap.put(k, convertSparkToJava(v))
+                }
+                javaMap
+              case other =>
+                // Scalars (Long, Double, String, byte arrays, etc.) pass through
+                other
+            }
+
+          val normalizedIrs = new Array[Any](aggregationParts.length)
+          aggregationParts.zipWithIndex.foreach {
+            case (part, idx) =>
+              val value = row.get(row.fieldIndex(part.incrementalOutputColumnName))
+              normalizedIrs(idx) = convertSparkToJava(value)
+          }
+
+          // Denormalize IRs to in-memory format (e.g., ArrayList -> HashSet)
+          val irs = rowAggregator.denormalize(normalizedIrs)
+
+          // Build HopIR : [IR1, IR2, ..., IRn, ts]
+          val hopIr: HopIr = irs :+ ts
+          (keyBuilder(row), hopIr)
+        }
+      }
+      .groupByKey()
+      .mapValues { hopIrs =>
+        //Convert to HopsAggregator.OutputArrayType: Array[Array[HopIr]]
+        val sortedHops = hopIrs.toArray.sortBy(_.last.asInstanceOf[Long])
+        Array(sortedHops)
+      }
+  }
+
+  def fromIncrementalDf(
+      groupByConf: api.GroupBy,
+      range: PartitionRange,
+      tableUtils: TableUtils
+  ): GroupBy = {
+
+    val incrementalOutputTable = groupByConf.metaData.incrementalOutputTable
+    assert(incrementalOutputTable != null,
+           s"incrementalOutputTable is not set for GroupBy: ${groupByConf.metaData.name}")
+
+    val (incrementalQueryableRange, aggregationParts) =
+      computeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable)
+
+    val (_, incrementalDf: DataFrame) = incrementalQueryableRange.scanQueryStringAndDf(null, incrementalOutputTable)
+
+    // Create a DataFrame with the source schema (raw data schema) to match aggregations
+    // We need this because GroupBy class variables expect inputDf schema to match aggregation input columns
+    // We create an empty DataFrame with the correct schema - it won't be used for computation
+    val sourceDf = buildSourceDataFrame(groupByConf, range, None, tableUtils, schemaOnly = true)
+
+    // Extract input schema for RowAggregator reconstruction on executors
+    // Pass lightweight schema instead of heavy RowAggregator to avoid serializing TimedDispatcher
+    val chrononSchema = SparkConversions.toChrononSchema(sourceDf.schema)
+
+    val incrementalHops =
+      convertIncrementalDfToHops(incrementalDf, aggregationParts, groupByConf, tableUtils, chrononSchema)
+
+    new GroupBy(
+      groupByConf.getAggregations.toScala,
+      groupByConf.getKeyColumns.toScala,
+      sourceDf, // Use source schema, not incremental schema
+      () => null
+    ) {
+      // Override hopsAggregate to return precomputed hops instead of computing from raw data
+      override def hopsAggregate(minQueryTs: Long,
+                                 resolution: Resolution): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] = {
+        incrementalHops
+      }
+    }
+
+  }
+
   def computeBackfill(groupByConf: api.GroupBy,
                       endPartition: String,
                       tableUtils: TableUtils,
                       stepDays: Option[Int] = None,
                       overrideStartPartition: Option[String] = None,
-                      skipFirstHole: Boolean = true): Unit = {
+                      skipFirstHole: Boolean = true,
+                      incrementalMode: Boolean = false): Unit = {
     assert(
       groupByConf.backfillStartDate != null,
       s"GroupBy:${groupByConf.metaData.name} has null backfillStartDate. This needs to be set for offline backfilling.")
@@ -754,7 +1002,11 @@ object GroupBy {
           stepRanges.zipWithIndex.foreach {
             case (range, index) =>
               logger.info(s"Computing group by for range: $range [${index + 1}/${stepRanges.size}]")
-              val groupByBackfill = from(groupByConf, range, tableUtils, computeDependency = true)
+              val groupByBackfill: GroupBy = if (incrementalMode) {
+                fromIncrementalDf(groupByConf, range, tableUtils)
+              } else {
+                from(groupByConf, range, tableUtils, computeDependency = true)
+              }
               val outputDf = groupByConf.dataModel match {
                 // group by backfills have to be snapshot only
                 case Entities => groupByBackfill.snapshotEntities

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -801,7 +801,8 @@ object GroupBy {
       range.end
     )(tableUtils)
 
-    logger.info(s"Materializing incremental df to $incrementalOutputTable for queryable range $incrementalQueryableRange")
+    logger.info(
+      s"Materializing incremental df to $incrementalOutputTable for queryable range $incrementalQueryableRange")
 
     val partitionRangeHoles: Option[Seq[PartitionRange]] = tableUtils.unfilledRanges(
       incrementalOutputTable,

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -429,15 +429,25 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
     }
 
   // Per-hole worker: aggregates `range` into daily IRs and writes them to the incremental table.
-  def computeIncrementalDf(incrementalOutputTable: String, range: PartitionRange, tableProps: Map[String, String]) = {
+  // Daily IRs are window-independent, so the resolution must be daily.
+  def computeIncrementalDf(incrementalOutputTable: String,
+                           range: PartitionRange,
+                           tableProps: Map[String, String],
+                           resolution: Resolution = DailyResolution) = {
+    require(resolution == DailyResolution,
+            s"Incremental IRs are daily; computeIncrementalDf requires DailyResolution, got $resolution")
 
-    val hops = hopsAggregate(range.toTimePoints.min, DailyResolution)
+    val hops = hopsAggregate(range.toTimePoints.min, resolution)
     val hopsDf: DataFrame = convertHopsToDf(hops, incrementalSchema)
     // hopsAggregate emits daily hops for days outside `range` (the source scan is widened by the
     // query window). Clamp the write to `range` so dynamic partition overwrite cannot clobber
     // neighboring partitions with window-truncated data.
     val clampedDf = hopsDf.filter(hopsDf.col(tableUtils.partitionColumn).between(range.start, range.end))
-    clampedDf.save(incrementalOutputTable, tableProps)
+    val incrementalTableProps = Option(tableProps).getOrElse(Map.empty) ++ Map(
+      Constants.ChrononGenerated -> "true",
+      Constants.ChrononTableType -> Constants.TableType.GroupByIncremental
+    )
+    clampedDf.save(incrementalOutputTable, incrementalTableProps)
   }
 }
 

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -989,10 +989,15 @@ object GroupBy {
       sourceDf,
       () => null
     ) {
-      // Serve the precomputed daily IRs instead of aggregating raw events.
+      // Serve the precomputed daily IRs instead of aggregating raw events. The cached IRs are daily,
+      // so reject any non-daily resolution (e.g. a TEMPORAL consumer passing FiveMinuteResolution)
+      // rather than silently returning daily hops as if finer-grained.
       override def hopsAggregate(minQueryTs: Long,
-                                 resolution: Resolution): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] =
+                                 resolution: Resolution): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] = {
+        require(resolution == DailyResolution,
+                s"Incremental hops are daily; hopsAggregate requires DailyResolution, got $resolution")
         incrementalHops
+      }
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -103,12 +103,9 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
   @transient lazy val flattenedAgg: RowAggregator =
     new RowAggregator(selectedSchema, aggregations.flatMap(_.unWindowed))
 
-  // The incremental (daily) IR column name drops the window suffix, since daily IRs are
-  // window-independent. So aggregations sharing the same (operation, input_column, bucket) but
-  // differing only by window collapse to the same column - e.g. SUM(price, 7d) and SUM(price, 30d)
-  // both -> price_sum, with identical IR values. We persist one column per distinct name; the read
-  // path (convertIncrementalDfToHops) looks up each part by name, so the collapsed windows all map
-  // back to that single column. These are the indices of the first occurrence of each name.
+  // The incremental column name drops the window suffix, so aggregations differing only by window
+  // collapse to one column with identical IR values (e.g. SUM(price,7d)/SUM(price,30d) -> price_sum).
+  // Keep the first occurrence of each name; the read path looks up by name and maps them all back.
   lazy val uniqueIncrementalIndices: Array[Int] = {
     val seen = mutable.HashSet.empty[String]
     flattenedAgg.incrementalOutputSchema.zipWithIndex.collect {
@@ -391,9 +388,7 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
             dailyHops.map { hopIr =>
               val timestamp = hopIr.last.asInstanceOf[Long]
               val normalizedIR = flattenedAgg.normalize(hopIr.dropRight(1))
-              // Keep only one value per distinct incremental column name (duplicates are identical),
-              // matching incrementalSchema.
-              val dedupedIR = uniqueIncrementalIndices.map(normalizedIR)
+              val dedupedIR = uniqueIncrementalIndices.map(normalizedIR) // match incrementalSchema
               ((keyWithHash.data :+ tableUtils.partitionSpec.at(timestamp) :+ timestamp), dedupedIR)
             }
           case None => Iterator.empty
@@ -446,7 +441,6 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
     }
 
   // Per-hole worker: aggregates `range` into daily IRs and writes them to the incremental table.
-  // Daily IRs are window-independent, so the resolution must be daily.
   def computeIncrementalDf(incrementalOutputTable: String,
                            range: PartitionRange,
                            tableProps: Map[String, String],
@@ -456,9 +450,8 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
 
     val hops = hopsAggregate(range.toTimePoints.min, resolution)
     val hopsDf: DataFrame = convertHopsToDf(hops, incrementalSchema)
-    // hopsAggregate emits daily hops for days outside `range` (the source scan is widened by the
-    // query window). Clamp the write to `range` so dynamic partition overwrite cannot clobber
-    // neighboring partitions with window-truncated data.
+    // hopsAggregate emits hops outside `range` (the source scan is window-widened); clamp the write
+    // so dynamic partition overwrite cannot clobber neighbors with window-truncated data.
     val clampedDf = hopsDf.filter(hopsDf.col(tableUtils.partitionColumn).between(range.start, range.end))
     val incrementalTableProps = Option(tableProps).getOrElse(Map.empty) ++ Map(
       Constants.ChrononGenerated -> "true",
@@ -788,22 +781,11 @@ object GroupBy {
   }
 
   /**
-    * The "build" / producer half of incremental mode: fills the per-day IR table
-    * (`<table>_daily_inc`) for the range needed to serve `range` (i.e. `[range.start - maxWindow,
-    * range.end]`). Idempotent - unfilledRanges makes it a no-op when the table is already complete,
-    * so it doubles as both the standalone producer node (production) and the ensure step of an ad
-    * hoc consumer (see `fromIncrementalDf`).
+    * Producer: idempotently fills the per-day IR table (`<table>_daily_inc`) for `[range.start -
+    * maxWindow, range.end]` (no-op when already complete, via unfilledRanges). Returns the queryable
+    * range a reader must scan and the unwindowed aggregation parts. Distinct from the instance-level
+    * `computeIncrementalDf`, which is the per-hole worker that writes a single sub-range.
     *
-    * Returns the queryable range (the window-expanded range a reader must scan) and the unwindowed
-    * aggregation parts, so a subsequent read does not recompute them.
-    *
-    * (Object-level "producer" build; distinct from the instance-level `computeIncrementalDf` which
-    * is the per-hole worker that aggregates and writes a single sub-range.)
-    *
-    * @param groupByConf
-    * @param range the output range to serve
-    * @param tableUtils
-    * @param incrementalOutputTable the `_daily_inc` table to fill
     * @param stepDays optional chunking of each hole into stepped sub-ranges (restartable, bounded memory)
     */
   def computeIncrementalDf(
@@ -839,11 +821,8 @@ object GroupBy {
 
     val aggregationParts = groupByConf.getAggregations.toScala.flatMap(_.unWindowed)
 
-    // Daily IRs are independent per ds, so each hole can be filled in stepped
-    // sub-ranges. Each sub-range commits separately - making the (potentially
-    // large) cold/full-recompute build restartable via unfilledRanges and
-    // bounding the per-write shuffle/memory footprint. stepDays = None keeps the
-    // original single-write behavior.
+    // Daily IRs are independent per ds, so fill each hole in stepped sub-ranges: each commits
+    // separately, making a large build restartable and bounding per-write memory. None = single write.
     partitionRangeHoles.foreach { holes =>
       holes.foreach { hole =>
         val subRanges = stepDays.map(hole.steps).getOrElse(Seq(hole))
@@ -887,8 +866,7 @@ object GroupBy {
     val keyBuilder: Row => KeyWithHash =
       FastHashing.generateKeyBuilder(keyColumns.toArray, incrementalDf.schema)
 
-    // Resolve column indices once on the driver (capturing the DataFrame schema, not the
-    // DataFrame itself, in the executor closure) instead of per row.
+    // Resolve column indices once on the driver (capture the schema, not the DataFrame).
     val partitionSpec = tableUtils.partitionSpec
     val partitionColIndex = incrementalDf.schema.fieldIndex(tableUtils.partitionColumn)
     val irColIndices: Array[Int] =
@@ -929,15 +907,12 @@ object GroupBy {
   }
 
   /**
-    * The "read" / consumer half of incremental mode: builds a GroupBy backed by the per-day IR
-    * table (`<table>_daily_inc`), overriding hopsAggregate to return the precomputed hops instead
-    * of scanning raw events. Any snapshot-events consumer (backfill, upload, later join) routes
-    * through hopsAggregate, so this is a mode-agnostic adapter - keep it free of consumer-specific
-    * logic.
+    * Consumer: builds a GroupBy backed by the per-day IR table, overriding hopsAggregate to return
+    * the cached hops instead of scanning raw events. Mode-agnostic adapter (backfill/upload/join all
+    * route through hopsAggregate) - keep it free of consumer-specific logic.
     *
-    * @param buildIfMissing when true (ad hoc / standalone), ensure the table is materialized first
-    *        (ensure-then-read). When false (production behind a dedicated producer node), only read;
-    *        the producer is the sole writer and consumers run as pure readers.
+    * @param buildIfMissing true = ensure-then-read (ad hoc); false = read-only (production, behind a
+    *        producer node that is the sole writer).
     */
   def fromIncrementalDf(
       groupByConf: api.GroupBy,
@@ -956,9 +931,8 @@ object GroupBy {
         // ensure-then-read: fill any holes (no-op if already complete), then read.
         computeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable, stepDays)
       } else {
-        // read-only: derive the same queryable range / parts without writing. Assumes an upstream
-        // producer node has already materialized the table; if holes remain, the read below simply
-        // reflects what is present (callers relying on this path depend on the producer).
+        // read-only: derive the queryable range / parts without writing (assumes an upstream
+        // producer node already materialized the table).
         val maxWindow = groupByConf.maxWindow.getOrElse(
           throw new IllegalArgumentException(
             s"GroupBy ${groupByConf.metaData.name} has no windowed aggregations. " +
@@ -989,9 +963,8 @@ object GroupBy {
       sourceDf,
       () => null
     ) {
-      // Serve the precomputed daily IRs instead of aggregating raw events. The cached IRs are daily,
-      // so reject any non-daily resolution (e.g. a TEMPORAL consumer passing FiveMinuteResolution)
-      // rather than silently returning daily hops as if finer-grained.
+      // Serve the precomputed daily IRs instead of aggregating raw events. Reject non-daily
+      // resolutions (e.g. a TEMPORAL consumer passing FiveMinuteResolution) rather than mis-serving.
       override def hopsAggregate(minQueryTs: Long,
                                  resolution: Resolution): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] = {
         require(resolution == DailyResolution,

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -102,7 +102,21 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
 
   @transient lazy val flattenedAgg: RowAggregator =
     new RowAggregator(selectedSchema, aggregations.flatMap(_.unWindowed))
-  lazy val incrementalSchema: Array[(String, api.DataType)] = flattenedAgg.incrementalOutputSchema
+
+  // The incremental (daily) IR column name drops the window suffix, since daily IRs are
+  // window-independent. So aggregations sharing the same (operation, input_column, bucket) but
+  // differing only by window collapse to the same column - e.g. SUM(price, 7d) and SUM(price, 30d)
+  // both -> price_sum, with identical IR values. We persist one column per distinct name; the read
+  // path (convertIncrementalDfToHops) looks up each part by name, so the collapsed windows all map
+  // back to that single column. These are the indices of the first occurrence of each name.
+  lazy val uniqueIncrementalIndices: Array[Int] = {
+    val seen = mutable.HashSet.empty[String]
+    flattenedAgg.incrementalOutputSchema.zipWithIndex.collect {
+      case ((name, _), idx) if seen.add(name) => idx
+    }
+  }
+  lazy val incrementalSchema: Array[(String, api.DataType)] =
+    uniqueIncrementalIndices.map(flattenedAgg.incrementalOutputSchema)
 
   @transient
   protected[spark] lazy val windowAggregator: RowAggregator =
@@ -377,7 +391,10 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
             dailyHops.map { hopIr =>
               val timestamp = hopIr.last.asInstanceOf[Long]
               val normalizedIR = flattenedAgg.normalize(hopIr.dropRight(1))
-              ((keyWithHash.data :+ tableUtils.partitionSpec.at(timestamp) :+ timestamp), normalizedIR)
+              // Keep only one value per distinct incremental column name (duplicates are identical),
+              // matching incrementalSchema.
+              val dedupedIR = uniqueIncrementalIndices.map(normalizedIR)
+              ((keyWithHash.data :+ tableUtils.partitionSpec.at(timestamp) :+ timestamp), dedupedIR)
             }
           case None => Iterator.empty
         }

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -831,6 +831,32 @@ object GroupBy {
     (incrementalQueryableRange, aggregationParts)
   }
 
+  // Recursively convert Spark types to the Java types that RowAggregator.denormalize() expects.
+  // Handles nested structures (e.g. FIRST_K: Array<Struct> -> ArrayList[Array]).
+  // Defined at object level (not as a per-row closure) so it is not re-allocated for every row.
+  private def convertSparkToJava(value: Any): Any =
+    value match {
+      case null   => null
+      case r: Row =>
+        // Struct -> Array[Any], recursively convert nested values
+        r.toSeq.map(convertSparkToJava).toArray
+      case arr: scala.collection.mutable.WrappedArray[_] =>
+        // Array -> ArrayList, recursively convert elements
+        val converted = arr.map(convertSparkToJava)
+        new java.util.ArrayList[Any](converted.toSeq.asJava)
+      case map: scala.collection.Map[_, _] =>
+        // Map -> HashMap, recursively convert values
+        val javaMap = new java.util.HashMap[Any, Any]()
+        map.foreach {
+          case (k, v) =>
+            javaMap.put(k, convertSparkToJava(v))
+        }
+        javaMap
+      case other =>
+        // Scalars (Long, Double, String, byte arrays, etc.) pass through
+        other
+    }
+
   private def convertIncrementalDfToHops(
       incrementalDf: DataFrame,
       aggregationParts: Seq[api.AggregationPart],
@@ -842,6 +868,14 @@ object GroupBy {
     val keyBuilder: Row => KeyWithHash =
       FastHashing.generateKeyBuilder(keyColumns.toArray, incrementalDf.schema)
 
+    // Resolve column indices once on the driver (capturing the DataFrame schema, not the
+    // DataFrame itself, in the executor closure) instead of per row.
+    val partitionSpec = tableUtils.partitionSpec
+    val partitionColIndex = incrementalDf.schema.fieldIndex(tableUtils.partitionColumn)
+    val irColIndices: Array[Int] =
+      aggregationParts.map(part => incrementalDf.schema.fieldIndex(part.incrementalOutputColumnName)).toArray
+    val numParts = aggregationParts.length
+
     incrementalDf.rdd
       .mapPartitions { rows =>
         // Reconstruct RowAggregator once per partition on executor
@@ -849,41 +883,16 @@ object GroupBy {
         val rowAggregator = new RowAggregator(inputSchema, aggregationParts)
 
         rows.map { row =>
-          //Extract timestamp from partition column
-          val ds = row.getAs[String](tableUtils.partitionColumn)
-          val ts = tableUtils.partitionSpec.epochMillis(ds)
+          // Extract timestamp from partition column
+          val ds = row.getString(partitionColIndex)
+          val ts = partitionSpec.epochMillis(ds)
 
-          // Extract normalized IRs from the row
-          // Recursively convert Spark types to Java types that denormalize() expects
-          // This handles nested structures (e.g., FIRST_K: Array<Struct> → ArrayList[Array])
-          def convertSparkToJava(value: Any): Any =
-            value match {
-              case null   => null
-              case r: Row =>
-                // Struct → Array[Any], recursively convert nested values
-                r.toSeq.map(convertSparkToJava).toArray
-              case arr: scala.collection.mutable.WrappedArray[_] =>
-                // Array → ArrayList, recursively convert elements
-                val converted = arr.map(convertSparkToJava)
-                new java.util.ArrayList[Any](converted.toSeq.asJava)
-              case map: scala.collection.Map[_, _] =>
-                // Map → HashMap, recursively convert values
-                val javaMap = new java.util.HashMap[Any, Any]()
-                map.foreach {
-                  case (k, v) =>
-                    javaMap.put(k, convertSparkToJava(v))
-                }
-                javaMap
-              case other =>
-                // Scalars (Long, Double, String, byte arrays, etc.) pass through
-                other
-            }
-
-          val normalizedIrs = new Array[Any](aggregationParts.length)
-          aggregationParts.zipWithIndex.foreach {
-            case (part, idx) =>
-              val value = row.get(row.fieldIndex(part.incrementalOutputColumnName))
-              normalizedIrs(idx) = convertSparkToJava(value)
+          // Extract normalized IRs from the row (Spark types -> Java types denormalize() expects).
+          val normalizedIrs = new Array[Any](numParts)
+          var idx = 0
+          while (idx < numParts) {
+            normalizedIrs(idx) = convertSparkToJava(row.get(irColIndices(idx)))
+            idx += 1
           }
 
           // Denormalize IRs to in-memory format (e.g., ArrayList -> HashSet)

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -979,6 +979,15 @@ object GroupBy {
     assert(
       groupByConf.backfillStartDate != null,
       s"GroupBy:${groupByConf.metaData.name} has null backfillStartDate. This needs to be set for offline backfilling.")
+    // Incremental mode currently only supports SNAPSHOT accuracy with event sources.
+    // (Temporal accuracy and entity sources may be supported later.)
+    require(
+      !incrementalMode ||
+        (groupByConf.inferredAccuracy == Accuracy.SNAPSHOT && groupByConf.dataModel == Events),
+      s"GroupBy:${groupByConf.metaData.name} has incremental mode enabled, which is only supported for " +
+        s"SNAPSHOT accuracy with event sources (found accuracy=${groupByConf.inferredAccuracy}, " +
+        s"dataModel=${groupByConf.dataModel})."
+    )
     groupByConf.setups.foreach(tableUtils.sql)
     val historicalBackfill = !groupByConf.metaData.isSetHistoricalBackfill || groupByConf.metaData.historicalBackfill
     val effectiveOverrideStartPartition = if (historicalBackfill) {

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -777,14 +777,22 @@ object GroupBy {
   }
 
   /**
-    * Computes and saves the output of hopsAggregation.
-    * HopsAggregate computes event level data to daily aggregates and saves the output in IR format
+    * The "build" / producer half of incremental mode: fills the per-day IR table
+    * (`<table>_daily_inc`) for the range needed to serve `range` (i.e. `[range.start - maxWindow,
+    * range.end]`). Idempotent - unfilledRanges makes it a no-op when the table is already complete,
+    * so it doubles as both the standalone producer node (production) and the ensure step of an ad
+    * hoc consumer (see `fromIncrementalDf`).
+    *
+    * Returns the queryable range (the window-expanded range a reader must scan) and the unwindowed
+    * aggregation parts, so a subsequent read does not recompute them.
     *
     * @param groupByConf
-    * @param range
+    * @param range the output range to serve
     * @param tableUtils
+    * @param incrementalOutputTable the `_daily_inc` table to fill
+    * @param stepDays optional chunking of each hole into stepped sub-ranges (restartable, bounded memory)
     */
-  def computeIncrementalDf(
+  def materializeIncrementalDf(
       groupByConf: api.GroupBy,
       range: PartitionRange,
       tableUtils: TableUtils,
@@ -806,7 +814,7 @@ object GroupBy {
       range.end
     )(tableUtils)
 
-    logger.info(s"Writing incremental df to $incrementalOutputTable")
+    logger.info(s"Materializing incremental df to $incrementalOutputTable for queryable range $incrementalQueryableRange")
 
     val partitionRangeHoles: Option[Seq[PartitionRange]] = tableUtils.unfilledRanges(
       incrementalOutputTable,
@@ -924,11 +932,23 @@ object GroupBy {
       }
   }
 
+  /**
+    * The "read" / consumer half of incremental mode: builds a GroupBy backed by the per-day IR
+    * table (`<table>_daily_inc`), overriding hopsAggregate to return the precomputed hops instead
+    * of scanning raw events. Any snapshot-events consumer (backfill, upload, later join) routes
+    * through hopsAggregate, so this is a mode-agnostic adapter - keep it free of consumer-specific
+    * logic.
+    *
+    * @param buildIfMissing when true (ad hoc / standalone), ensure the table is materialized first
+    *        (ensure-then-read). When false (production behind a dedicated producer node), only read;
+    *        the producer is the sole writer and consumers run as pure readers.
+    */
   def fromIncrementalDf(
       groupByConf: api.GroupBy,
       range: PartitionRange,
       tableUtils: TableUtils,
-      stepDays: Option[Int] = None
+      stepDays: Option[Int] = None,
+      buildIfMissing: Boolean = true
   ): GroupBy = {
 
     val incrementalOutputTable = groupByConf.metaData.incrementalOutputTable
@@ -936,7 +956,23 @@ object GroupBy {
            s"incrementalOutputTable is not set for GroupBy: ${groupByConf.metaData.name}")
 
     val (incrementalQueryableRange, aggregationParts) =
-      computeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable, stepDays)
+      if (buildIfMissing) {
+        // ensure-then-read: fill any holes (no-op if already complete), then read.
+        materializeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable, stepDays)
+      } else {
+        // read-only: derive the same queryable range / parts without writing. Assumes an upstream
+        // producer node has already materialized the table; if holes remain, the read below simply
+        // reflects what is present (callers relying on this path depend on the producer).
+        val maxWindow = groupByConf.maxWindow.getOrElse(
+          throw new IllegalArgumentException(
+            s"GroupBy ${groupByConf.metaData.name} has no windowed aggregations. " +
+              "Incremental mode requires at least one windowed aggregation."))
+        val queryableRange = PartitionRange(
+          tableUtils.partitionSpec.minus(range.start, maxWindow),
+          range.end
+        )(tableUtils)
+        (queryableRange, groupByConf.getAggregations.toScala.flatMap(_.unWindowed))
+      }
 
     val (_, incrementalDf: DataFrame) = incrementalQueryableRange.scanQueryStringAndDf(null, incrementalOutputTable)
 

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -428,20 +428,14 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
       windowAggregator.normalize(ir)
     }
 
-  /**
-    * computes incremental daily table
-    * @param incrementalOutputTable output of the incremental data stored here
-    * @param range date range to calculate daily aggregations
-    * @param tableProps
-    */
+  // Per-hole worker: aggregates `range` into daily IRs and writes them to the incremental table.
   def computeIncrementalDf(incrementalOutputTable: String, range: PartitionRange, tableProps: Map[String, String]) = {
 
     val hops = hopsAggregate(range.toTimePoints.min, DailyResolution)
     val hopsDf: DataFrame = convertHopsToDf(hops, incrementalSchema)
-    // The source scan for `range` is widened by the query window (getIntersectedRange), so
-    // hopsAggregate emits daily hops for days outside `range` too. With dynamic partition
-    // overwrite, saving those would clobber neighboring partitions with window-truncated
-    // (incomplete) data. Clamp the write to exactly the partitions we were asked to fill.
+    // hopsAggregate emits daily hops for days outside `range` (the source scan is widened by the
+    // query window). Clamp the write to `range` so dynamic partition overwrite cannot clobber
+    // neighboring partitions with window-truncated data.
     val clampedDf = hopsDf.filter(hopsDf.col(tableUtils.partitionColumn).between(range.start, range.end))
     clampedDf.save(incrementalOutputTable, tableProps)
   }
@@ -594,13 +588,8 @@ object GroupBy {
       df
     }
 
-    //if incrementalMode is enabled, we do not compute finalize values
-    //IR values are stored in the table
-    val finalizeValue = if (incrementalMode) {
-      false
-    } else {
-      finalize
-    }
+    // incremental mode stores un-finalized IRs in the table, so never finalize here.
+    val finalizeValue = if (incrementalMode) false else finalize
 
     new GroupBy(Option(groupByConf.getAggregations).map(_.toScala).orNull,
                 keyColumns,
@@ -734,15 +723,10 @@ object GroupBy {
   }
 
   /**
-    * Builds a unified DataFrame from all sources in the GroupBy configuration.
-    * Used to create input DataFrames with proper schema alignment.
+    * Unions all of the GroupBy's sources into one schema-aligned input DataFrame.
     *
-    * @param groupByConf the GroupBy configuration
-    * @param range the partition range to query
-    * @param window the window size for querying (None uses maxWindow from config)
-    * @param tableUtils table utilities for partition handling
-    * @param schemaOnly if true, returns empty DataFrame with just schema (uses .limit(0))
-    * @return unified DataFrame from all sources
+    * @param window query window (None uses the config's maxWindow)
+    * @param schemaOnly if true, returns an empty (limit 0) DataFrame with just the schema
     */
   private def buildSourceDataFrame(
       groupByConf: api.GroupBy,
@@ -786,13 +770,16 @@ object GroupBy {
     * Returns the queryable range (the window-expanded range a reader must scan) and the unwindowed
     * aggregation parts, so a subsequent read does not recompute them.
     *
+    * (Object-level "producer" build; distinct from the instance-level `computeIncrementalDf` which
+    * is the per-hole worker that aggregates and writes a single sub-range.)
+    *
     * @param groupByConf
     * @param range the output range to serve
     * @param tableUtils
     * @param incrementalOutputTable the `_daily_inc` table to fill
     * @param stepDays optional chunking of each hole into stepped sub-ranges (restartable, bounded memory)
     */
-  def materializeIncrementalDf(
+  def computeIncrementalDf(
       groupByConf: api.GroupBy,
       range: PartitionRange,
       tableUtils: TableUtils,
@@ -844,30 +831,21 @@ object GroupBy {
     (incrementalQueryableRange, aggregationParts)
   }
 
-  // Recursively convert Spark types to the Java types that RowAggregator.denormalize() expects.
-  // Handles nested structures (e.g. FIRST_K: Array<Struct> -> ArrayList[Array]).
-  // Defined at object level (not as a per-row closure) so it is not re-allocated for every row.
+  // Recursively convert Spark types to the Java types that RowAggregator.denormalize() expects
+  // (e.g. FIRST_K's Array<Struct> -> ArrayList[Array]). Object-level (not a per-row closure) so it
+  // is not re-allocated for every row.
   private def convertSparkToJava(value: Any): Any =
     value match {
-      case null   => null
+      case null => null
       case r: Row =>
-        // Struct -> Array[Any], recursively convert nested values
         r.toSeq.map(convertSparkToJava).toArray
       case arr: scala.collection.mutable.WrappedArray[_] =>
-        // Array -> ArrayList, recursively convert elements
-        val converted = arr.map(convertSparkToJava)
-        new java.util.ArrayList[Any](converted.toSeq.asJava)
+        new java.util.ArrayList[Any](arr.map(convertSparkToJava).toSeq.asJava)
       case map: scala.collection.Map[_, _] =>
-        // Map -> HashMap, recursively convert values
         val javaMap = new java.util.HashMap[Any, Any]()
-        map.foreach {
-          case (k, v) =>
-            javaMap.put(k, convertSparkToJava(v))
-        }
+        map.foreach { case (k, v) => javaMap.put(k, convertSparkToJava(v)) }
         javaMap
-      case other =>
-        // Scalars (Long, Double, String, byte arrays, etc.) pass through
-        other
+      case other => other
     }
 
   private def convertIncrementalDfToHops(
@@ -891,42 +869,32 @@ object GroupBy {
 
     incrementalDf.rdd
       .mapPartitions { rows =>
-        // Reconstruct RowAggregator once per partition on executor
-        // Avoids serializing TimedDispatcher and reduces network overhead
+        // Reconstruct RowAggregator per partition (avoids serializing TimedDispatcher).
         val rowAggregator = new RowAggregator(inputSchema, aggregationParts)
 
         rows.map { row =>
-          // Extract timestamp from partition column
-          val ds = row.getString(partitionColIndex)
-          val ts = partitionSpec.epochMillis(ds)
+          val ts = partitionSpec.epochMillis(row.getString(partitionColIndex))
 
-          // Extract normalized IRs from the row (Spark types -> Java types denormalize() expects).
           val normalizedIrs = new Array[Any](numParts)
           var idx = 0
           while (idx < numParts) {
             normalizedIrs(idx) = convertSparkToJava(row.get(irColIndices(idx)))
             idx += 1
           }
-
-          // Denormalize IRs to in-memory format (e.g., ArrayList -> HashSet)
           val irs = rowAggregator.denormalize(normalizedIrs)
 
-          // Build HopIR : [IR1, IR2, ..., IRn, ts]
+          // HopIR is [IR1, ..., IRn, ts]
           val hopIr: HopIr = irs :+ ts
           (keyBuilder(row), hopIr)
         }
       }
-      // Use aggregateByKey (map-side combine) instead of groupByKey to stay
-      // resilient to key skew: a hot key's daily hops are accumulated/merged
-      // incrementally rather than all shuffled to one task and materialized as a
-      // single Iterable. There is one IR row per (key, ds), so each buffer holds
-      // at most one hop per active day for the key.
+      // aggregateByKey (map-side combine) over groupByKey for skew resilience: a hot key's hops are
+      // merged incrementally instead of shuffled to one task as a single Iterable.
       .aggregateByKey(mutable.ArrayBuffer.empty[HopIr])(
         seqOp = (buf, hop) => buf += hop,
         combOp = (a, b) => a ++= b
       )
       .mapValues { hopIrs =>
-        //Convert to HopsAggregator.OutputArrayType: Array[Array[HopIr]]
         val sortedHops = hopIrs.toArray.sortBy(_.last.asInstanceOf[Long])
         Array(sortedHops)
       }
@@ -958,7 +926,7 @@ object GroupBy {
     val (incrementalQueryableRange, aggregationParts) =
       if (buildIfMissing) {
         // ensure-then-read: fill any holes (no-op if already complete), then read.
-        materializeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable, stepDays)
+        computeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable, stepDays)
       } else {
         // read-only: derive the same queryable range / parts without writing. Assumes an upstream
         // producer node has already materialized the table; if holes remain, the read below simply
@@ -976,13 +944,12 @@ object GroupBy {
 
     val (_, incrementalDf: DataFrame) = incrementalQueryableRange.scanQueryStringAndDf(null, incrementalOutputTable)
 
-    // Create a DataFrame with the source schema (raw data schema) to match aggregations
-    // We need this because GroupBy class variables expect inputDf schema to match aggregation input columns
-    // We create an empty DataFrame with the correct schema - it won't be used for computation
+    // Empty DF carrying the raw source schema - the GroupBy needs inputDf's schema to match the
+    // aggregation input columns; it is never read (hopsAggregate is overridden below).
     val sourceDf = buildSourceDataFrame(groupByConf, range, None, tableUtils, schemaOnly = true)
 
-    // Extract input schema for RowAggregator reconstruction on executors
-    // Pass lightweight schema instead of heavy RowAggregator to avoid serializing TimedDispatcher
+    // Pass the lightweight schema (not a RowAggregator) so executors rebuild it without serializing
+    // the TimedDispatcher.
     val chrononSchema = SparkConversions.toChrononSchema(sourceDf.schema)
 
     val incrementalHops =
@@ -991,16 +958,14 @@ object GroupBy {
     new GroupBy(
       groupByConf.getAggregations.toScala,
       groupByConf.getKeyColumns.toScala,
-      sourceDf, // Use source schema, not incremental schema
+      sourceDf,
       () => null
     ) {
-      // Override hopsAggregate to return precomputed hops instead of computing from raw data
+      // Serve the precomputed daily IRs instead of aggregating raw events.
       override def hopsAggregate(minQueryTs: Long,
-                                 resolution: Resolution): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] = {
+                                 resolution: Resolution): RDD[(KeyWithHash, HopsAggregator.OutputArrayType)] =
         incrementalHops
-      }
     }
-
   }
 
   def computeBackfill(groupByConf: api.GroupBy,

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -438,7 +438,12 @@ class GroupBy(val aggregations: Seq[api.Aggregation],
 
     val hops = hopsAggregate(range.toTimePoints.min, DailyResolution)
     val hopsDf: DataFrame = convertHopsToDf(hops, incrementalSchema)
-    hopsDf.save(incrementalOutputTable, tableProps)
+    // The source scan for `range` is widened by the query window (getIntersectedRange), so
+    // hopsAggregate emits daily hops for days outside `range` too. With dynamic partition
+    // overwrite, saving those would clobber neighboring partitions with window-truncated
+    // (incomplete) data. Clamp the write to exactly the partitions we were asked to fill.
+    val clampedDf = hopsDf.filter(hopsDf.col(tableUtils.partitionColumn).between(range.start, range.end))
+    clampedDf.save(incrementalOutputTable, tableProps)
   }
 }
 

--- a/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/GroupBy.scala
@@ -783,7 +783,8 @@ object GroupBy {
       groupByConf: api.GroupBy,
       range: PartitionRange,
       tableUtils: TableUtils,
-      incrementalOutputTable: String
+      incrementalOutputTable: String,
+      stepDays: Option[Int] = None
   ): (PartitionRange, Seq[api.AggregationPart]) = {
 
     val tableProps: Map[String, String] = Option(groupByConf.metaData.tableProperties)
@@ -810,12 +811,20 @@ object GroupBy {
 
     val aggregationParts = groupByConf.getAggregations.toScala.flatMap(_.unWindowed)
 
+    // Daily IRs are independent per ds, so each hole can be filled in stepped
+    // sub-ranges. Each sub-range commits separately - making the (potentially
+    // large) cold/full-recompute build restartable via unfilledRanges and
+    // bounding the per-write shuffle/memory footprint. stepDays = None keeps the
+    // original single-write behavior.
     partitionRangeHoles.foreach { holes =>
       holes.foreach { hole =>
-        logger.info(s"Filling hole in incremental table: $hole")
-        val incrementalGroupByBackfill =
-          from(groupByConf, hole, tableUtils, computeDependency = true, incrementalMode = true)
-        incrementalGroupByBackfill.computeIncrementalDf(incrementalOutputTable, hole, tableProps)
+        val subRanges = stepDays.map(hole.steps).getOrElse(Seq(hole))
+        subRanges.foreach { subRange =>
+          logger.info(s"Filling hole in incremental table: $subRange")
+          val incrementalGroupByBackfill =
+            from(groupByConf, subRange, tableUtils, computeDependency = true, incrementalMode = true)
+          incrementalGroupByBackfill.computeIncrementalDf(incrementalOutputTable, subRange, tableProps)
+        }
       }
     }
 
@@ -885,7 +894,15 @@ object GroupBy {
           (keyBuilder(row), hopIr)
         }
       }
-      .groupByKey()
+      // Use aggregateByKey (map-side combine) instead of groupByKey to stay
+      // resilient to key skew: a hot key's daily hops are accumulated/merged
+      // incrementally rather than all shuffled to one task and materialized as a
+      // single Iterable. There is one IR row per (key, ds), so each buffer holds
+      // at most one hop per active day for the key.
+      .aggregateByKey(mutable.ArrayBuffer.empty[HopIr])(
+        seqOp = (buf, hop) => buf += hop,
+        combOp = (a, b) => a ++= b
+      )
       .mapValues { hopIrs =>
         //Convert to HopsAggregator.OutputArrayType: Array[Array[HopIr]]
         val sortedHops = hopIrs.toArray.sortBy(_.last.asInstanceOf[Long])
@@ -896,7 +913,8 @@ object GroupBy {
   def fromIncrementalDf(
       groupByConf: api.GroupBy,
       range: PartitionRange,
-      tableUtils: TableUtils
+      tableUtils: TableUtils,
+      stepDays: Option[Int] = None
   ): GroupBy = {
 
     val incrementalOutputTable = groupByConf.metaData.incrementalOutputTable
@@ -904,7 +922,7 @@ object GroupBy {
            s"incrementalOutputTable is not set for GroupBy: ${groupByConf.metaData.name}")
 
     val (incrementalQueryableRange, aggregationParts) =
-      computeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable)
+      computeIncrementalDf(groupByConf, range, tableUtils, incrementalOutputTable, stepDays)
 
     val (_, incrementalDf: DataFrame) = incrementalQueryableRange.scanQueryStringAndDf(null, incrementalOutputTable)
 
@@ -1003,7 +1021,7 @@ object GroupBy {
             case (range, index) =>
               logger.info(s"Computing group by for range: $range [${index + 1}/${stepRanges.size}]")
               val groupByBackfill: GroupBy = if (incrementalMode) {
-                fromIncrementalDf(groupByConf, range, tableUtils)
+                fromIncrementalDf(groupByConf, range, tableUtils, stepDays)
               } else {
                 from(groupByConf, range, tableUtils, computeDependency = true)
               }

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
@@ -1,0 +1,469 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.spark.test
+
+import ai.chronon.aggregator.test.{CStream, Column}
+import ai.chronon.api.Extensions._
+import ai.chronon.api.{
+  Aggregation,
+  Builders,
+  DoubleType,
+  IntType,
+  LongType,
+  Operation,
+  Source,
+  StringType,
+  TimeUnit,
+  Window
+}
+import ai.chronon.spark.Extensions._
+import ai.chronon.spark._
+import ai.chronon.spark.catalog.TableUtils
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.{StructField, StructType, LongType => SparkLongType, StringType => SparkStringType}
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.functions.col
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.util.Random
+
+class GroupByIncrementalTest {
+
+  private def createTestSourceIncremental(windowSize: Int = 365,
+                               suffix: String = "",
+                               partitionColOpt: Option[String] = None): (Source, String) = {
+    lazy val spark: SparkSession =
+      SparkSessionBuilder.build("GroupByIncrementalTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val startPartition = tableUtils.partitionSpec.minus(today, new Window(windowSize, TimeUnit.DAYS))
+    val endPartition = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val sourceSchema = List(
+      Column("user", StringType, 10000),
+      Column("item", StringType, 100),
+      Column("time_spent_ms", LongType, 5000),
+      Column("price", DoubleType, 100)
+    )
+    val namespace = "chronon_incremental_test"
+    val sourceTable = s"$namespace.test_group_by_steps$suffix"
+
+    tableUtils.createDatabase(namespace)
+    val genDf =
+      DataFrameGen.events(spark, sourceSchema, count = 1000, partitions = 200, partitionColOpt = partitionColOpt)
+    partitionColOpt match {
+      case Some(partitionCol) => genDf.save(sourceTable, partitionColumns = Seq(partitionCol))
+      case None               => genDf.save(sourceTable)
+    }
+
+    val source = Builders.Source.events(
+      query = Builders.Query(selects = Builders.Selects("ts", "user", "time_spent_ms", "price", "item"),
+        startPartition = startPartition,
+        partitionColumn = partitionColOpt.orNull),
+      table = sourceTable
+    )
+    (source, endPartition)
+  }
+
+  /**
+   * Tests basic aggregations in incremental mode by comparing Chronon's output against SQL.
+   *
+   * Operations: SUM, COUNT, AVERAGE, MIN, MAX, VARIANCE, UNIQUE_COUNT, HISTOGRAM, BOUNDED_UNIQUE_COUNT
+   *
+   * Actual:   Chronon computes daily IRs using computeIncrementalDf, storing intermediate results
+   * Expected: SQL query computes the same aggregations directly on the input data for the same date
+   */
+  @Test
+  def testIncrementalBasicAggregations(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTestIncrementalBasic" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace = s"incremental_basic_aggs_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+    val schema = List(
+      Column("user", StringType, 10),
+      Column("price", DoubleType, 100),
+      Column("quantity", IntType, 50),
+      Column("product_id", StringType, 20),  // Low cardinality for UNIQUE_COUNT, HISTOGRAM, BOUNDED_UNIQUE_COUNT
+      Column("rating", DoubleType, 2000)
+    )
+
+    val df = DataFrameGen.events(spark, schema, count = 100000, partitions = 100)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      // Simple aggregations
+      Builders.Aggregation(Operation.SUM, "price", Seq(new Window(7, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.COUNT, "quantity", Seq(new Window(7, TimeUnit.DAYS))),
+
+      // Complex aggregation - AVERAGE (struct IR with sum/count)
+      Builders.Aggregation(Operation.AVERAGE, "rating", Seq(new Window(7, TimeUnit.DAYS))),
+
+      // Min/Max
+      Builders.Aggregation(Operation.MIN, "price", Seq(new Window(7, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.MAX, "quantity", Seq(new Window(7, TimeUnit.DAYS))),
+
+      // Variance (struct IR with count/mean/m2)
+      Builders.Aggregation(Operation.VARIANCE, "price", Seq(new Window(7, TimeUnit.DAYS))),
+
+      // UNIQUE_COUNT (array IR): IR = array<double> of distinct values
+      Builders.Aggregation(Operation.UNIQUE_COUNT, "price", Seq(new Window(7, TimeUnit.DAYS))),
+
+      // HISTOGRAM (map IR)
+      Builders.Aggregation(Operation.HISTOGRAM, "product_id", Seq(new Window(7, TimeUnit.DAYS)), argMap = Map("k" -> "0")),
+
+      // BOUNDED_UNIQUE_COUNT (array IR with bound): IR = array<string> of bounded distinct values (MD5-hashed)
+      Builders.Aggregation(Operation.BOUNDED_UNIQUE_COUNT, "product_id", Seq(new Window(7, TimeUnit.DAYS)), argMap = Map("k" -> "100"))
+    )
+
+    val tableProps: Map[String, String] = Map("source" -> "chronon")
+
+    val today_date = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val today_minus_7_date = tableUtils.partitionSpec.minus(today_date, new Window(7, TimeUnit.DAYS))
+    val today_minus_20_date = tableUtils.partitionSpec.minus(today_date, new Window(20, TimeUnit.DAYS))
+
+    val partitionRange = PartitionRange(today_minus_20_date, today_date)
+
+    val groupBy = new GroupBy(aggregations, Seq("user"), df)
+    groupBy.computeIncrementalDf(s"${namespace}.testIncrementalBasicAggsOutput", partitionRange, tableProps)
+
+    val actualIncrementalDf = spark.sql(s"select * from ${namespace}.testIncrementalBasicAggsOutput where ds='$today_minus_7_date'")
+    df.createOrReplaceTempView("test_basic_aggs_input")
+
+    // Compare against SQL computation
+    val query =
+      s"""
+         |WITH base_aggs AS (
+         |  SELECT user, ds, UNIX_TIMESTAMP(ds, 'yyyy-MM-dd')*1000 as ts,
+         |    sum(price) as price_sum,
+         |    count(quantity) as quantity_count,
+         |    struct(sum(rating) as sum, count(rating) as count) as rating_average,
+         |    min(price) as price_min,
+         |    max(quantity) as quantity_max,
+         |    struct(
+         |      cast(count(price) as int) as count,
+         |      avg(price) as mean,
+         |      sum(price * price) - count(price) * avg(price) * avg(price) as m2
+         |    ) as price_variance,
+         |    count(distinct price) as price_unique_count,
+         |    least(count(distinct product_id), 100) as product_id_bounded_unique_count
+         |  FROM test_basic_aggs_input
+         |  WHERE ds='$today_minus_7_date'
+         |  GROUP BY user, ds
+         |),
+         |histogram_agg AS (
+         |  SELECT user, ds,
+         |    map_from_entries(collect_list(struct(product_id, cast(cnt as int)))) as product_id_histogram
+         |  FROM (
+         |    SELECT user, ds, product_id, count(*) as cnt
+         |    FROM test_basic_aggs_input
+         |    WHERE ds='$today_minus_7_date' AND product_id IS NOT NULL
+         |    GROUP BY user, ds, product_id
+         |  )
+         |  GROUP BY user, ds
+         |)
+         |SELECT b.*, h.product_id_histogram
+         |FROM base_aggs b
+         |LEFT JOIN histogram_agg h ON b.user <=> h.user AND b.ds <=> h.ds
+         |""".stripMargin
+
+    val expectedDf = spark.sql(query)
+
+    // Replace UNIQUE_COUNT and BOUNDED_UNIQUE_COUNT array columns with their sizes for comparison.
+    // SQL produces Long counts; size() returns Int — cast both to Long for type consistency.
+    import org.apache.spark.sql.functions.size
+    val actualForComparison = actualIncrementalDf
+      .withColumn("price_unique_count", size(col("price_unique_count")).cast("long"))
+      .withColumn("product_id_bounded_unique_count", size(col("product_id_bounded_unique_count")).cast("long"))
+
+    val diff = Comparison.sideBySide(actualForComparison, expectedDf, List("user", tableUtils.partitionColumn))
+
+    val irRowCount = actualIncrementalDf.count()
+    if (diff.count() > 0) {
+      println(s"=== Diff Details for All Aggregations ===")
+      println(s"Actual count: ${irRowCount}")
+      println(s"Expected count: ${expectedDf.count()}")
+      println(s"Diff count: ${diff.count()}")
+      actualForComparison.show(10, truncate = false)
+      diff.show(100, truncate = false)
+    }
+
+    assertEquals(0, diff.count())
+  }
+
+  /**
+   * This test verifies that the incremental snapshotEvents output matches the non-incremental output.
+   *
+   * 1. Computes snapshotEvents using the standard GroupBy on the full input data.
+   * 2. Computes snapshotEvents using GroupBy in incremental mode over the same date range.
+   * 3. Compares the two outputs to ensure they are identical.
+   */
+  @Test
+  def testSnapshotIncrementalEvents(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace =  s"incremental_groupBy_snapshot_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+
+    val outputDates = CStream.genPartitions(10, tableUtils.partitionSpec)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      // Basic
+      Builders.Aggregation(Operation.SUM, "time_spent_ms", Seq(new Window(10, TimeUnit.DAYS), new Window(5, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SUM, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.COUNT, "user", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.AVERAGE, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.MIN, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.MAX, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      // Statistical
+      Builders.Aggregation(Operation.VARIANCE, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SKEW, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.KURTOSIS, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.APPROX_PERCENTILE, "price", Seq(new Window(10, TimeUnit.DAYS)),
+        argMap = Map("percentiles" -> "[0.5, 0.25, 0.75]")),
+      // Temporal
+      Builders.Aggregation(Operation.FIRST, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.LAST, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.FIRST_K, "price", Seq(new Window(10, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.LAST_K, "price", Seq(new Window(10, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.TOP_K, "price", Seq(new Window(10, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.BOTTOM_K, "price", Seq(new Window(10, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      // Cardinality / Set
+      Builders.Aggregation(Operation.UNIQUE_COUNT, "user", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "user", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.BOUNDED_UNIQUE_COUNT, "user", Seq(new Window(10, TimeUnit.DAYS))),
+      // Distribution
+      Builders.Aggregation(Operation.HISTOGRAM, "user", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.APPROX_HISTOGRAM_K, "user", Seq(new Window(10, TimeUnit.DAYS)), argMap = Map("k" -> "10"))
+    )
+
+    val (source, endPartition) = createTestSourceIncremental(windowSize = 30, suffix = "_snapshot_events", partitionColOpt = Some(tableUtils.partitionColumn))
+    val groupByConf = Builders.GroupBy(
+      sources = Seq(source),
+      keyColumns = Seq("item"),
+      aggregations = aggregations,
+      metaData = Builders.MetaData(name = "testSnapshotIncremental", namespace = namespace, team = "chronon"),
+      backfillStartDate = tableUtils.partitionSpec.minus(tableUtils.partitionSpec.at(System.currentTimeMillis()),
+        new Window(20, TimeUnit.DAYS))
+    )
+
+    val df = spark.read.table(source.table)
+
+    val groupBy = new GroupBy(aggregations, Seq("item"), df.filter("item is not null"))
+    val actualDf = groupBy.snapshotEvents(PartitionRange(outputDates.min, outputDates.max))
+
+    val  groupByIncremental = GroupBy.fromIncrementalDf(groupByConf, PartitionRange(outputDates.min, outputDates.max), tableUtils)
+    val incrementalExpectedDf = groupByIncremental.snapshotEvents(PartitionRange(outputDates.min, outputDates.max))
+
+    val outputDatesRdd: RDD[Row] = spark.sparkContext.parallelize(outputDates.map(Row(_)))
+    val outputDatesDf = spark.createDataFrame(outputDatesRdd, StructType(Seq(StructField("ds", SparkStringType))))
+    val datesViewName = "test_group_by_snapshot_events_output_range"
+    outputDatesDf.createOrReplaceTempView(datesViewName)
+
+    val diff = Comparison.sideBySide(actualDf, incrementalExpectedDf, List("item", tableUtils.partitionColumn))
+    if (diff.count() > 0) {
+      diff.show()
+      println("=== Diff result rows ===")
+    }
+    assertEquals(0, diff.count())
+  }
+
+  /**
+   * Unit test for FIRST and LAST aggregations with incremental IR
+   * FIRST/LAST use TimeTuple IR: struct {epochMillis: Long, payload: Value}
+   * FIRST keeps the value with the earliest timestamp
+   * LAST keeps the value with the latest timestamp
+   */
+  @Test
+  def testIncrementalFirstLast(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTestFirstLast" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace = s"incremental_first_last_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+    val schema = List(
+      Column("user", StringType, 5),
+      Column("value", DoubleType, 100)
+    )
+
+    // Generate events and add random milliseconds to ts for unique timestamps
+    import org.apache.spark.sql.functions.{rand, col}
+    import org.apache.spark.sql.types.{LongType => SparkLongType}
+
+    val dfWithRandom = DataFrameGen.events(spark, schema, count = 10000, partitions = 20)
+      .withColumn("ts", col("ts") + (rand() * 86400000).cast(SparkLongType))  // Add 0-24h random millis
+      .cache()  // Mark for caching
+
+    // Force materialization - computes and caches the random values
+    dfWithRandom.count()
+
+    // Write the CACHED data to table - writes already-materialized values
+    dfWithRandom.write.mode("overwrite").saveAsTable(s"${namespace}.test_first_last_input")
+
+    // Read back from table - guaranteed same data as what was written
+    val df = spark.table(s"${namespace}.test_first_last_input")
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.FIRST, "value", Seq(new Window(7, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.LAST, "value", Seq(new Window(7, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.FIRST_K, "value", Seq(new Window(7, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.LAST_K, "value", Seq(new Window(7, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.TOP_K, "value", Seq(new Window(7, TimeUnit.DAYS)), argMap = Map("k" -> "3")),
+      Builders.Aggregation(Operation.BOTTOM_K, "value", Seq(new Window(7, TimeUnit.DAYS)), argMap = Map("k" -> "3"))
+    )
+
+    val tableProps: Map[String, String] = Map("source" -> "chronon")
+    val today_date = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val today_minus_7_date = tableUtils.partitionSpec.minus(today_date, new Window(7, TimeUnit.DAYS))
+    val today_minus_20_date = tableUtils.partitionSpec.minus(today_date, new Window(20, TimeUnit.DAYS))
+    val partitionRange = PartitionRange(today_minus_20_date, today_date)
+
+    val groupBy = new GroupBy(aggregations, Seq("user"), df)
+    groupBy.computeIncrementalDf(s"${namespace}.testIncrementalFirstLastOutput", partitionRange, tableProps)
+
+    val rawIncrementalDf = spark.sql(s"select * from ${namespace}.testIncrementalFirstLastOutput where ds='$today_minus_7_date'")
+
+    println("=== Incremental FIRST/LAST IR Schema ===")
+    rawIncrementalDf.printSchema()
+
+    // Sort array columns in raw IRs to match SQL output ordering
+    // Raw IRs store unsorted arrays for mergeability, but we need to sort them for comparison
+    import org.apache.spark.sql.functions.{sort_array, col}
+    val actualIncrementalDf = rawIncrementalDf
+      .withColumn("value_first3", sort_array(col("value_first3")))
+      .withColumn("value_last3", sort_array(col("value_last3")))
+      .withColumn("value_top3", sort_array(col("value_top3")))
+      .withColumn("value_bottom3", sort_array(col("value_bottom3")))
+
+    // Compare against SQL computation
+    // Note: ts column in IR table is the partition timestamp (derived from ds)
+    // But FIRST/LAST use the actual event timestamps (with random milliseconds)
+    val query =
+      s"""
+         |SELECT user,
+         |  to_date(from_unixtime(ts / 1000, 'yyyy-MM-dd HH:mm:ss')) as ds,
+         |  named_struct(
+         |    'epochMillis', min(ts),
+         |    'payload', sort_array(collect_list(struct(ts, value)))[0].value
+         |  ) as value_first,
+         |  named_struct(
+         |    'epochMillis', max(ts),
+         |    'payload', reverse(sort_array(collect_list(struct(ts, value))))[0].value
+         |  ) as value_last,
+         |  transform(
+         |    slice(sort_array(filter(collect_list(struct(ts, value)), x -> x.value IS NOT NULL)), 1, 3),
+         |    x -> named_struct('epochMillis', x.ts, 'payload', x.value)
+         |  ) as value_first3,
+         |  transform(
+         |    slice(sort_array(filter(collect_list(struct(ts, value)), x -> x.value IS NOT NULL)),
+         |          greatest(-size(sort_array(filter(collect_list(struct(ts, value)), x -> x.value IS NOT NULL))), -3), 3),
+         |    x -> named_struct('epochMillis', x.ts, 'payload', x.value)
+         |  ) as value_last3,
+         |  transform(
+         |    slice(sort_array(filter(collect_list(struct(value, ts)), x -> x.value IS NOT NULL), true),
+         |          greatest(-size(sort_array(filter(collect_list(struct(value, ts)), x -> x.value IS NOT NULL))), -3), 3),
+         |    x -> x.value
+         |  ) as value_top3,
+         |  transform(
+         |    slice(sort_array(filter(collect_list(struct(value, ts)), x -> x.value IS NOT NULL), true), 1, 3),
+         |    x -> x.value
+         |  ) as value_bottom3
+         |FROM ${namespace}.test_first_last_input
+         |WHERE to_date(from_unixtime(ts / 1000, 'yyyy-MM-dd HH:mm:ss'))='$today_minus_7_date'
+         |GROUP BY user, to_date(from_unixtime(ts / 1000, 'yyyy-MM-dd HH:mm:ss'))
+         |""".stripMargin
+
+    val expectedDf = spark.sql(query)
+
+    // Drop ts from comparison - it's just the partition timestamp, not part of the aggregation IR
+    val actualWithoutTs = actualIncrementalDf.drop("ts")
+
+    val diff = Comparison.sideBySide(actualWithoutTs, expectedDf, List("user", tableUtils.partitionColumn))
+
+    if (diff.count() > 0) {
+      println(s"=== Diff Details for Time-based Aggregations ===")
+      println(s"Expected count: ${expectedDf.count()}")
+      println(s"Diff count: ${diff.count()}")
+      diff.show(100, truncate = false)
+    }
+
+    assertEquals(0, diff.count())
+
+    println("=== Time-based Aggregations Incremental Test Passed ===")
+    println("✓ FIRST: TimeTuple IR {epochMillis, payload}")
+    println("✓ LAST: TimeTuple IR {epochMillis, payload}")
+    println("✓ FIRST_K: Array[TimeTuple] - stores timestamps")
+    println("✓ LAST_K: Array[TimeTuple] - stores timestamps")
+    println("✓ TOP_K: Array[Double] - stores only values")
+    println("✓ BOTTOM_K: Array[Double] - stores only values")
+
+    // Cleanup
+    spark.stop()
+  }
+
+  @Test
+  def testIncrementalStatisticalAggregations(): Unit = {
+    lazy val spark: SparkSession = SparkSessionBuilder.build("GroupByTestStatistical" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace = s"incremental_stats_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+    val outputDates = CStream.genPartitions(10, tableUtils.partitionSpec)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      // Moment-based (IR = array<double> [n, m1, m2, m3, m4]); finalized to Double
+      Builders.Aggregation(Operation.SKEW, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.KURTOSIS, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      // Sketch-based (IR = binary KLL sketch); finalized to Array[Float]
+      Builders.Aggregation(Operation.APPROX_PERCENTILE, "price", Seq(new Window(10, TimeUnit.DAYS)),
+        argMap = Map("percentiles" -> "[0.5, 0.25, 0.75]")),
+      // Sketch-based (IR = binary CPC sketch); finalized to Long
+      Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "user", Seq(new Window(10, TimeUnit.DAYS))),
+      // Sketch-based (IR = binary); finalized to Map[String, Long]
+      Builders.Aggregation(Operation.APPROX_HISTOGRAM_K, "user", Seq(new Window(10, TimeUnit.DAYS)),
+        argMap = Map("k" -> "10"))
+    )
+
+    val (source, _) = createTestSourceIncremental(windowSize = 30, suffix = "_stats_events",
+      partitionColOpt = Some(tableUtils.partitionColumn))
+    val groupByConf = Builders.GroupBy(
+      sources = Seq(source),
+      keyColumns = Seq("item"),
+      aggregations = aggregations,
+      metaData = Builders.MetaData(name = "testIncrementalStats", namespace = namespace, team = "chronon"),
+      backfillStartDate = tableUtils.partitionSpec.minus(tableUtils.partitionSpec.at(System.currentTimeMillis()),
+        new Window(20, TimeUnit.DAYS))
+    )
+
+    val df = spark.read.table(source.table)
+    val groupBy = new GroupBy(aggregations, Seq("item"), df.filter("item is not null"))
+    val nonIncrementalDf = groupBy.snapshotEvents(PartitionRange(outputDates.min, outputDates.max))
+
+    val groupByIncremental = GroupBy.fromIncrementalDf(groupByConf, PartitionRange(outputDates.min, outputDates.max), tableUtils)
+    val incrementalDf = groupByIncremental.snapshotEvents(PartitionRange(outputDates.min, outputDates.max))
+
+    val diff = Comparison.sideBySide(nonIncrementalDf, incrementalDf, List("item", tableUtils.partitionColumn))
+    if (diff.count() > 0) {
+      println("=== Diff Details for Statistical Aggregations ===")
+      diff.show(100, truncate = false)
+    }
+    assertEquals(0, diff.count())
+
+    // Cleanup
+    spark.stop()
+  }
+}

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
@@ -21,6 +21,7 @@ import ai.chronon.api.Extensions._
 import ai.chronon.api.{
   Aggregation,
   Builders,
+  Constants,
   DoubleType,
   IntType,
   LongType,
@@ -411,6 +412,11 @@ class GroupByIncrementalTest {
       Set(targetDay),
       writtenPartitions
     )
+
+    // The _daily_inc table is tagged as a Chronon-generated incremental table.
+    val props = tableUtils.getTableProperties(outputTable).getOrElse(Map.empty)
+    assertEquals(Constants.TableType.GroupByIncremental, props.get(Constants.ChrononTableType).orNull)
+    assertEquals("true", props.get(Constants.ChrononGenerated).orNull)
   }
 
   /**
@@ -431,19 +437,23 @@ class GroupByIncrementalTest {
       Column("value", DoubleType, 100)
     )
 
-    // Generate events and add random milliseconds to ts for unique timestamps
-    import org.apache.spark.sql.functions.{rand, col}
-    import org.apache.spark.sql.types.{LongType => SparkLongType}
+    // FIRST/LAST tie-break is ambiguous when two events for the same (user, day) share a ts, so
+    // make ts unique WITHIN each day deterministically: snap to the day's midnight and add a
+    // per-day row number as a millisecond offset. With << 86.4M rows/day the offset stays within
+    // the day (ds unchanged) and no two rows in a day collide -> FIRST/LAST is well-defined and the
+    // test is deterministic (no rand()).
+    import org.apache.spark.sql.functions.{col, monotonically_increasing_id, row_number}
+    import org.apache.spark.sql.expressions.{Window => SparkWindow}
+    val dayMs = 86400000L
 
-    val dfWithRandom = DataFrameGen.events(spark, schema, count = 10000, partitions = 20)
-      .withColumn("ts", col("ts") + (rand() * 86400000).cast(SparkLongType))  // Add 0-24h random millis
-      .cache()  // Mark for caching
+    val dfUnique = DataFrameGen.events(spark, schema, count = 10000, partitions = 20)
+      .withColumn("_day_ms", (col("ts") / dayMs).cast("long") * dayMs)
+      .withColumn("_rn", row_number().over(SparkWindow.partitionBy("_day_ms").orderBy(monotonically_increasing_id())))
+      .withColumn("ts", col("_day_ms") + col("_rn"))
+      .drop("_day_ms", "_rn")
 
-    // Force materialization - computes and caches the random values
-    dfWithRandom.count()
-
-    // Write the CACHED data to table - writes already-materialized values
-    dfWithRandom.write.mode("overwrite").saveAsTable(s"${namespace}.test_first_last_input")
+    // Materialize by writing to a table and reading back, so the row numbering is frozen.
+    dfUnique.write.mode("overwrite").saveAsTable(s"${namespace}.test_first_last_input")
 
     // Read back from table - guaranteed same data as what was written
     val df = spark.table(s"${namespace}.test_first_last_input")

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
@@ -283,6 +283,87 @@ class GroupByIncrementalTest {
   }
 
   /**
+   * Verifies the chunked incremental IR build (stepDays-driven hole filling).
+   *
+   * Runs the full GroupBy.computeBackfill path in incremental mode with a small
+   * stepDays so the daily-IR hole is filled in several stepped sub-ranges rather
+   * than a single write. Asserts:
+   *   1. The _daily_inc table accumulates IR partitions across the full
+   *      [start - maxWindow, end] queryable range (i.e. the stepped writes
+   *      committed every expected day).
+   *   2. The final GroupBy output is identical to a non-incremental
+   *      computeBackfill over the same range (stepped IR build changes nothing).
+   */
+  @Test
+  def testIncrementalChunkedBuild(): Unit = {
+    lazy val spark: SparkSession =
+      SparkSessionBuilder.build("GroupByTestChunked" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace = s"incremental_chunked_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+    val maxWindowDays = 10
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "price", Seq(new Window(maxWindowDays, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.COUNT, "user", Seq(new Window(maxWindowDays, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.AVERAGE, "price", Seq(new Window(maxWindowDays, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.LAST, "price", Seq(new Window(maxWindowDays, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.APPROX_PERCENTILE, "price", Seq(new Window(maxWindowDays, TimeUnit.DAYS)),
+        argMap = Map("percentiles" -> "[0.5, 0.75]")),
+      Builders.Aggregation(Operation.APPROX_UNIQUE_COUNT, "user", Seq(new Window(maxWindowDays, TimeUnit.DAYS)))
+    )
+
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val backfillStart = tableUtils.partitionSpec.minus(today, new Window(5, TimeUnit.DAYS))
+
+    // Single shared source so the incremental and normal backfills read identical
+    // data (createTestSourceIncremental generates random data per call).
+    val (source, _) =
+      createTestSourceIncremental(windowSize = 30, suffix = "_chunked", partitionColOpt = Some(tableUtils.partitionColumn))
+
+    def mkConf(name: String): ai.chronon.api.GroupBy =
+      Builders.GroupBy(
+        sources = Seq(source),
+        keyColumns = Seq("item"),
+        aggregations = aggregations,
+        metaData = Builders.MetaData(name = name, namespace = namespace, team = "chronon"),
+        backfillStartDate = backfillStart
+      )
+
+    // Incremental backfill with a small stepDays -> chunked IR build.
+    val incConf = mkConf("chunked_incremental")
+    GroupBy.computeBackfill(incConf, today, tableUtils, stepDays = Some(2), incrementalMode = true)
+
+    // (1) The chunked build should have committed multiple IR partitions across
+    // the window (proving the stepped sub-range writes landed incrementally,
+    // rather than nothing/one monolithic write). Exact bounds are intentionally
+    // not asserted: step-boundary alignment may round the scan slightly wider and
+    // days with no source events produce no IR partition - both harmless. The
+    // output-equality check below is the authoritative correctness guarantee.
+    val incrementalTable = incConf.metaData.incrementalOutputTable
+    val irPartitions = tableUtils.partitions(incrementalTable)
+    assertTrue(
+      s"Daily-inc table $incrementalTable should have committed multiple IR partitions, found ${irPartitions.size}",
+      irPartitions.size > 1
+    )
+
+    // (2) Final output must match a non-incremental backfill over the same range.
+    val normalConf = mkConf("chunked_normal")
+    GroupBy.computeBackfill(normalConf, today, tableUtils, stepDays = Some(2), incrementalMode = false)
+
+    val incrementalOutput = spark.read.table(incConf.metaData.outputTable)
+    val normalOutput = spark.read.table(normalConf.metaData.outputTable)
+    val diff = Comparison.sideBySide(normalOutput, incrementalOutput, List("item", tableUtils.partitionColumn))
+    if (diff.count() > 0) {
+      println("=== Chunked incremental vs normal diff ===")
+      diff.show(100, truncate = false)
+    }
+    assertEquals(0, diff.count())
+
+    spark.stop()
+  }
+
+  /**
    * Unit test for FIRST and LAST aggregations with incremental IR
    * FIRST/LAST use TimeTuple IR: struct {epochMillis: Long, payload: Value}
    * FIRST keeps the value with the earliest timestamp

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
@@ -360,8 +360,6 @@ class GroupByIncrementalTest {
       diff.show(100, truncate = false)
     }
     assertEquals(0, diff.count())
-
-    spark.stop()
   }
 
   /**
@@ -611,9 +609,6 @@ class GroupByIncrementalTest {
     println("✓ LAST_K: Array[TimeTuple] - stores timestamps")
     println("✓ TOP_K: Array[Double] - stores only values")
     println("✓ BOTTOM_K: Array[Double] - stores only values")
-
-    // Cleanup
-    spark.stop()
   }
 
   @Test
@@ -663,8 +658,5 @@ class GroupByIncrementalTest {
       diff.show(100, truncate = false)
     }
     assertEquals(0, diff.count())
-
-    // Cleanup
-    spark.stop()
   }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
@@ -364,6 +364,56 @@ class GroupByIncrementalTest {
   }
 
   /**
+   * Regression test: the per-day IR write must be clamped to the requested range.
+   *
+   * hopsAggregate runs over the GroupBy's full input DataFrame and emits daily hops for
+   * every day with events, not just the requested range. With dynamic partition overwrite,
+   * an unclamped save would write ALL those partitions - so filling one day's hole would
+   * (re)write and clobber neighboring partitions. computeIncrementalDf must clamp the write
+   * to exactly the requested range, writing only those partitions.
+   *
+   * Calls the instance computeIncrementalDf directly (as testIncrementalBasicAggregations
+   * does) with a single-day range over a 30-day input: without the clamp this writes ~30
+   * partitions; with it, exactly one.
+   */
+  @Test
+  def testIncrementalWriteIsClampedToRange(): Unit = {
+    lazy val spark: SparkSession =
+      SparkSessionBuilder.build("GroupByTestClamp" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace = s"incremental_clamp_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+    val schema = List(
+      Column("user", StringType, 100),
+      Column("price", DoubleType, 100)
+    )
+    // 30 partitions of events -> hopsAggregate will produce hops spanning ~30 days.
+    val df = DataFrameGen.events(spark, schema, count = 20000, partitions = 30)
+
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "price", Seq(new Window(10, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.COUNT, "user", Seq(new Window(10, TimeUnit.DAYS)))
+    )
+    val tableProps: Map[String, String] = Map("source" -> "chronon")
+    val outputTable = s"$namespace.clamp_daily_inc"
+
+    val groupBy = new GroupBy(aggregations, Seq("user"), df)
+
+    // Request a single day; hopsAggregate still sees all 30 days of input.
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val targetDay = tableUtils.partitionSpec.minus(today, new Window(15, TimeUnit.DAYS))
+    groupBy.computeIncrementalDf(outputTable, PartitionRange(targetDay, targetDay), tableProps)
+
+    val writtenPartitions = tableUtils.partitions(outputTable).toSet
+    assertEquals(
+      s"computeIncrementalDf for a single day must write only that partition; wrote ${writtenPartitions.toSeq.sorted}",
+      Set(targetDay),
+      writtenPartitions
+    )
+  }
+
+  /**
    * Unit test for FIRST and LAST aggregations with incremental IR
    * FIRST/LAST use TimeTuple IR: struct {epochMillis: Long, payload: Value}
    * FIRST keeps the value with the earliest timestamp

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByIncrementalTest.scala
@@ -420,6 +420,66 @@ class GroupByIncrementalTest {
   }
 
   /**
+   * Aggregations sharing the same (operation, input_column, bucket) but differing only by window
+   * collapse to the same daily IR column (the window suffix is dropped) - e.g. SUM(price, 7d) and
+   * SUM(price, 30d) both -> price_sum, with identical IR values. The incremental schema dedups them
+   * to a single column rather than writing duplicates; this verifies one column is written and the
+   * windowed output still matches the non-incremental path.
+   */
+  @Test
+  def testIncrementalDedupsSharedColumns(): Unit = {
+    lazy val spark: SparkSession =
+      SparkSessionBuilder.build("GroupByTestDupCols" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    implicit val tableUtils = TableUtils(spark)
+    val namespace = s"incremental_dupcols_${Random.alphanumeric.take(6).mkString}"
+    tableUtils.createDatabase(namespace)
+
+    val maxWindowDays = 10
+    // Same (SUM, price) split across two aggregations differing only by window -> both collapse to
+    // the daily IR column "price_sum". Include COUNT so there is a second, non-colliding column.
+    val aggregations: Seq[Aggregation] = Seq(
+      Builders.Aggregation(Operation.SUM, "price", Seq(new Window(5, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.SUM, "price", Seq(new Window(maxWindowDays, TimeUnit.DAYS))),
+      Builders.Aggregation(Operation.COUNT, "user", Seq(new Window(maxWindowDays, TimeUnit.DAYS)))
+    )
+
+    val (source, _) =
+      createTestSourceIncremental(windowSize = 30, suffix = "_dedup", partitionColOpt = Some(tableUtils.partitionColumn))
+    def mkConf(name: String): ai.chronon.api.GroupBy =
+      Builders.GroupBy(
+        sources = Seq(source),
+        keyColumns = Seq("item"),
+        aggregations = aggregations,
+        metaData = Builders.MetaData(name = name, namespace = namespace, team = "chronon"),
+        backfillStartDate = tableUtils.partitionSpec.minus(tableUtils.partitionSpec.at(System.currentTimeMillis()),
+          new Window(5, TimeUnit.DAYS))
+      )
+
+    val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
+    val incConf = mkConf("dedup_incremental")
+    GroupBy.computeBackfill(incConf, today, tableUtils, stepDays = Some(1), incrementalMode = true)
+
+    // The _daily_inc table writes exactly one price_sum column (the two windows collapsed).
+    val incCols = spark.table(incConf.metaData.incrementalOutputTable).columns.toSeq
+    assertEquals(s"expected a single price_sum daily-IR column, got: $incCols", 1, incCols.count(_ == "price_sum"))
+
+    // The final windowed output still matches the non-incremental path (both price_sum_5d and
+    // price_sum_10d are correctly reconstructed from the single shared daily IR).
+    val normalConf = mkConf("dedup_normal")
+    GroupBy.computeBackfill(normalConf, today, tableUtils, stepDays = Some(1), incrementalMode = false)
+
+    val diff = Comparison.sideBySide(
+      spark.read.table(normalConf.metaData.outputTable),
+      spark.read.table(incConf.metaData.outputTable),
+      List("item", tableUtils.partitionColumn))
+    if (diff.count() > 0) {
+      println("=== dedup incremental vs normal diff ===")
+      diff.show(50, truncate = false)
+    }
+    assertEquals(0, diff.count())
+  }
+
+  /**
    * Unit test for FIRST and LAST aggregations with incremental IR
    * FIRST/LAST use TimeTuple IR: struct {epochMillis: Long, payload: Value}
    * FIRST keeps the value with the earliest timestamp


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adds an opt-in `is_incremental` mode for **SNAPSHOT-accuracy event** GroupBy backfills. Instead of re-scanning the full window of raw events on every backfill step, per-day partial aggregates (IRs) are computed once and cached in a `<table>_daily_inc` table, then reused. This turns the dominant cost (raw-event hop aggregation) into a write-once read-many step.

Validated end-to-end on a ~500M-rows/day, 730-day-window source: a warm daily run completes in 
~30 min vs ~6 h for the equivalent full backfill (**~10× wall-clock**), producing output that matches the non-incremental path on all deterministic columns .

  - `is_incremental=True` on the GroupBy sets a new thrift field `isIncremental`.
  - **Build** (`computeIncrementalDf`): fills the `_daily_inc` IR table for `[ds − maxWindow, ds]`, idempotent via
  `unfilledRanges` (no-op when already complete).
  - **Read** (`fromIncrementalDf`): returns a GroupBy whose `hopsAggregate` is served from the cached IRs instead of raw events; `snapshotEvents` then windows them as usual.
  - Build and read are split so the daily table can later be reused by upload and join (see follow-ups). `fromIncrementalDf` is a mode-agnostic adapter; `buildIfMissing` controls ensure-then-read (ad hoc) vs read-only (production behind a producer node).

<img width="1121" height="231" alt="image" src="https://github.com/user-attachments/assets/016fad92-9610-4ee4-9770-d0795f3d78b3" />


## Follow-ups (separate PRs)

  - Snapshot-events incremental **upload** (producer node + ensure-then-read).
  - **Join** snapshot right-parts consuming the same `_daily_inc` table.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Even though Chronon can scale sublinearly, the limitation is usually within the same Spark session. 

This change will enable persisting the intermediate result so that for the large backfills, it does not have to read the raw events.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
- [x] tested on gateway machine and compare with standard output 
## Checklist
- [ ] Documentation update

## Reviewers
@yuli-han @Shiyinghaha @kambstreat 
