### PR TITLE
Export StagingQuery metadata in MetadataExporter

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -36,6 +36,7 @@ object Metrics {
     val StagingQueryOffline = "staging_query.offline"
     val groupByMetadataExport = "group_by.metadata_export"
     val joinMetadataExport = "join.metadata_export"
+    val stagingQueryMetadataExport = "staging_query.metadata_export"
     val JoinLogFlatten = "join.log_flatten"
     val LabelJoin = "label_join"
     val ModelTransform = "model_transform"

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -338,6 +338,8 @@ class Analyzer(tableUtils: TableUtils,
                                finalOutputSchema: Seq[(String, DataType)],
                                finalOutputMetadata: ListBuffer[AggregationMetadata])
 
+  case class AnalyzeStagingQueryResult(outputSchema: Seq[(String, DataType)])
+
   def analyzeJoin(joinConf: api.Join,
                   enableHitter: Boolean = false,
                   validateTablePermission: Boolean = validateTablePermission,
@@ -573,6 +575,28 @@ class Analyzer(tableUtils: TableUtils,
       finalOutputSchema,
       finalOutputMetadata
     )
+  }
+
+  def analyzeStagingQuery(stagingQueryConf: api.StagingQuery): AnalyzeStagingQueryResult = {
+    val name = "staging_queries/" + stagingQueryConf.metaData.name
+    logger.info(s"Running StagingQuery analysis for $name ...")
+
+    Option(stagingQueryConf.setups).foreach(_.toScala.foreach(tableUtils.sql))
+
+    val dummyStart = "2000-01-01"
+    val dummyEnd = "2000-01-02"
+    val renderedQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, dummyStart, dummyEnd, dummyEnd)
+    val outputSchema = SparkConversions.toChrononSchema(tableUtils.sql(renderedQuery).schema)
+
+    if (!silenceMode) {
+      logger.info(s"""
+           |----- OUTPUT SCHEMA -----
+           |${stringifySchema(outputSchema)}
+           |------ END --------------
+           |""".stripMargin)
+    }
+
+    AnalyzeStagingQueryResult(outputSchema)
   }
 
   // validate the schema of the left and right side of the join and make sure the types match

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -585,7 +585,7 @@ class Analyzer(tableUtils: TableUtils,
 
     val baseStart = "2000-01-01"
     val baseEnd = "2000-01-02"
-    val renderedQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, dummyStart, dummyEnd, dummyEnd)
+    val renderedQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, baseStart, baseEnd, baseEnd)
     val outputSchema = SparkConversions.toChrononSchema(tableUtils.sql(renderedQuery).schema)
 
     if (!silenceMode) {

--- a/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Analyzer.scala
@@ -583,8 +583,8 @@ class Analyzer(tableUtils: TableUtils,
 
     Option(stagingQueryConf.setups).foreach(_.toScala.foreach(tableUtils.sql))
 
-    val dummyStart = "2000-01-01"
-    val dummyEnd = "2000-01-02"
+    val baseStart = "2000-01-01"
+    val baseEnd = "2000-01-02"
     val renderedQuery = StagingQuery.substitute(tableUtils, stagingQueryConf.query, dummyStart, dummyEnd, dummyEnd)
     val outputSchema = SparkConversions.toChrononSchema(tableUtils.sql(renderedQuery).schema)
 

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory
 
 import java.io.{BufferedWriter, File, FileWriter}
 import ai.chronon.api
-import ai.chronon.api.ThriftJsonCodec
+import ai.chronon.api.{DataType, ThriftJsonCodec}
 import ai.chronon.online.Metrics
 import ai.chronon.online.Metrics.Environment
 import ai.chronon.spark.catalog.TableUtils
@@ -46,7 +46,7 @@ object MetadataExporter {
 
   val mapper = new ObjectMapper()
   mapper.registerModule(DefaultScalaModule)
-  val sparkSession = SparkSessionBuilder.build("metadata_exporter")
+  val sparkSession = SparkSessionBuilder.build("metadata_exporter", enforceKryoSerializer = false)
   val tableUtils = TableUtils(sparkSession)
   private val today = tableUtils.partitionSpec.at(System.currentTimeMillis())
   private val yesterday = tableUtils.partitionSpec.before(today)
@@ -128,6 +128,33 @@ object MetadataExporter {
         } catch {
           // Unable to parse join file
           case exception: Throwable => handleException(exception, "join")
+        }
+
+      case p if p.contains(STAGING_QUERY_PATH_SUFFIX) =>
+        try {
+          val stagingQuery = ThriftJsonCodec.fromJsonFile[api.StagingQuery](path, check = false)
+          try {
+            val outputSchema =
+              analyzer.analyzeStagingQuery(stagingQuery).outputSchema.map { case (name, dataType) =>
+                Map(
+                  "name" -> name,
+                  "columnType" -> DataType.toString(dataType),
+                  "operation" -> "StagingQuery",
+                  "window" -> null,
+                  "inputColumn" -> null,
+                  "groupBy" -> null
+                )
+              }
+            configData + ("features" -> outputSchema)
+          } catch {
+            case exception: Throwable =>
+              val context =
+                Metrics.Context(environment = Environment.stagingQueryMetadataExport, stagingQuery = stagingQuery)
+              context.incrementException(exception)
+              handleException(exception, "staging_query")
+          }
+        } catch {
+          case exception: Throwable => handleException(exception, "staging_query")
         }
 
       case _ =>
@@ -261,6 +288,8 @@ object MetadataExporter {
           writeOutputToFile(data, path, outputPath + GROUPBY_PATH_SUFFIX)
         } else if (path.contains(JOIN_PATH_SUFFIX)) {
           writeOutputToFile(data, path, outputPath + JOIN_PATH_SUFFIX)
+        } else if (path.contains(STAGING_QUERY_PATH_SUFFIX)) {
+          writeOutputToFile(data, path, outputPath + STAGING_QUERY_PATH_SUFFIX)
         }
         (path, true, None)
       } catch {

--- a/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
+++ b/spark/src/main/scala/ai/chronon/spark/MetadataExporter.scala
@@ -135,15 +135,16 @@ object MetadataExporter {
           val stagingQuery = ThriftJsonCodec.fromJsonFile[api.StagingQuery](path, check = false)
           try {
             val outputSchema =
-              analyzer.analyzeStagingQuery(stagingQuery).outputSchema.map { case (name, dataType) =>
-                Map(
-                  "name" -> name,
-                  "columnType" -> DataType.toString(dataType),
-                  "operation" -> "StagingQuery",
-                  "window" -> null,
-                  "inputColumn" -> null,
-                  "groupBy" -> null
-                )
+              analyzer.analyzeStagingQuery(stagingQuery).outputSchema.map {
+                case (name, dataType) =>
+                  Map(
+                    "name" -> name,
+                    "columnType" -> DataType.toString(dataType),
+                    "operation" -> "StagingQuery",
+                    "window" -> null,
+                    "inputColumn" -> null,
+                    "groupBy" -> null
+                  )
               }
             configData + ("features" -> outputSchema)
           } catch {

--- a/spark/src/test/resources/staging_queries/team/example_staging_query.v1
+++ b/spark/src/test/resources/staging_queries/team/example_staging_query.v1
@@ -4,6 +4,6 @@
     "outputNamespace": "example_namespace",
     "team": "team"
   },
-  "query": "SELECT a, b, c, d FROM example_namespace.table WHERE ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'",
+  "query": "SELECT a, b, c, d, e FROM example_namespace.table WHERE ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'",
   "startPartition": "2021-06-01"
 }

--- a/spark/src/test/resources/staging_queries/team/example_staging_query.v1
+++ b/spark/src/test/resources/staging_queries/team/example_staging_query.v1
@@ -1,0 +1,9 @@
+{
+  "metaData": {
+    "name": "team.example_staging_query.v1",
+    "outputNamespace": "example_namespace",
+    "team": "team"
+  },
+  "query": "SELECT a, b, c, d FROM example_namespace.table WHERE ds BETWEEN '{{ start_date }}' AND '{{ end_date }}'",
+  "startPartition": "2021-06-01"
+}

--- a/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
@@ -101,7 +101,8 @@ class MetadataExporterTest extends TestCase {
       Column("a", api.StringType, 10),
       Column("b", api.StringType, 10),
       Column("c", api.LongType, 100),
-      Column("d", api.LongType, 100)
+      Column("d", api.LongType, 100),
+      Column("e", api.LongType, 100)
     )
     DataFrameGen.events(spark, sampleData, 10000, partitions = 30).save(s"$namespace.$tablename")
 

--- a/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/MetadataExporterTest.scala
@@ -93,6 +93,39 @@ class MetadataExporterTest extends TestCase {
     assertEquals(jsonNode.get("metaData").get("name").asText(), "team.example_join.v1")
   }
 
+  def testStagingQueryMetadataExport(): Unit = {
+    val namespace = "example_namespace"
+    val tablename = "table"
+    tableUtils.createDatabase(namespace)
+    val sampleData = List(
+      Column("a", api.StringType, 10),
+      Column("b", api.StringType, 10),
+      Column("c", api.LongType, 100),
+      Column("d", api.LongType, 100)
+    )
+    DataFrameGen.events(spark, sampleData, 10000, partitions = 30).save(s"$namespace.$tablename")
+
+    val confResource = getClass.getResource("/")
+    val tmpDir: File = Files.createTempDir()
+    MetadataExporter.run(confResource.getPath, Some(tmpDir.getAbsolutePath))
+
+    val stagingQueryFile = new File(s"${tmpDir.getAbsolutePath}/staging_queries/example_staging_query.v1")
+    assertTrue(s"Expected staging query output at ${stagingQueryFile.getAbsolutePath}", stagingQueryFile.exists())
+
+    val source = Source.fromFile(stagingQueryFile)
+    val jsonString = source.getLines().mkString("\n")
+    source.close()
+    val objectMapper = new ObjectMapper()
+    objectMapper.registerModule(DefaultScalaModule)
+    val jsonNode = objectMapper.readTree(jsonString)
+    assertEquals("team.example_staging_query.v1", jsonNode.get("metaData").get("name").asText())
+    assertTrue("Expected features array in staging query output", jsonNode.has("features"))
+    val features = jsonNode.get("features")
+    assertTrue("Expected non-empty features array", features.size() > 0)
+    val firstFeature = features.get(0)
+    assertEquals("StagingQuery", firstFeature.get("operation").asText())
+  }
+
   def testEmbeddedGroupByExport(): Unit = {
     // Create the table used by both the Join left side and embedded GroupBy sources.
     val namespace = "example_namespace"


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adds StagingQuery support to the metadata export pipeline so that staging query configs appear alongside GroupBy/Join configs in the metadata table, enabling complete column-level lineage in one place.

Changes:
- Analyzer.scala: add analyzeStagingQuery() that dry-runs the query with dummy dates to derive the output schema, returning AnalyzeStagingQueryResult with Chronon-typed column metadata
- MetadataExporter.scala: add STAGING_QUERY_PATH_SUFFIX case in enrichMetadata(), write features array with operation="StagingQuery"; also fix writeOutputToTable by building the SparkSession with enforceKryoSerializer=false — Kryo cannot instantiate the Row trait and was causing InstantiationError when distributing the DataFrame across executors
- Metrics.scala: add stagingQueryMetadataExport environment constant
- Test fixture + MetadataExporterTest: add testStagingQueryMetadataExport

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @Shiyinghaha 
