### PR TITLE
Fix CI: Spark test JVMs crash on cgroup-v2 (ExecutorMetricType BufferPool MBean)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
                   command: |
                       conda activate chronon_py
                       # Increase if we see OOM.
-                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -XX:MaxPermSize=4G -Xmx4G -Xms2G"
 
                       # Split tests across parallel containers, excluding Fetcher tests
                       TESTFILES=$(find spark/src/test/scala aggregator/src/test/scala -name "*Test.scala" | \
@@ -108,7 +108,7 @@ jobs:
                   command: |
                       conda activate chronon_py
                       # Increase if we see OOM.
-                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=8G -Xmx8G -Xms4G"
+                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -XX:MaxPermSize=8G -Xmx8G -Xms4G"
 
                       # Split tests across parallel containers, excluding Fetcher tests
                       TESTFILES=$(find spark/src/test/scala aggregator/src/test/scala -name "*Test.scala" | \
@@ -168,7 +168,7 @@ jobs:
             command: |
               conda activate chronon_py
               # Increase if we see OOM.
-              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -XX:MaxPermSize=4G -Xmx4G -Xms2G"
               sbt "++ 2.11.12 compile"
         - save_cache:
             key: sbt-cache-v1-{{ checksum "build.sbt" }}-{{ checksum "project/plugins.sbt" }}
@@ -191,7 +191,7 @@ jobs:
                   shell: /bin/bash -leuxo pipefail
                   command: |
                       conda activate chronon_py
-                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+                      export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -XX:MaxPermSize=4G -Xmx4G -Xms2G"
                       sbt "++ 2.12.12; spark_uber/testOnly ai.chronon.spark.test.FetcherTest ai.chronon.spark.test.ChainingFetcherTest ai.chronon.spark.test.JavaFetcherTest"
             - store_test_results:
                   path: /chronon/spark/target/test-reports
@@ -229,7 +229,7 @@ jobs:
                   shell: /bin/bash -leuxo pipefail
                   command: |
                     conda activate chronon_py
-                    export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -Xmx4G -Xms2G"
+                    export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -Xmx4G -Xms2G"
                     sbt "++ 2.12.12; publishLocal"
             - run:
                   name: Run Chronon Python tests
@@ -292,7 +292,7 @@ jobs:
             command: |
               conda activate chronon_py
               # Increase if we see OOM.
-              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -XX:MaxPermSize=4G -Xmx4G -Xms2G"
               sbt ';project spark_embedded; ++ 2.13.6; testOnly ai.chronon.spark.test.TableUtilsFormatTest'
         - store_test_results:
             path: /chronon/spark/target/test-reports
@@ -330,7 +330,7 @@ jobs:
             command: |
               conda activate chronon_py
               # Increase if we see OOM.
-              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xms2G"
+              export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:-UseContainerSupport -XX:MaxPermSize=4G -Xmx4G -Xms2G"
               sbt ';project spark_embedded; ++ 2.13.6; testOnly ai.chronon.spark.test.TableUtilsTest'
         - store_test_results:
             path: /chronon/spark/target/test-reports

--- a/api/py/test/test_pyspark.py
+++ b/api/py/test/test_pyspark.py
@@ -23,6 +23,7 @@ Requirements:
     - PySpark with py4j
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -111,6 +112,16 @@ def spark() -> SparkSession:
         .setMaster("local[2]")
         .setAppName("chronon-pyspark-tests")
     )
+
+    # On JDK 8 running under cgroup v2, CgroupV2Subsystem.getInstance NPEs during
+    # ManagementFactory.getPlatformMBeanServer(), aborting registration of the java.nio BufferPool
+    # MBeans. Spark's ExecutorMetricType init then fails looking them up and takes down the
+    # SparkContext (Py4JJavaError constructing JavaSparkContext). Disable container support so the
+    # cgroup path is skipped and platform-MBean registration completes. Set via _JAVA_OPTIONS
+    # because the driver JVM is launched (by py4j) before this SparkConf is applied.
+    java_opts = os.environ.get("_JAVA_OPTIONS", "")
+    if "UseContainerSupport" not in java_opts:
+        os.environ["_JAVA_OPTIONS"] = (java_opts + " -XX:-UseContainerSupport").strip()
 
     spark = SparkSession.builder.config(conf=spark_conf).getOrCreate()
 


### PR DESCRIPTION
## Problem

Spark test JVMs fail across CI shards (`TableUtilsTest`, `DataRangeTest`, `test_pyspark`, …) with:

```
java.lang.ExceptionInInitializerError
  at org.apache.spark.metrics.ExecutorMetricType$.<clinit>
Caused by: javax.management.InstanceNotFoundException: java.nio:type=BufferPool,name=direct
```

Once `ExecutorMetricType` fails to initialize, every code path that touches it (`ExecutorMetricsSource`, `AppStatusListener.onExecutorAdded`, …) crashes `SparkContext` creation, and the remaining tests in that JVM cascade to `NoClassDefFoundError` — taking down whole shards.

## Root cause

On **JDK 8 under cgroup v2**, `CgroupV2Subsystem.getInstance` throws a `NullPointerException` during `ManagementFactory.getPlatformMBeanServer()`. That NPE (on the OperatingSystem MXBean) **aborts platform-MBean registration before the `java.nio` BufferPool MXBeans are registered**. Spark's `ExecutorMetricType` then looks those beans up, doesn't find them, and fails. Environmental JDK/cgroup bug, not a code defect — which is why gating individual callers doesn't help; the class itself can't initialize.

## Fix

Disable JVM container support (`-XX:-UseContainerSupport`) in the test JVMs, so the cgroup path that NPEs is skipped and platform-MBean registration completes normally (registering the BufferPool beans):

- **`.circleci/config.yml`** — added the flag to every `SBT_OPTS` (the sbt JVM that runs the Scala test shards).
- **`api/py/test/test_pyspark.py`** — set the flag via `_JAVA_OPTIONS` before `SparkSession.getOrCreate()`, because the pyspark driver JVM is launched (by py4j) before the test's `SparkConf` applies.

## Scope / safety

- **CI-only.** No production or library code changes.
- `-XX:-UseContainerSupport` only disables cgroup-based resource auto-detection; heap is set explicitly via `-Xmx`, so behavior is otherwise unchanged.

## Verification

- Root cause confirmed from the full driver stack trace (cgroup NPE → aborted registration → missing BufferPool MBean).
- The cgroup-v2 JVM behavior is not reproducible locally (local JDK registers the beans), so CI on this branch is the definitive check across the previously-failing shards and `test_pyspark`.
