### PR TITLE
Handle Jackson-deserialized types in SparkInternalRowConversions.to()

### DIFF
--- a/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
@@ -149,22 +149,59 @@ object SparkInternalRowConversions {
         val names = fields.map { _.name }
 
         def mapConverter(structMap: Any): Any = {
-          val map = structMap.asInstanceOf[Map[Any, Any]]
-          val valueArr =
-            names.iterator
-              .zip(funcs.iterator)
-              .map { case (name, func) => map.get(name).map(func).orNull }
-              .toArray
+          val getValue: Any => Any = structMap match {
+            case scalaMap: Map[_, _]          => (name: Any) => scalaMap.asInstanceOf[Map[Any, Any]].get(name).orNull
+            case javaMap: java.util.Map[_, _] => (name: Any) => javaMap.asInstanceOf[java.util.Map[Any, Any]].get(name)
+            case _                            => throw new ClassCastException(s"Cannot cast ${structMap.getClass.getName} to Map")
+          }
+
+          val valueArr = names.iterator
+            .zip(funcs.iterator)
+            .map {
+              case (name, func) =>
+                val value = getValue(name)
+                if (value != null) func(value) else null
+            }
+            .toArray
           new GenericInternalRow(valueArr)
         }
 
-        def arrayConverter(structArr: Any): Any = {
-          val valueArr = structArr
-            .asInstanceOf[Array[Any]]
-            .iterator
-            .zip(funcs.iterator)
-            .map { case (value, func) => if (value != null) func(value) else null }
-            .toArray
+        def arrayConverter(structData: Any): Any = {
+          val valueArr = structData match {
+            case listValue: java.util.List[_] =>
+              listValue
+                .iterator()
+                .toScala
+                .zip(funcs.iterator)
+                .map { case (value, func) => if (value != null) func(value) else null }
+                .toArray
+            case arrayValue: Array[_] =>
+              arrayValue.iterator
+                .zip(funcs.iterator)
+                .map { case (value, func) => if (value != null) func(value) else null }
+                .toArray
+            case javaMap: java.util.Map[_, _] =>
+              val map = javaMap.asInstanceOf[java.util.Map[Any, Any]]
+              names.iterator
+                .zip(funcs.iterator)
+                .map {
+                  case (name, func) =>
+                    val value = map.get(name)
+                    if (value != null) func(value) else null
+                }
+                .toArray
+            case scalaMap: Map[_, _] =>
+              val map = scalaMap.asInstanceOf[Map[Any, Any]]
+              names.iterator
+                .zip(funcs.iterator)
+                .map {
+                  case (name, func) =>
+                    val value = map.get(name).orNull
+                    if (value != null) func(value) else null
+                }
+                .toArray
+            case _ => throw new ClassCastException(s"Cannot cast ${structData.getClass.getName} to Array, List, or Map")
+          }
           new GenericInternalRow(valueArr)
         }
 

--- a/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
+++ b/online/src/main/scala/ai/chronon/online/SparkInternalRowConversions.scala
@@ -30,6 +30,17 @@ object SparkInternalRowConversions {
   // the identity function
   private def id(x: Any): Any = x
 
+  // Coerce a numeric value to the exact JVM type Catalyst expects for a given numeric DataType.
+  // JSON deserializers (e.g. Jackson) infer a number's type from its literal - `5` becomes an Integer,
+  // `1.5` a Double - regardless of the target schema. Spark's typed row accessors (getLong, getInt, ...)
+  // unbox to a fixed primitive, so an Integer sitting in a LongType slot throws a ClassCastException at
+  // read time. Normalising every java.lang.Number to the schema's type here makes the conversion robust
+  // to that mismatch; values that are already the right type are coerced idempotently.
+  private def numericConverter(coerce: java.lang.Number => Any): Any => Any = {
+    case n: java.lang.Number => coerce(n)
+    case other               => other
+  }
+
   // recursively convert sparks byte array based internal row to chronon's fetcher result type (map[string, any])
   // The purpose of this class is to be used on fetcher output in a fetching context
   // we take a data type and build a function that operates on actual value
@@ -206,6 +217,12 @@ object SparkInternalRowConversions {
         }
 
         if (structToMap) mapConverter else arrayConverter
+      case types.ByteType    => numericConverter(_.byteValue())
+      case types.ShortType   => numericConverter(_.shortValue())
+      case types.IntegerType => numericConverter(_.intValue())
+      case types.LongType    => numericConverter(_.longValue())
+      case types.FloatType   => numericConverter(_.floatValue())
+      case types.DoubleType  => numericConverter(_.doubleValue())
       case types.StringType =>
         def stringConvertor(x: Any): Any = { UTF8String.fromString(x.asInstanceOf[String]) }
 

--- a/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
@@ -813,4 +813,26 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     assertEquals(2147483648L, result.get("struct_id"))
     assertEquals("10", result.get("struct_amount"))
   }
+
+  // A numeric value may arrive boxed narrower than the schema declares (e.g. a small integer as
+  // java.lang.Integer for a LongType field, as JSON parsers produce). The converter must coerce it
+  // to the schema's type so Catalyst's typed accessors (getLong, ...) don't throw at read time.
+  @Test
+  def testNarrowNumericValuesAreCoercedToSchemaType(): Unit = {
+    val nested = new util.LinkedHashMap[String, Any]()
+    nested.put("inner_long", 7) // Integer in a LongType slot
+    val data: Map[String, Any] = Map("a_long" -> 5, "nested" -> nested)
+    val schema = StructType.from(
+      "NumericCoercionStruct",
+      Array(
+        ("a_long", LongType),
+        ("nested", StructType.from("Nested", Array(("inner_long", LongType))))
+      )
+    )
+    val selects = Seq("a_long" -> "a_long", "inner_long" -> "nested.inner_long")
+    val result = new PooledCatalystUtil(selects, schema).applyDerivations(data)
+    assertEquals(2, result.get.size)
+    assertEquals(5L, result.get("a_long"))
+    assertEquals(7L, result.get("inner_long")) // nested coercion — the case castTo never reaches
+  }
 }

--- a/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/CatalystUtilTest.scala
@@ -685,4 +685,132 @@ class CatalystUtilTest extends TestCase with CatalystUtilTestSparkSQLStructs {
     assertEquals("test_key_1", result.get("key"))
     assertArrayEquals(Array(1L, 2L), result.get("ids").asInstanceOf[java.util.List[Long]].toScala.toArray)
   }
+
+  // Tests for JSON-deserialized types (LinkedHashMap, ArrayList) in nested structs.
+  // These simulate what happens when contextual values arrive via the online HTTP API,
+  // where Java's JSON parser produces LinkedHashMap for objects and ArrayList for arrays.
+
+  @Test
+  def testSelectWithNestedJavaMapShouldWork(): Unit = {
+    val javaMapInner1 = new util.LinkedHashMap[String, Any]()
+    javaMapInner1.put("int32_req", 12)
+    javaMapInner1.put("int32_opt", 34)
+    val javaMapInner2 = new util.LinkedHashMap[String, Any]()
+    javaMapInner2.put("int32_req", 56)
+    javaMapInner2.put("int32_opt", 78)
+
+    val nestedJavaMapRow: Map[String, Any] = Map(
+      "inner_req" -> javaMapInner1,
+      "inner_opt" -> javaMapInner2
+    )
+
+    val selects = Seq(
+      "inner_req_int32_req" -> "inner_req.int32_req",
+      "inner_req_int32_opt" -> "inner_req.int32_opt",
+      "inner_opt_int32_req" -> "inner_opt.int32_req",
+      "inner_opt_int32_opt" -> "inner_opt.int32_opt"
+    )
+    val cu = new CatalystUtil(selects, NestedOuterStruct)
+    val res = cu.sqlTransform(nestedJavaMapRow)
+    assertEquals(res.get.size, 4)
+    assertEquals(res.get("inner_req_int32_req"), 12)
+    assertEquals(res.get("inner_req_int32_opt"), 34)
+    assertEquals(res.get("inner_opt_int32_req"), 56)
+    assertEquals(res.get("inner_opt_int32_opt"), 78)
+  }
+
+  @Test
+  def testPooledCatalystUtilWithJavaMapStructs(): Unit = {
+    val javaMapStruct1 = new util.LinkedHashMap[String, Any]()
+    javaMapStruct1.put("id", 1L)
+    javaMapStruct1.put("data", "data1")
+    val javaMapStruct2 = new util.LinkedHashMap[String, Any]()
+    javaMapStruct2.put("id", 2L)
+    javaMapStruct2.put("data", "data2")
+
+    val structListDataWithJavaMaps: Map[String, Any] = Map(
+      "ts" -> 1000L,
+      "key" -> "test_key_1",
+      "value" -> makeArrayList(javaMapStruct1, javaMapStruct2)
+    )
+
+    val selects = Seq(
+      "ts" -> "ts",
+      "key" -> "key",
+      "ids" -> "transform(value, v -> v.id)"
+    )
+    val pooledCatalystUtil = new PooledCatalystUtil(selects, structListType)
+    val result = pooledCatalystUtil.applyDerivations(structListDataWithJavaMaps)
+    assertEquals(3, result.get.size)
+    assertEquals(1000L, result.get("ts"))
+    assertEquals("test_key_1", result.get("key"))
+    assertArrayEquals(Array(1L, 2L), result.get("ids").asInstanceOf[java.util.List[Long]].toScala.toArray)
+  }
+
+  @Test
+  def testPooledCatalystUtilWithJavaListStructs(): Unit = {
+    val javaListStruct1 = new util.ArrayList[Any](util.Arrays.asList(1L, "data1"))
+    val javaListStruct2 = new util.ArrayList[Any](util.Arrays.asList(2L, "data2"))
+
+    val structListDataWithJavaLists: Map[String, Any] = Map(
+      "ts" -> 1000L,
+      "key" -> "test_key_1",
+      "value" -> makeArrayList(javaListStruct1, javaListStruct2)
+    )
+
+    val selects = Seq(
+      "ts" -> "ts",
+      "key" -> "key",
+      "ids" -> "transform(value, v -> v.id)"
+    )
+    val pooledCatalystUtil = new PooledCatalystUtil(selects, structListType)
+    val result = pooledCatalystUtil.applyDerivations(structListDataWithJavaLists)
+    assertEquals(3, result.get.size)
+    assertEquals(1000L, result.get("ts"))
+    assertEquals("test_key_1", result.get("key"))
+    assertArrayEquals(Array(1L, 2L), result.get("ids").asInstanceOf[java.util.List[Long]].toScala.toArray)
+  }
+
+  @Test
+  def testPooledCatalystUtilWithNestedJavaMapContextualValues(): Unit = {
+    val contextualStruct: StructType = StructType.from(
+      "ContextualStruct",
+      Array(
+        ("account_id", StringType),
+        ("transaction_amount", LongType),
+        ("transaction_struct",
+         StructType.from(
+           "TxnStruct",
+           Array(
+             ("id", LongType),
+             ("amount", StringType)
+           )
+         ))
+      )
+    )
+
+    val javaMapTxnStruct = new util.LinkedHashMap[String, Any]()
+    javaMapTxnStruct.put("id", 2147483648L)
+    javaMapTxnStruct.put("amount", "10")
+
+    val contextualData: Map[String, Any] = Map(
+      "account_id" -> "acc_123",
+      "transaction_amount" -> 2147483648L,
+      "transaction_struct" -> javaMapTxnStruct
+    )
+
+    val selects = Seq(
+      "account_id_echo" -> "account_id",
+      "amount_doubled" -> "ABS(CAST(transaction_amount AS LONG)) * 2",
+      "struct_id" -> "CAST(transaction_struct.id AS LONG)",
+      "struct_amount" -> "CAST(transaction_struct.amount AS STRING)"
+    )
+    val pooledCatalystUtil = new PooledCatalystUtil(selects, contextualStruct)
+    val result = pooledCatalystUtil.applyDerivations(contextualData)
+    assertEquals(4, result.get.size)
+    assertEquals("acc_123", result.get("account_id_echo"))
+    assertEquals(2147483648L * 2, result.get("amount_doubled"))
+    assertEquals(2147483648L, result.get("struct_id"))
+    assertEquals("10", result.get("struct_amount"))
+  }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/FetcherTest.scala
@@ -787,6 +787,78 @@ class FetcherTest extends TestCase {
     logger.info(s"✅ Fetcher correctly returns ONLY derived columns (no wildcard): ${responseKeys.mkString(", ")}")
   }
 
+  // Mirrors a Join with a ContextualSource that has a struct-typed field, read back online through
+  // derivations (e.g. ext_contextual_transaction_struct.id). When contextual values arrive via the
+  // online HTTP API, Jackson deserializes the nested struct as a java.util.LinkedHashMap - which
+  // previously blew up the StructType converter in SparkInternalRowConversions.to(). This exercises
+  // that path end-to-end through the fetcher and its derivations.
+  def testFetchJoinContextualStruct(): Unit = {
+    val spark: SparkSession = createSparkSession()
+    val namespace = "contextual_struct_fetch"
+    val tableUtils = TableUtils(spark)
+    tableUtils.createDatabase(namespace)
+    implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
+
+    val txnStruct = StructType(
+      "transaction_struct",
+      Array(StructField("id", LongType), StructField("amount", StringType))
+    )
+
+    val contextualSource = Builders.ContextualSource(
+      fields = Array(
+        StructField("transaction_amount_demo", LongType),
+        StructField("transaction_id", StringType),
+        StructField("transaction_struct", txnStruct)
+      )
+    )
+
+    val joinConf = Builders.Join(
+      // left doesn't matter for a fetch-only test - contextual keys come from the request
+      left = Builders.Source.events(
+        Builders.Query(selects = Builders.Selects("account_id")),
+        table = "non_existent_table"
+      ),
+      externalParts = Seq(Builders.ExternalPart(contextualSource)),
+      derivations = Seq(
+        Builders.Derivation(name = "txn_amount", expression = "ext_contextual_transaction_amount_demo"),
+        Builders.Derivation(name = "txn_id", expression = "ext_contextual_transaction_id"),
+        Builders.Derivation(name = "struct_id", expression = "ext_contextual_transaction_struct.id"),
+        Builders.Derivation(name = "struct_amount", expression = "ext_contextual_transaction_struct.amount")
+      ),
+      metaData =
+        Builders.MetaData(name = "unit_test/fetcher_contextual_struct_join", namespace = namespace, team = "chronon")
+    )
+
+    val kvStoreFunc = () => OnlineUtils.buildInMemoryKVStore("FetcherTest#contextual_struct")
+    val mockApi = new MockApi(kvStoreFunc, namespace)
+    val fetcher = mockApi.buildFetcher(debug = false)
+    fetcher.kvStore.create(ChrononMetadataKey)
+    fetcher.putJoinConf(joinConf)
+
+    // Mirror the online HTTP path: Jackson deserializes the nested JSON struct as a LinkedHashMap.
+    val jacksonStruct = new java.util.LinkedHashMap[String, AnyRef]()
+    jacksonStruct.put("id", java.lang.Long.valueOf(2147483648L))
+    jacksonStruct.put("amount", "10")
+
+    val request = Request(
+      joinConf.metaData.name,
+      Map(
+        "account_id" -> "1",
+        "transaction_amount_demo" -> java.lang.Long.valueOf(2147483648L),
+        "transaction_id" -> "txn_1",
+        "transaction_struct" -> jacksonStruct
+      )
+    )
+
+    val response = Await.result(fetcher.fetchJoin(Seq(request)), Duration(10, SECONDS)).head
+    assertTrue(response.values.isSuccess)
+    val values = response.values.get
+    assertEquals(2147483648L, values("txn_amount"))
+    assertEquals("txn_1", values("txn_id"))
+    assertEquals(2147483648L, values("struct_id"))
+    assertEquals("10", values("struct_amount"))
+  }
+
   def testTemporalFetchJoinGenerated(): Unit = {
     val namespace = "generated_fetch"
     val joinConf = generateRandomData(namespace)


### PR DESCRIPTION
When contextual values arrive via the HTTP API, Jackson deserializes nested objects as LinkedHashMap and arrays as ArrayList. The StructType converters in to() assumed Scala Map/Array, causing ClassCastExceptions.

Broaden the StructType cases to accept both Scala and Java collection types from Jackson deserialization.

### Summary

SparkInternalRowConversions.to() builds converters that turn fetcher result values into Spark InternalRows. For the StructType case, the converters previously hard-cast struct values to Scala types: mapConverter cast to Map[Any, Any] and arrayConverter cast to Array[Any].

This holds for values produced internally by Chronon, but not for contextual values supplied through the online HTTP API. There, Jackson deserializes JSON objects as java.util.LinkedHashMap and JSON arrays as java.util.ArrayList, so a nested struct field reaches the converter as a LinkedHashMap and blows up the Array[_] cast.

This PR broadens both converters in the StructType branch:
- mapConverter now resolves field values from either a Scala Map or a java.util.Map.
- arrayConverter now handles java.util.List, Array, java.util.Map, and Scala Map representations of a struct, falling back to a clear ClassCastException for anything else.

Added 4 unit tests in CatalystUtilTest covering JSON-deserialized (LinkedHashMap/ArrayList) nested structs, including an end-to-end test that mirrors a contextual source with a struct field run through PooledCatalystUtil derivations.

### Why / Goal

We want to declare a Join with a ContextualSource where one of the fields is a struct type, and read it back online via derivations such as ext_contextual_transaction_struct.id. Example:

```
TxnStruct = DataType.STRUCT(
    "custom_struct",
    ("id", DataType.LONG),
    ("amount", DataType.STRING),
)

v3 = Join(
    ...
    online_external_parts=[
        ExternalPart(
            ContextualSource(
                fields=[
                    ("transaction_amount_demo", DataType.LONG),
                    ("transaction_id", DataType.STRING),
                    ("transaction_struct", TxnStruct),
                ]
            )
        ),
    ],
    derivations=[
        Derivation(name="txn_amount", expression="ext_contextual_transaction_amount_demo"),
        Derivation(name="txn_id", expression="ext_contextual_transaction_id"),
        Derivation(name="struct_id", expression="ext_contextual_transaction_struct.id"),
        Derivation(name="struct_amount", expression="ext_contextual_transaction_struct.amount"),
    ],
    online=True,
)
```

This works offline for backfilling, but online a fetch request like:

```
[
  {
    "account_id": "1",
    "transaction_amount_demo": 2147483648,
    "transaction_id": "txn_1",
    "transaction_struct": {"amount": "10", "id": 2147483648}
  }
]
```

fails with:

```
java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class [Ljava.lang.Object;
  at ai.chronon.online.SparkInternalRowConversions$.arrayConverter$3(SparkInternalRowConversions.scala:162)
  ...
  at ai.chronon.online.CatalystUtil.toInternalRow(CatalystUtil.scala:147)
  at ai.chronon.online.PooledCatalystUtil.applyDerivations(CatalystUtil.scala:116)
  at ai.chronon.online.OnlineDerivationUtil$.applyDeriveFunc(OnlineDerivationUtil.scala:73)
  at ai.chronon.online.Fetcher.$anonfun$fetchJoin$11(Fetcher.scala:283)
```

The root cause is arrayConverter in the StructType case hard-casting to Array[_], while Jackson has deserialised the JSON struct as a LinkedHashMap. This PR unblocks struct-typed fields on contextual sources for online serving, so the same Join definition that backfills offline now also fetches correctly online.

### Test Plan

<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
