### PR TITLE
Retry Spark streaming queries on ContinuousTaskRetryException

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -29,12 +29,14 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkFiles
+import org.apache.spark.sql.execution.streaming.continuous.ContinuousTaskRetryException
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.sql.streaming.StreamingQueryListener.{
   QueryProgressEvent,
   QueryStartedEvent,
   QueryTerminatedEvent
 }
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException}
 import org.apache.spark.sql.{DataFrame, SparkSession, SparkSessionExtensions}
 import org.apache.thrift.TBase
 import org.rogach.scallop.{ScallopConf, ScallopOption, Subcommand}
@@ -1018,6 +1020,42 @@ object Driver {
       statuses.find(_._2 == true).map(_._1)
     }
 
+    // Walks the cause chain of `t` looking for an instance of `T` - task failures surface wrapped
+    // in layers of SparkException, so the ContinuousTaskRetryException we care about is rarely the top-level cause.
+    private def isCausedBy[T <: Throwable](t: Throwable)(implicit tag: ClassTag[T]): Boolean = {
+      var cause = t
+      while (cause != null) {
+        if (tag.runtimeClass.isInstance(cause)) return true
+        cause = cause.getCause
+      }
+      false
+    }
+
+    // Continuous-trigger streaming queries (see streaming.GroupBy) abort with a
+    // ContinuousTaskRetryException on any task-level retry, since continuous mode doesn't support
+    // task retries itself - see org.apache.spark.sql.execution.streaming.continuous.ContinuousTaskRetryException.
+    // We treat that as a query-level failure and restart the whole query, up to maxRetries times.
+    // package-private so it can be exercised directly (with a fake startQuery) in tests, without a real SparkSession.
+    private[spark] def runWithRetries(maxRetries: Int)(startQuery: () => StreamingQuery): Unit = {
+      var attempt = 0
+      var succeeded = false
+      while (!succeeded) {
+        if (attempt > 0)
+          logger.info(s"Restarting streaming query, attempt $attempt/$maxRetries")
+        val query = startQuery()
+        try {
+          query.awaitTermination()
+          succeeded = true
+        } catch {
+          case e: StreamingQueryException if attempt < maxRetries && isCausedBy[ContinuousTaskRetryException](e) =>
+            attempt += 1
+            logger.warn(
+              s"Streaming query failed with ContinuousTaskRetryException, restarting (attempt $attempt/$maxRetries)",
+              e)
+        }
+      }
+    }
+
     def run(args: Args): Unit = {
       // session needs to be initialized before we can call find file.
       implicit val session: SparkSession = SparkSessionBuilder.buildStreaming(args.debug())
@@ -1031,26 +1069,34 @@ object Driver {
       if (args.debug())
         onlineJar.foreach(session.sparkContext.addJar)
       implicit val apiImpl = args.impl(args.serializableProps)
-      val query = if (groupByConf.streamingSource.get.isSetJoinSource) {
-        new JoinSourceRunner(groupByConf,
-                             args.serializableProps,
-                             args.debug(),
-                             args.lagMillis.getOrElse(2000)).chainedStreamingQuery.start()
-      } else {
-        val streamingSource = groupByConf.streamingSource
-        assert(streamingSource.isDefined,
-               "There is no valid streaming source - with a valid topic, and endDate < today")
-        lazy val host = streamingSource.get.topicTokens.get("host")
-        lazy val port = streamingSource.get.topicTokens.get("port")
-        if (!args.kafkaBootstrap.isDefined)
-          assert(
-            host.isDefined && port.isDefined,
-            "Either specify a kafkaBootstrap url or provide host and port in your topic definition as topic/host=host/port=port")
-        val inputStream: DataFrame =
-          dataStream(session, args.kafkaBootstrap.getOrElse(s"${host.get}:${port.get}"), streamingSource.get.cleanTopic)
-        new streaming.GroupBy(inputStream, session, groupByConf, args.impl(args.serializableProps), args.debug()).run()
+
+      def startQuery(): StreamingQuery = {
+        if (groupByConf.streamingSource.get.isSetJoinSource) {
+          new JoinSourceRunner(groupByConf,
+                               args.serializableProps,
+                               args.debug(),
+                               args.lagMillis.getOrElse(2000)).chainedStreamingQuery.start()
+        } else {
+          val streamingSource = groupByConf.streamingSource
+          assert(streamingSource.isDefined,
+                 "There is no valid streaming source - with a valid topic, and endDate < today")
+          lazy val host = streamingSource.get.topicTokens.get("host")
+          lazy val port = streamingSource.get.topicTokens.get("port")
+          if (!args.kafkaBootstrap.isDefined)
+            assert(
+              host.isDefined && port.isDefined,
+              "Either specify a kafkaBootstrap url or provide host and port in your topic definition as topic/host=host/port=port")
+          val inputStream: DataFrame =
+            dataStream(session,
+                       args.kafkaBootstrap.getOrElse(s"${host.get}:${port.get}"),
+                       streamingSource.get.cleanTopic)
+          new streaming.GroupBy(inputStream, session, groupByConf, args.impl(args.serializableProps), args.debug())
+            .run()
+        }
       }
-      query.awaitTermination()
+
+      val maxRetries: Int = session.conf.get("spark.chronon.stream.max_retries", "0").toInt
+      runWithRetries(maxRetries)(startQuery)
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/streaming/CheckpointConfig.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/CheckpointConfig.scala
@@ -1,0 +1,32 @@
+/*
+ *    Copyright (C) 2026 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.spark.streaming
+
+import ai.chronon.api
+import ai.chronon.api.Extensions.MetadataOps
+import org.apache.spark.sql.SparkSession
+
+object CheckpointConfig {
+
+  // Opt-in: only set a stable, GroupBy-derived checkpoint location when the base dir is explicitly
+  // configured - restarts (manual or retried) then resume from it with no setup. Left unset otherwise,
+  // to avoid changing behavior for callers that haven't opted in.
+  def location(groupByConf: api.GroupBy, session: SparkSession): Option[String] =
+    session.conf.getOption("spark.chronon.stream.checkpoint_base_dir").map { baseDir =>
+      s"$baseDir/${groupByConf.metaData.nameToFilePath}/"
+    }
+}

--- a/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/GroupBy.scala
@@ -172,7 +172,7 @@ class GroupBy(inputStream: DataFrame,
     val valueToBytes = AvroConversions.encodeBytes(valueZSchema, GenericRowHandler.func)
 
     val dataWriter = new DataWriter(onlineImpl, context.withSuffix("egress"), 120, debug, notificationTopic)
-    selectedDf
+    val writer = selectedDf
       .map { row =>
         val keys = keyIndices.map(row.get)
         val values = valueIndices.map(row.get)
@@ -198,6 +198,10 @@ class GroupBy(inputStream: DataFrame,
       .writeStream
       .outputMode("append")
       .trigger(Trigger.Continuous(2.minute))
+
+    CheckpointConfig
+      .location(groupByConf, session)
+      .foldLeft(writer) { case (w, checkpointLocation) => w.option("checkpointLocation", checkpointLocation) }
       .foreach(dataWriter)
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -685,7 +685,12 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
   private def writeToKVStore(
       joinSourceDf: DataFrame
   ): DataStreamWriter[Row] = {
-    val writer = joinSourceDf.writeStream.outputMode("append").trigger(Trigger.ProcessingTime(microBatchIntervalMillis))
+    val baseWriter = joinSourceDf.writeStream
+      .outputMode("append")
+      .trigger(Trigger.ProcessingTime(microBatchIntervalMillis))
+    val writer = CheckpointConfig
+      .location(groupByConf, session)
+      .foldLeft(baseWriter) { case (w, checkpointLocation) => w.option("checkpointLocation", checkpointLocation) }
     val putRequestHelper = PutRequestHelper(joinSourceDf.schema)
 
     def emitRequestMetric(request: PutRequest, context: Metrics.Context): Unit = {

--- a/spark/src/test/scala/ai/chronon/spark/test/CheckpointConfigTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/CheckpointConfigTest.scala
@@ -1,0 +1,46 @@
+/*
+ *    Copyright (C) 2026 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.spark.test
+
+import ai.chronon.api.Builders
+import ai.chronon.spark.SparkSessionBuilder
+import ai.chronon.spark.streaming.CheckpointConfig
+import org.apache.spark.sql.SparkSession
+import org.junit.Assert._
+import org.junit.Test
+
+class CheckpointConfigTest {
+
+  val spark: SparkSession = SparkSessionBuilder.build("CheckpointConfigTest", local = true)
+
+  private val groupByConf =
+    Builders.GroupBy(metaData = Builders.MetaData(name = "unit_test.checkpoint_config_gb"))
+
+  @Test
+  def locationIsUnsetWhenBaseDirIsNotConfigured(): Unit = {
+    spark.conf.unset("spark.chronon.stream.checkpoint_base_dir")
+    assertEquals(None, CheckpointConfig.location(groupByConf, spark))
+  }
+
+  @Test
+  def locationIsDerivedFromBaseDirAndGroupByNameWhenConfigured(): Unit = {
+    spark.conf.set("spark.chronon.stream.checkpoint_base_dir", "s3://bucket/checkpoints")
+    assertEquals(Some("s3://bucket/checkpoints/unit_test/checkpoint_config_gb/"),
+                 CheckpointConfig.location(groupByConf, spark))
+    spark.conf.unset("spark.chronon.stream.checkpoint_base_dir")
+  }
+}

--- a/spark/src/test/scala/ai/chronon/spark/test/GroupByStreamingRetryTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/GroupByStreamingRetryTest.scala
@@ -1,0 +1,118 @@
+/*
+ *    Copyright (C) 2026 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.spark.test
+
+import ai.chronon.spark.Driver
+import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.streaming.continuous.ContinuousTaskRetryException
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException}
+import org.junit.Assert._
+import org.junit.Test
+import org.mockito.Mockito._
+
+class GroupByStreamingRetryTest {
+
+  // StreamingQueryException's constructor is private[sql], so we can't `new` one directly from here;
+  // mock it instead and stub getCause() to mirror how the failure actually surfaces at runtime:
+  // ContinuousTaskRetryException wrapped in a SparkException, wrapped in the StreamingQueryException
+  // that awaitTermination throws.
+  private def exceptionWithCause(cause: Throwable): StreamingQueryException = {
+    val e = mock(classOf[StreamingQueryException])
+    when(e.getCause).thenReturn(cause)
+    e
+  }
+
+  private def continuousRetryFailure(): StreamingQueryException =
+    exceptionWithCause(new SparkException("wrapped", new ContinuousTaskRetryException()))
+
+  private def unrelatedFailure(): StreamingQueryException =
+    exceptionWithCause(new RuntimeException("boom"))
+
+  @Test
+  def restartsOnContinuousTaskRetryExceptionUntilItSucceeds(): Unit = {
+    val query = mock(classOf[StreamingQuery])
+    val firstFailure = continuousRetryFailure()
+    val secondFailure = continuousRetryFailure()
+    doThrow(firstFailure)
+      .doThrow(secondFailure)
+      .doNothing()
+      .when(query)
+      .awaitTermination()
+
+    var startCalls = 0
+    Driver.GroupByStreaming.runWithRetries(maxRetries = 2) { () =>
+      startCalls += 1
+      query
+    }
+
+    assertEquals(3, startCalls)
+  }
+
+  @Test
+  def givesUpOnceMaxRetriesIsExhausted(): Unit = {
+    val query = mock(classOf[StreamingQuery])
+    doThrow(continuousRetryFailure()).when(query).awaitTermination()
+
+    var startCalls = 0
+    try {
+      Driver.GroupByStreaming.runWithRetries(maxRetries = 1) { () =>
+        startCalls += 1
+        query
+      }
+      fail("expected StreamingQueryException to propagate")
+    } catch {
+      case _: StreamingQueryException => // expected
+    }
+    assertEquals(2, startCalls)
+  }
+
+  @Test
+  def defaultOfZeroRetriesDoesNotRestart(): Unit = {
+    val query = mock(classOf[StreamingQuery])
+    doThrow(continuousRetryFailure()).when(query).awaitTermination()
+
+    var startCalls = 0
+    try {
+      Driver.GroupByStreaming.runWithRetries(maxRetries = 0) { () =>
+        startCalls += 1
+        query
+      }
+      fail("expected StreamingQueryException to propagate")
+    } catch {
+      case _: StreamingQueryException => // expected
+    }
+    assertEquals(1, startCalls)
+  }
+
+  @Test
+  def doesNotRetryFailuresUnrelatedToContinuousTaskRetry(): Unit = {
+    val query = mock(classOf[StreamingQuery])
+    doThrow(unrelatedFailure()).when(query).awaitTermination()
+
+    var startCalls = 0
+    try {
+      Driver.GroupByStreaming.runWithRetries(maxRetries = 5) { () =>
+        startCalls += 1
+        query
+      }
+      fail("expected StreamingQueryException to propagate")
+    } catch {
+      case _: StreamingQueryException => // expected
+    }
+    assertEquals(1, startCalls)
+  }
+}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
- Continuous-trigger streaming queries (Trigger.Continuous) currently die on any task-level retry: continuous mode doesn't support task retries and surfaces that as ContinuousTaskRetryException, wrapped inside StreamingQueryException, which kills awaitTermination and the whole job. Driver.run now catches that case and restarts the query, up to spark.chronon.stream.max_retries attempts (default 0 — unchanged behavior unless explicitly opted in). The retry loop is factored into GroupByStreaming.runWithRetries so it's testable without a real SparkSession or streaming source.
- Give restarted queries a stable place to resume from: CheckpointConfig derives a checkpointLocation from the GroupBy's metadata and sets it on the streaming writer, but only when spark.chronon.stream.checkpoint_base_dir is explicitly configured — callers that haven't opted in (e.g. test harnesses reusing a GroupBy name across runs) keep their existing (unset) behavior.
- Both new config keys follow the existing spark.chronon.* convention (inline snake_case literals).

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->
- On YARN, executors live inside long-running NodeManagers, so losing one mid-job is rare. On Kubernetes, executor pods are routinely decommissioned during the life of an application — node scale-down, spot/preemptible reclamation, bin-packing/rebalancing — independent of whether the task itself is unhealthy. Spark's continuous-trigger mode has no concept of task-level retry, so any one of these normal, expected k8s events surfaces as a ContinuousTaskRetryException and previously took the entire streaming job down with it.

- That made continuous-trigger GroupBys meaningfully less resilient on k8s than on YARN: a routine infra event unrelated to the job's own health could kill a feature pipeline and require someone to notice and manually restart it.

- With this change, the app instead recovers itself: Driver.run catches the exception and restarts the query in-process as soon as it happens, up to spark.chronon.stream.max_retries times, so recovery time after an executor is decommissioned is bounded by "restart the query," not "wait for an on-call to intervene." The opt-in checkpoint location means each restart resumes from where it left off rather than reprocessing or dropping records.

- Net effect: Continuous streaming GroupBy queries can run reliably on Kubernetes, closing a reliability gap that would otherwise prevent these jobs from running on Kubernetes. Both flags default to off/unset, so nothing changes for jobs that haven't opted in.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested
------------
- App starting
```
  34:26/08/07 23:28:52 INFO SparkContext: Running Spark version 3.1.1
  620:26/08/07 23:29:24 INFO Driver$GroupByStreaming$: Query started: <QUERY_ID_REDACTED>
  1110:26/08/07 23:29:27 INFO ContinuousExecution: New epoch 1 is starting.
  1282:26/08/07 23:29:28 INFO SparkContext: Starting job: start at GroupBy.scala:80
```

- Run 1 (initial run) — epochs 1–52
```
  5789:26/08/08 01:11:04 ERROR TaskSchedulerImpl: Lost executor 5 on <IP_REDACTED>: The executor with id 5 was deleted by a user or the framework.
...
  5833:26/08/08 01:11:10 ERROR TaskSchedulerImpl: Lost executor 9 on <IP_REDACTED>: The executor with id 9 was deleted by a user or the framework.
  5843-5862: [replacement executors 21,22,23,24,25 registered]
  6090:26/08/08 01:11:42 ERROR ContinuousExecution: Query [id = <QUERY_ID_REDACTED>, runId = <RUN_ID_REDACTED>] terminated with error
  6225:26/08/08 01:11:42 WARN Driver$GroupByStreaming$: Streaming query failed with ContinuousTaskRetryException, restarting (attempt 1/5)
  6384:26/08/08 01:11:42 INFO Driver$GroupByStreaming$: Query terminated: <QUERY_ID_REDACTED>
```

- Run 2 — epochs 53–62

```
7926:26/08/08 01:28:12 ERROR TaskSchedulerImpl: Lost executor 21 on <IP_REDACTED>: The executor with id 21 was deleted by a user or the framework.
...
7969:26/08/08 01:28:19 ERROR TaskSchedulerImpl: Lost executor 25 on <IP_REDACTED>: The executor with id 25 was deleted by a user or the framework.
7978-7993: [replacement executors 26,30,27,29 registered]
8437:26/08/08 01:28:49 INFO Driver$GroupByStreaming$: Query terminated: <QUERY_ID_REDACTED>
```

- Run 3 — epochs 63–67 (67 fails)

```
9495:26/08/08 01:35:42 ERROR TaskSchedulerImpl: Lost executor 11 on <IP_REDACTED>: The executor with id 11 was deleted by a user or the framework.
...
9542:26/08/08 01:35:47 ERROR TaskSchedulerImpl: Lost executor 15 on <IP_REDACTED>: The executor with id 15 was deleted by a user or the framework.
9557-9656: [replacement executors 33,32,31,34,35 registered]
9797:26/08/08 01:36:19 ERROR ContinuousExecution: Query [id = <QUERY_ID_REDACTED>, runId = <RUN_ID_REDACTED>] terminated with error
9939:26/08/08 01:36:19 WARN Driver$GroupByStreaming$: Streaming query failed with ContinuousTaskRetryException, restarting (attempt 3/5)
9938:26/08/08 01:36:19 INFO Driver$GroupByStreaming$: Query terminated: <QUERY_ID_REDACTED>
```

###### Epochs (63–67)

```
┌───────┬──────────┬──────────────────────────────────────────────┬──────────┐
│ Epoch │  Start   │                    Finish                    │ Duration │
├───────┼──────────┼──────────────────────────────────────────────┼──────────┤
│ 63    │ 01:28:54 │ 01:29:48                                     │ 54s      │
├───────┼──────────┼──────────────────────────────────────────────┼──────────┤
│ 64    │ 01:30:00 │ 01:30:02                                     │ 2s       │
├───────┼──────────┼──────────────────────────────────────────────┼──────────┤
│ 65    │ 01:32:00 │ 01:32:02                                     │ 2s       │
├───────┼──────────┼──────────────────────────────────────────────┼──────────┤
│ 66    │ 01:34:00 │ 01:34:02                                     │ 2s       │
├───────┼──────────┼──────────────────────────────────────────────┼──────────┤
│ 67    │ 01:36:00 │ NEVER COMMITTED — query failed before commit │ —        │
└───────┴──────────┴──────────────────────────────────────────────┴──────────┘
```

- Run 4 — epochs 67 (retried) – 79

```
11923:26/08/08 02:00:24 ERROR TaskSchedulerImpl: Lost executor 20 on <IP_REDACTED>: The executor with id 20 was deleted by a user or the framework.
...
11964:26/08/08 02:00:28 ERROR TaskSchedulerImpl: Lost executor 16 on <IP_REDACTED>: The executor with id 16 was deleted by a user or the framework.
11974-11993: [replacement executors 37,36,40,38,39 registered]
```

###### Epochs (67–79)
```
┌───────┬──────────┬──────────┬──────────┐
│ Epoch │  Start   │  Finish  │ Duration │
├───────┼──────────┼──────────┼──────────┤
│ 67    │ 01:36:23 │ 01:36:41 │ 18s      │
├───────┼──────────┼──────────┼──────────┤
│ 68    │ 01:38:00 │ 01:38:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 69    │ 01:40:00 │ 01:40:03 │ 3s       │
├───────┼──────────┼──────────┼──────────┤
│ 70    │ 01:42:00 │ 01:42:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 71    │ 01:44:00 │ 01:44:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 72    │ 01:46:00 │ 01:46:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 73    │ 01:48:00 │ 01:48:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 74    │ 01:50:00 │ 01:50:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 75    │ 01:52:00 │ 01:52:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 76    │ 01:54:00 │ 01:54:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 77    │ 01:56:00 │ 01:56:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 78    │ 01:58:00 │ 01:58:02 │ 2s       │
├───────┼──────────┼──────────┼──────────┤
│ 79    │ 02:00:00 │ 02:00:02 │ 2s       │
└───────┴──────────┴──────────┴──────────┘
```

- Run 5 — epochs 80–81

```
13305:26/08/08 02:02:59 ERROR TaskSchedulerImpl: Lost executor 1 on <IP_REDACTED>: The executor with id 1 was deleted by a user or the framework.
...
13352:26/08/08 02:03:06 ERROR TaskSchedulerImpl: Lost executor 10 on <IP_REDACTED>: The executor with id 10 was deleted by a user or the framework.
13359-13373: [replacement executors 44,42,41,43 registered]
```

###### Epochs (80–81)

```
┌───────┬──────────┬──────────┬──────────┐
│ Epoch │  Start   │  Finish  │ Duration │
├───────┼──────────┼──────────┼──────────┤
│ 80    │ 02:00:53 │ 02:01:03 │ 10s      │
├───────┼──────────┼──────────┼──────────┤
│ 81    │ 02:02:00 │ 02:02:02 │ 2s       │
└───────┴──────────┴──────────┴──────────┘
```

(executors lost at 02:02:57, right after epoch 81 committed — this was the 5th and final allowed restart)

- Run 6 (final — no restarts left) — epochs 82–85, then permanent failure

```
14965:26/08/08 02:09:12 ERROR TaskSchedulerImpl: Lost executor 33 on <IP_REDACTED>: The executor with id 33 was deleted by a user or the framework.
...
15033:26/08/08 02:09:19 ERROR TaskSchedulerImpl: Lost executor 38 on <IP_REDACTED>: The executor with id 38 was deleted by a user or the framework.
15040-15069: [replacement executors 47,46,48,50,49,51,52 registered]
```

Failing (permanent — restart budget exhausted)


## Checklist
- [ ] Documentation update

## Reviewers
@yuli-han 
