### PR TITLE
Substitute macros on unpartitioned staging-query path

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
+++ b/spark/src/main/scala/ai/chronon/spark/StagingQuery.scala
@@ -56,7 +56,10 @@ class StagingQuery(stagingQueryConf: api.StagingQuery, endPartition: String, tab
     Option(stagingQueryConf.setups).foreach(_.toScala.foreach(tableUtils.sql))
     // the input table is not partitioned, usually for data testing or for kaggle demos
     if (stagingQueryConf.startPartition == null) {
-      tableUtils.sql(stagingQueryConf.query).save(outputTable)
+      // Still run macro substitution so range-independent macros
+      val renderedQuery =
+        StagingQuery.substitute(tableUtils, stagingQueryConf.query, null, null, endPartition)
+      tableUtils.sql(renderedQuery).save(outputTable)
       return
     }
     val historicalBackfill =
@@ -207,7 +210,15 @@ object StagingQuery {
       )
     )
 
-    macros.foldLeft(query) { case (q, m) => m.replace(q) }
+    val rendered = macros.foldLeft(query) { case (q, m) => m.replace(q) }
+
+    val unresolved = """\{\{\s*\w+.*?}}""".r.findAllIn(rendered).toList.distinct
+    if (unresolved.nonEmpty) {
+      throw new IllegalStateException(
+        s"Unresolved template macro(s) after substitution: ${unresolved.mkString(", ")}. " +
+          "Supported macros: start_date, end_date, latest_date, max_date(table=...).")
+    }
+    rendered
   }
 
   def main(args: Array[String]): Unit = {

--- a/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/StagingQueryTest.scala
@@ -25,6 +25,7 @@ import ai.chronon.spark.{StagingQuery, _}
 import org.apache.spark.sql.SparkSession
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
+import org.scalatest.Assertions.intercept
 import org.slf4j.LoggerFactory
 
 import scala.util.Random
@@ -293,6 +294,28 @@ class StagingQueryTest {
       diff.show()
     }
     assertEquals(0, diff.count())
+
+    // Unpartitioned-input path (no startPartition) must also resolve max_date rather than
+    // run `{{ max_date(...) }}` literally (which would match nothing / write empty data).
+    val noStartConf = Builders.StagingQuery(
+      query = s"SELECT ds, '{{ max_date(table=$viewName) }}' AS latest_ds FROM $viewName",
+      metaData = Builders.MetaData(name = "test.staging_max_date_no_start", namespace = namespace)
+    )
+    new StagingQuery(noStartConf, today, tableUtils).computeStagingQuery()
+    assertEquals(
+      Seq(maxDate),
+      tableUtils
+        .sql(s"SELECT DISTINCT latest_ds FROM ${noStartConf.metaData.outputTable}")
+        .collect()
+        .map(_.getString(0))
+        .toSeq
+    )
+
+    // substitute() must fail loudly on an unresolved macro instead of passing it through.
+    val ex = intercept[IllegalStateException] {
+      StagingQuery.substitute(tableUtils, "SELECT '{{ bogus_macro }}'", ninetyDaysAgo, today, today)
+    }
+    assertTrue(ex.getMessage.contains("Unresolved template macro"))
   }
 
   @Test


### PR DESCRIPTION
## Summary
When a `StagingQuery` has no `startPartition`, `computeStagingQuery` takes the "unpartitioned input" fast path, which ran the raw query **without** calling `substitute()`. As a result, range-independent template macros (`max_date`, `latest_date`) were passed through literally (e.g. `ds = '{{ max_date(...) }}'`), matched no partition, and the job **silently wrote empty output while reporting success**.

This PR:
- Runs `StagingQuery.substitute` on the null-`startPartition` path as well, so `max_date` / `latest_date` resolve (`start`/`end` are `null` since there is no partition range).
- Adds a guard in `substitute()` that throws if any `{{ ... }}` macro template survives substitution — turning silent bad output into a loud failure.

## Why / Goal
A production staging query using `{{ max_date(table=...) }}` (migrated from the legacy `MAX_DS` Hive UDF) silently produced an **empty** output table in prod. The config had no `startPartition`, so the macro was never substituted and executed as a literal string that matched no partition — and because the Spark job still reported success, monitoring didn't catch it. This change lets range-independent macros work on the unpartitioned path and makes any unresolved macro fail loudly instead of corrupting data silently.

## Test Plan
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

`StagingQueryTest.testStagingQueryMaxDate` now also runs a second query with no `startPartition` and asserts `max_date` resolves to the latest partition (fails on empty or literal `{{ ... }}` output); added a `substitute()` guard assertion for an unresolved macro.

## Checklist
- [ ] Documentation update

## Reviewers
@yuli-han @Shiyinghaha 