### PR TITLE
Fix flaky FetcherTest and CatalystUtilTest

### DIFF
--- a/online/src/test/scala/ai/chronon/online/test/DataStreamBuilderTest.scala
+++ b/online/src/test/scala/ai/chronon/online/test/DataStreamBuilderTest.scala
@@ -31,10 +31,14 @@ class DataStreamBuilderTest {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   lazy val spark: SparkSession = {
     System.setSecurityManager(null)
+    // Spark allows only one SparkContext per JVM, so whichever test's getOrCreate() runs first in this
+    // process wins and everyone else just gets that session back - including its config. Set the same
+    // spark.cleaner.referenceTracking value CatalystUtil.session requests, so it doesn't matter who wins.
     val spark = SparkSession
       .builder()
       .appName("DataStreamBuilderTest")
       .master("local")
+      .config("spark.cleaner.referenceTracking", "false")
       .getOrCreate()
     spark
   }

--- a/spark/src/test/scala/ai/chronon/spark/test/InMemoryKvStore.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/InMemoryKvStore.scala
@@ -59,6 +59,9 @@ class InMemoryKvStore(tableUtils: () => TableUtils, hardFailureOnInvalidDataset:
             .filter {
               case (version, _) => req.afterTsMillis.forall(version >= _)
             } // filter version
+            // Real KV stores return time-ordered results; multiPut() appends in whatever order
+            // Spark's writer tasks happen to run in, which isn't guaranteed to match version order.
+            .sortBy { case (version, _) => version }
             .map { case (version, bytes) => TimedValue(bytes, version) }
         }
         KVStore.GetResponse(req, values)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Fixes two flaky/order-dependent tests:
1. `InMemoryKvStore.multiGet` now sorts returned records by version before returning them, so `FetcherTest`'s temporal aggregation always merges inserts before their reversals.
2. `DataStreamBuilderTest`'s shared `SparkSession` now sets `spark.cleaner.referenceTracking=false`, matching the config `CatalystUtilTest` expects, so `CatalystUtilTest` no longer depends on which test's session wins the JVM-wide `SparkContext` race.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
Both failures stem from shared, order-dependent state across tests running in the same JVM/sbt process:
- `InMemoryKvStore` appended mutation records in whatever order Spark's write-stream tasks happened to run, not by mutation time. `FetcherBase` folds that sequence directly into its temporal aggregator, which requires inserts to be merged before their reversals — out-of-order delivery could merge a reversal before its insert, producing wrong results and intermittent diffs in `testTemporalFetchJoinDeterministic`/`Derivation`/`DerivationRenameOnly`.
- Spark only allows one `SparkContext` per JVM, so whichever test's `getOrCreate()` runs first wins and every other caller (including sbt's parallel test execution) reuses that same session's config. When `DataStreamBuilderTest` won that race before `CatalystUtilTest` ran, `CatalystUtil.session`'s `spark.cleaner.referenceTracking -> false` config was silently ignored, causing `testServingSessionDisablesSparkCleanerReferenceTracking`'s bare `.get()` to throw `NoSuchElementException`.

Removing this flakiness unblocks reliable CI signal and avoids wasted debugging time from spurious red builds unrelated to the change under test.



## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

Both fixes were verified by reproducing the original flake locally and confirming it no longer occurs across repeated runs of `FetcherTest` and `online/test` (`CatalystUtilTest` + `DataStreamBuilderTest`) with varied test ordering.

## Checklist
- [ ] Documentation update

## Reviewers
@yuli-han 
