### PR TITLE
Chronon Struct Data Support

### DIFF
--- a/online/src/main/java/ai/chronon/online/JavaFeatureRecord.java
+++ b/online/src/main/java/ai/chronon/online/JavaFeatureRecord.java
@@ -1,0 +1,187 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online;
+
+import ai.chronon.online.serde.FeatureRecord;
+import scala.util.ScalaVersionSpecificCollectionsConverter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Java-friendly view of a Scala {@link FeatureRecord}. Fields are accessed by name at every
+ * level of nesting instead of by position: struct-typed fields resolve to nested
+ * JavaFeatureRecords, and lists of structs resolve to {@code List<JavaFeatureRecord>}.
+ *
+ * <p>{@code values} carries everything the underlying fetcher response carried, including the
+ * {@code <name>_exception} keys the fetcher uses to report partial failures (see {@link #errors}).
+ */
+public class JavaFeatureRecord {
+    private static final String EXCEPTION_SUFFIX = "_exception";
+
+    public final Map<String, Object> values;
+
+    public JavaFeatureRecord(FeatureRecord scalaRecord) {
+        this.values = scalaRecord == null ? null : convertValues(scalaRecord);
+    }
+
+    private static Map<String, Object> convertValues(FeatureRecord scalaRecord) {
+        Map<String, Object> scalaAsJavaMap =
+                ScalaVersionSpecificCollectionsConverter.convertScalaMapToJava(scalaRecord.values());
+        Map<String, Object> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : scalaAsJavaMap.entrySet()) {
+            result.put(entry.getKey(), convertValue(entry.getValue()));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object convertValue(Object value) {
+        if (value instanceof FeatureRecord) {
+            return new JavaFeatureRecord((FeatureRecord) value);
+        } else if (value instanceof scala.collection.immutable.List) {
+            List<Object> scalaAsJavaList = ScalaVersionSpecificCollectionsConverter
+                    .convertScalaListToJava((scala.collection.immutable.List<Object>) value);
+            List<Object> converted = new ArrayList<>(scalaAsJavaList.size());
+            for (Object item : scalaAsJavaList) {
+                converted.add(convertValue(item));
+            }
+            return converted;
+        } else if (value instanceof scala.collection.Map) {
+            Map<Object, Object> scalaAsJavaMap = ScalaVersionSpecificCollectionsConverter
+                    .convertScalaMapToJava((scala.collection.immutable.Map<Object, Object>) value);
+            Map<Object, Object> converted = new HashMap<>();
+            for (Map.Entry<Object, Object> entry : scalaAsJavaMap.entrySet()) {
+                converted.put(entry.getKey(), convertValue(entry.getValue()));
+            }
+            return converted;
+        } else {
+            return value;
+        }
+    }
+
+    private Number asNumber(String field) {
+        Object value = values.get(field);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Number)) {
+            throw new IllegalArgumentException(
+                    "Field '" + field + "' holds a " + value.getClass().getName() + ", which is not numeric");
+        }
+        return (Number) value;
+    }
+
+    public String getString(String field) {
+        Object value = values.get(field);
+        if (value == null) {
+            return null;
+        }
+        return value instanceof String ? (String) value : value.toString();
+    }
+
+    public Optional<String> getStringOpt(String field) {
+        return Optional.ofNullable(getString(field));
+    }
+
+    // Numeric getters widen through Number so that, for example, an IntType field can be read as a
+    // Long. Chronon and consumer-side types (notably Thrift i64) do not always line up exactly.
+    public Long getLong(String field) {
+        Number n = asNumber(field);
+        return n == null ? null : n.longValue();
+    }
+
+    public Optional<Long> getLongOpt(String field) {
+        return Optional.ofNullable(getLong(field));
+    }
+
+    public Integer getInt(String field) {
+        Number n = asNumber(field);
+        return n == null ? null : n.intValue();
+    }
+
+    public Optional<Integer> getIntOpt(String field) {
+        return Optional.ofNullable(getInt(field));
+    }
+
+    public Double getDouble(String field) {
+        Number n = asNumber(field);
+        return n == null ? null : n.doubleValue();
+    }
+
+    public Optional<Double> getDoubleOpt(String field) {
+        return Optional.ofNullable(getDouble(field));
+    }
+
+    public Boolean getBoolean(String field) {
+        return (Boolean) values.get(field);
+    }
+
+    public Optional<Boolean> getBooleanOpt(String field) {
+        return Optional.ofNullable(getBoolean(field));
+    }
+
+    public JavaFeatureRecord getStruct(String field) {
+        return (JavaFeatureRecord) values.get(field);
+    }
+
+    public Optional<JavaFeatureRecord> getStructOpt(String field) {
+        return Optional.ofNullable(getStruct(field));
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<JavaFeatureRecord> getStructList(String field) {
+        return (List<JavaFeatureRecord>) values.get(field);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> List<T> getList(String field) {
+        return (List<T>) values.get(field);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> Map<String, V> getMap(String field) {
+        return (Map<String, V>) values.get(field);
+    }
+
+    /**
+     * The {@code <name>_exception} entries the fetcher uses to report per-groupBy,
+     * per-external-part, derivation and codec failures. These are not part of the declared value
+     * schema, so they are surfaced here rather than through the typed getters.
+     */
+    public Map<String, Object> errors() {
+        Map<String, Object> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : values.entrySet()) {
+            if (entry.getKey().endsWith(EXCEPTION_SUFFIX)) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    public boolean hasErrors() {
+        for (String key : values.keySet()) {
+            if (key.endsWith(EXCEPTION_SUFFIX)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -18,6 +18,7 @@ package ai.chronon.online;
 
 import ai.chronon.online.Fetcher.Request;
 import ai.chronon.online.Fetcher.Response;
+import ai.chronon.online.Fetcher.StructuredResponse;
 import ai.chronon.online.FutureConverters;
 
 import scala.Some;
@@ -156,6 +157,19 @@ public class JavaFetcher {
         });
     }
 
+    public static List<JavaStructuredResponse> toJavaStructuredResponses(Seq<StructuredResponse> responseSeq) {
+        List<JavaStructuredResponse> result = new ArrayList<>(responseSeq.size());
+        Iterator<StructuredResponse> it = responseSeq.iterator();
+        while (it.hasNext()) {
+            result.add(new JavaStructuredResponse(it.next()));
+        }
+        return result;
+    }
+
+    private CompletableFuture<List<JavaStructuredResponse>> convertStructuredResponses(Future<Seq<StructuredResponse>> responses) {
+        return FutureConverters.toJava(responses).toCompletableFuture().thenApply(JavaFetcher::toJavaStructuredResponses);
+    }
+
     public static List<JavaStatsResponse> toJavaStatsResponses(Seq<Fetcher.StatsResponse> responseSeq) {
         List<JavaStatsResponse> result = new ArrayList<>(responseSeq.size());
         Iterator<Fetcher.StatsResponse> it = responseSeq.iterator();
@@ -209,6 +223,34 @@ public class JavaFetcher {
         Future<FetcherResponseWithTs> scalaResponses = this.fetcher.withTs(this.fetcher.fetchJoin(scalaRequests, Option.empty()));
         // Convert responses to CompletableFuture
         return convertResponsesWithTs(scalaResponses, false, startTs);
+    }
+
+    /**
+     * Like {@link #fetchGroupBys}, but names struct-typed values (and lists of structs) at every
+     * nesting level instead of returning them as bare positional arrays.
+     */
+    public CompletableFuture<List<JavaStructuredResponse>> fetchGroupBysStructured(List<JavaRequest> requests) {
+        long startTs = System.currentTimeMillis();
+        // Convert java requests to scala requests
+        Seq<Request> scalaRequests = convertJavaRequestList(requests, true, startTs);
+        // Get responses from the fetcher
+        Future<Seq<StructuredResponse>> scalaResponses = this.fetcher.fetchGroupByStructured(scalaRequests);
+        // Convert responses to CompletableFuture
+        return convertStructuredResponses(scalaResponses);
+    }
+
+    /**
+     * Like {@link #fetchJoin}, but names struct-typed values (and lists of structs) at every
+     * nesting level instead of returning them as bare positional arrays.
+     */
+    public CompletableFuture<List<JavaStructuredResponse>> fetchJoinStructured(List<JavaRequest> requests) {
+        long startTs = System.currentTimeMillis();
+        // Convert java requests to scala requests
+        Seq<Request> scalaRequests = convertJavaRequestList(requests, false, startTs);
+        // Get responses from the fetcher
+        Future<Seq<StructuredResponse>> scalaResponses = this.fetcher.fetchJoinStructured(scalaRequests, Option.empty());
+        // Convert responses to CompletableFuture
+        return convertStructuredResponses(scalaResponses);
     }
 
     public List<CompletableFuture<List<JavaResponse>>> fetchJoinChunked(List<JavaRequest> requests, int chunkSizeOverride) {

--- a/online/src/main/java/ai/chronon/online/JavaStructuredResponse.java
+++ b/online/src/main/java/ai/chronon/online/JavaStructuredResponse.java
@@ -1,0 +1,34 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online;
+
+public class JavaStructuredResponse {
+    public JavaRequest request;
+    public JTry<JavaFeatureRecord> values;
+
+    public JavaStructuredResponse(JavaRequest request, JTry<JavaFeatureRecord> values) {
+        this.request = request;
+        this.values = values;
+    }
+
+    public JavaStructuredResponse(Fetcher.StructuredResponse scalaResponse) {
+        this.request = new JavaRequest(scalaResponse.request());
+        this.values = JTry
+                .fromScala(scalaResponse.values())
+                .map(v -> v == null ? null : new JavaFeatureRecord(v));
+    }
+}

--- a/online/src/main/scala/ai/chronon/online/Fetcher.scala
+++ b/online/src/main/scala/ai/chronon/online/Fetcher.scala
@@ -33,7 +33,7 @@ import ai.chronon.online.DerivationUtils.{applyDeriveFunc, buildDerivedFields}
 import ai.chronon.online.Fetcher._
 import ai.chronon.online.KVStore.GetRequest
 import ai.chronon.online.Metrics.Environment
-import ai.chronon.online.serde.{AvroCodec, AvroConversions}
+import ai.chronon.online.serde.{AvroCodec, AvroConversions, FeatureRecord}
 import com.google.gson.Gson
 import com.timgroup.statsd.Event
 import com.timgroup.statsd.Event.AlertType
@@ -59,6 +59,7 @@ object Fetcher {
   case class StatsResponse(request: StatsRequest, values: Try[Map[String, AnyRef]], millis: Long)
   case class SeriesStatsResponse(request: StatsRequest, values: Try[Map[String, AnyRef]])
   case class Response(request: Request, values: Try[Map[String, AnyRef]])
+  case class StructuredResponse(request: Request, values: Try[FeatureRecord])
   case class ResponseWithContext(request: Request,
                                  ctx: Metrics.Context,
                                  requestStartTs: Long,
@@ -260,6 +261,33 @@ class Fetcher(val kvStore: KVStore,
     val batchFutures: Seq[Future[Seq[Response]]] =
       batches.map(batch => doFetchJoin(batch, joinConf))
     batchFutures
+  }
+
+  /** Like `fetchJoin`, but names struct-typed values (and lists of structs) at every nesting
+    * level instead of returning them as bare positional arrays. This is purely an alternative
+    * view of the values `fetchJoin` already returns, resolved against the same
+    * `JoinCodec.valueSchema`.
+    *
+    * That schema spans base, derived and model-transform fields while any single response holds
+    * only one of those sets, so `FeatureRecord` narrows it to the fields actually present.
+    */
+  def fetchJoinStructured(requests: scala.collection.Seq[Request],
+                          joinConf: Option[Join] = None): Future[scala.collection.Seq[StructuredResponse]] = {
+    // Resolved at most once per call rather than once per response: building a join codec walks
+    // every join part's serving info.
+    lazy val localSchema: Try[StructType] = Try(buildJoinCodec(joinConf.get, refreshOnFail = false)._1.valueSchema)
+    fetchJoin(requests, joinConf).map { responses =>
+      responses.map { response =>
+        val schemaTry: Try[StructType] =
+          if (joinConf.isDefined) localSchema
+          else getJoinCodecs(response.request.name).map(_._1.valueSchema)
+        val featureRecordTry: Try[FeatureRecord] = for {
+          schema <- schemaTry
+          values <- response.values
+        } yield FeatureRecord.fromValueMap(schema, values)
+        StructuredResponse(response.request, featureRecordTry)
+      }
+    }
   }
 
   def fetchBaseJoin(requests: scala.collection.Seq[Request],

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -22,12 +22,12 @@ import ai.chronon.aggregator.windowing.{FinalBatchIr, SawtoothOnlineAggregator, 
 import ai.chronon.api.Constants.ChrononMetadataKey
 import ai.chronon.api.Extensions.{GroupByOps, JoinOps, MetadataOps, ThrowableOps, WindowOps}
 import ai.chronon.api._
-import ai.chronon.online.Fetcher.{ColumnSpec, PrefixedRequest, Request, Response}
+import ai.chronon.online.Fetcher.{ColumnSpec, PrefixedRequest, Request, Response, StructuredResponse}
 import ai.chronon.online.FetcherCache.{BatchResponses, CachedBatchResponse, KvStoreBatchResponse}
 import ai.chronon.online.KVStore.{GetRequest, GetResponse, TimedValue}
 import ai.chronon.online.Metrics.Name
 import ai.chronon.online.DerivationUtils.{applyDeriveFunc, buildRenameOnlyDerivationFunction}
-import ai.chronon.online.serde.AvroConversions
+import ai.chronon.online.serde.{AvroConversions, FeatureRecord}
 import com.google.gson.Gson
 
 import java.util
@@ -562,6 +562,24 @@ class FetcherBase(kvStore: KVStore,
         }.toList
         responses
       }
+  }
+
+  /** Like `fetchGroupBys`, but names struct-typed values (and lists of structs) at every nesting
+    * level instead of returning them as bare positional arrays. Resolves the same value schema
+    * that the classic map response is already shaped by - derivations included - so this is
+    * purely an alternative view of the same values.
+    */
+  def fetchGroupByStructured(
+      requests: scala.collection.Seq[Request]): Future[scala.collection.Seq[StructuredResponse]] = {
+    fetchGroupBys(requests).map { responses =>
+      responses.map { response =>
+        val featureRecordTry: Try[FeatureRecord] = for {
+          servingInfo <- getGroupByServingInfo(response.request.name)
+          values <- response.values
+        } yield FeatureRecord.fromValueMap(servingInfo.responseChrononSchema, values)
+        StructuredResponse(response.request, featureRecordTry)
+      }
+    }
   }
 
   /**

--- a/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
+++ b/online/src/main/scala/ai/chronon/online/GroupByServingInfoParsed.scala
@@ -52,13 +52,24 @@ class GroupByServingInfoParsed(val groupByServingInfo: GroupByServingInfo, parti
     StructType.from(s"${groupBy.metaData.cleanName}_IR", aggregator.batchIrSchema)
 
   @transient lazy val deriveFunc: DerivationFunc = {
-    val keySchema = keyCodec.chrononSchema.asInstanceOf[StructType]
-    val baseValueSchema = if (groupBy.aggregations == null) {
-      selectedChrononSchema
-    } else {
-      outputChrononSchema
-    }
-    buildDerivationFunction(groupBy.derivationsScala, keySchema, baseValueSchema)
+    buildDerivationFunction(groupBy.derivationsScala, keyChrononSchema, baseValueChrononSchema)
+  }
+
+  @transient lazy val baseValueChrononSchema: StructType = if (groupBy.aggregations == null) {
+    selectedChrononSchema
+  } else {
+    outputChrononSchema
+  }
+
+  /** Schema of the value map returned by `FetcherBase.fetchGroupBys`: the derived schema when the
+    * groupBy declares derivations, otherwise the base value schema. Cached because resolving
+    * derived fields can involve Catalyst, which is far too expensive to redo per request.
+    */
+  @transient lazy val responseChrononSchema: StructType = if (groupBy.hasDerivations) {
+    val derivedFields = buildDerivedFields(groupBy.derivationsScala, keyChrononSchema, baseValueChrononSchema)
+    StructType(s"${groupBy.metaData.cleanName}_RESPONSE", derivedFields.toArray)
+  } else {
+    baseValueChrononSchema
   }
 
   def keyCodec: AvroCodec = AvroCodec.of(keyAvroSchema)

--- a/online/src/main/scala/ai/chronon/online/serde/AvroCodec.scala
+++ b/online/src/main/scala/ai/chronon/online/serde/AvroCodec.scala
@@ -16,7 +16,7 @@
 
 package ai.chronon.online.serde
 
-import ai.chronon.api.{DataType, Row}
+import ai.chronon.api.{DataType, Row, StructType}
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
 import org.apache.avro.file.SeekableByteArrayInput
@@ -108,6 +108,15 @@ class AvroCodec(val schemaStr: String) extends Serializable {
       .toChrononRow(decode(bytes), chrononSchema)
       .asInstanceOf[Array[Any]]
     fieldNames.iterator.zip(output.iterator.map(_.asInstanceOf[AnyRef])).toMap
+  }
+
+  /** Like `decodeMap`, but names fields at every nesting level instead of just the top level, so
+    * struct-typed values (and lists of structs) come back as [[FeatureRecord]]s rather than bare
+    * positional arrays.
+    */
+  def decodeStructured(bytes: Array[Byte]): FeatureRecord = {
+    if (bytes == null) return null
+    FeatureRecord.fromValueMap(chrononSchema.asInstanceOf[StructType], decodeMap(bytes))
   }
 }
 

--- a/online/src/main/scala/ai/chronon/online/serde/FeatureRecord.scala
+++ b/online/src/main/scala/ai/chronon/online/serde/FeatureRecord.scala
@@ -41,8 +41,7 @@ case class FeatureRecord(schema: StructType, values: Map[String, Any]) {
     value match {
       case n: Number => n
       case other =>
-        throw new IllegalArgumentException(
-          s"Field '$field' holds a ${other.getClass.getName}, which is not numeric")
+        throw new IllegalArgumentException(s"Field '$field' holds a ${other.getClass.getName}, which is not numeric")
     }
 
   private def asString(value: Any): String =

--- a/online/src/main/scala/ai/chronon/online/serde/FeatureRecord.scala
+++ b/online/src/main/scala/ai/chronon/online/serde/FeatureRecord.scala
@@ -1,0 +1,171 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online.serde
+
+import ai.chronon.api.{DataType, ListType, MapType, StructType}
+
+import java.util
+import scala.util.ScalaJavaConversions.{ListOps, MapOps}
+
+/** A named, nested view of a Chronon feature value.
+  *
+  * Unlike the classic `Map[String, AnyRef]` fetcher response, where struct-typed values are
+  * positional `Array[Any]` and the field names live only in the schema, every level of a
+  * FeatureRecord is keyed by field name. Struct-typed fields resolve to nested FeatureRecords and
+  * lists of structs resolve to `List[FeatureRecord]`, so callers can navigate arbitrarily deep
+  * nesting by name instead of by position.
+  *
+  * `values` carries everything the underlying fetcher response carried, including the
+  * `<name>_exception` keys the fetcher uses to report partial failures (see [[errors]]).
+  * `schema` is narrowed to the declared fields actually present in `values`.
+  */
+case class FeatureRecord(schema: StructType, values: Map[String, Any]) {
+
+  private def opt(field: String): Option[Any] = values.get(field).flatMap(Option(_))
+
+  private def asNumber(value: Any, field: String): Number =
+    value match {
+      case n: Number => n
+      case other =>
+        throw new IllegalArgumentException(
+          s"Field '$field' holds a ${other.getClass.getName}, which is not numeric")
+    }
+
+  private def asString(value: Any): String =
+    value match {
+      // Utf8 and friends implement CharSequence; avro string values are normally already
+      // converted to String by AvroConversions.toChrononRow, but derived values may not be.
+      case s: String       => s
+      case c: CharSequence => c.toString
+      case other           => other.toString
+    }
+
+  def getString(field: String): String = asString(values(field))
+  def getStringOpt(field: String): Option[String] = opt(field).map(asString)
+
+  // Numeric getters widen through Number so that, for example, an IntType field can be read as a
+  // Long. Chronon and consumer-side types (notably Thrift i64) do not always line up exactly.
+  def getLong(field: String): Long = asNumber(values(field), field).longValue()
+  def getLongOpt(field: String): Option[Long] = opt(field).map(asNumber(_, field).longValue())
+
+  def getInt(field: String): Int = asNumber(values(field), field).intValue()
+  def getIntOpt(field: String): Option[Int] = opt(field).map(asNumber(_, field).intValue())
+
+  def getDouble(field: String): Double = asNumber(values(field), field).doubleValue()
+  def getDoubleOpt(field: String): Option[Double] = opt(field).map(asNumber(_, field).doubleValue())
+
+  def getBoolean(field: String): Boolean = values(field).asInstanceOf[Boolean]
+  def getBooleanOpt(field: String): Option[Boolean] = opt(field).map(_.asInstanceOf[Boolean])
+
+  def getStruct(field: String): FeatureRecord = values(field).asInstanceOf[FeatureRecord]
+  def getStructOpt(field: String): Option[FeatureRecord] = opt(field).map(_.asInstanceOf[FeatureRecord])
+
+  def getStructList(field: String): List[FeatureRecord] = values(field).asInstanceOf[List[FeatureRecord]]
+
+  def getList[T](field: String): List[T] = values(field).asInstanceOf[List[T]]
+
+  def getMap[V](field: String): Map[String, V] = values(field).asInstanceOf[Map[String, V]]
+
+  /** The `<name>_exception` entries the fetcher uses to report per-groupBy, per-external-part,
+    * derivation and codec failures. These are not part of the declared value schema, so they are
+    * surfaced here rather than through the typed getters.
+    */
+  def errors: Map[String, Any] = values.filter(_._1.endsWith("_exception"))
+
+  def hasErrors: Boolean = values.keysIterator.exists(_.endsWith("_exception"))
+}
+
+object FeatureRecord {
+
+  /** Build a FeatureRecord out of a flat fetcher response map (e.g. the output of
+    * `FetcherBase.fetchGroupBys` / `Fetcher.fetchJoin`) plus the StructType describing it.
+    *
+    * The top level of `values` is already keyed by field name; this walks it alongside `schema`
+    * and recursively attaches names to any nested struct-typed values, which otherwise arrive as
+    * bare positional `Array[Any]` (see `AvroConversions.toChrononRow`).
+    *
+    * Entries with no matching schema field are passed through untouched rather than dropped, so
+    * the fetcher's `<name>_exception` keys survive into the structured response.
+    */
+  def fromValueMap(schema: StructType, values: Map[String, Any]): FeatureRecord = {
+    if (values == null) return null
+    val declaredTypes: Map[String, DataType] = schema.fields.iterator.map(f => f.name -> f.fieldType).toMap
+    val named = values.map {
+      case (name, value) =>
+        name -> declaredTypes.get(name).map(attachNames(value, _)).getOrElse(value)
+    }
+    // Narrow the schema to what the response actually carried. The join value schema in
+    // particular is a superset: it spans base and derived (and model) fields, while a given
+    // response holds only one of those sets.
+    val presentFields = schema.fields.filter(f => values.contains(f.name))
+    FeatureRecord(StructType(schema.name, presentFields), named)
+  }
+
+  private def attachNames(value: Any, dataType: DataType): Any = {
+    if (value == null) return null
+    dataType match {
+      case _ if value.isInstanceOf[FeatureRecord] => value
+
+      case st: StructType => namedStruct(value, st)
+
+      case ListType(elemType) =>
+        elementsOf(value).map(elem => attachNames(elem, elemType)).toList
+
+      case MapType(_, valueType) =>
+        value match {
+          case m: util.Map[_, _] =>
+            m.asInstanceOf[util.Map[Any, Any]].toScala.map { case (k, v) => k -> attachNames(v, valueType) }.toMap
+          case m: Map[_, _] =>
+            m.asInstanceOf[Map[Any, Any]].map { case (k, v) => k -> attachNames(v, valueType) }
+          case other =>
+            throw new IllegalArgumentException(s"Expected a map value, but got ${other.getClass.getName}")
+        }
+
+      case _ => value
+    }
+  }
+
+  private def namedStruct(value: Any, st: StructType): FeatureRecord =
+    value match {
+      // The common case: avro-decoded structs are positional, in schema-declared field order.
+      case arr: Array[_] =>
+        val named = st.fields.iterator.zipWithIndex
+          .filter { case (_, idx) => idx < arr.length }
+          .map { case (field, idx) => field.name -> attachNames(arr(idx), field.fieldType) }
+          .toMap
+        FeatureRecord(st, named)
+      // Struct values can also arrive keyed by field name, e.g. nested rows surfaced through the
+      // Spark SQL transforms used to evaluate derivations. Row.to handles the same two shapes.
+      case m: Map[_, _] =>
+        fromValueMap(st, m.asInstanceOf[Map[String, Any]])
+      case m: util.Map[_, _] =>
+        fromValueMap(st, m.asInstanceOf[util.Map[String, Any]].toScala)
+      case other =>
+        throw new IllegalArgumentException(
+          s"Expected a positional array or a field-keyed map for struct '${st.name}', " +
+            s"but got ${other.getClass.getName}")
+    }
+
+  private def elementsOf(value: Any): Iterator[Any] =
+    value match {
+      case list: util.List[_]           => list.asInstanceOf[util.List[Any]].toScala.iterator
+      case seq: scala.collection.Seq[_] => seq.iterator
+      case arr: Array[_]                => arr.iterator
+      case other =>
+        throw new IllegalArgumentException(s"Expected a list value, but got ${other.getClass.getName}")
+    }
+}

--- a/online/src/test/scala/ai/chronon/online/FetcherStructuredTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherStructuredTest.scala
@@ -69,9 +69,10 @@ class FetcherStructuredTest extends MockitoSugar with MockitoHelper {
   private def groupByFetcher(schema: StructType, values: Try[Map[String, AnyRef]]): FetcherBase =
     new FetcherBase(kvStore) {
       override lazy val getGroupByServingInfo: TTLCache[String, Try[GroupByServingInfoParsed]] =
-        new TTLCache[String, Try[GroupByServingInfoParsed]](
-          { _: String => Success(servingInfoWith(schema)) },
-          { name: String => Metrics.Context(environment = "test", groupBy = name) })
+        new TTLCache[String, Try[GroupByServingInfoParsed]]({ _: String => Success(servingInfoWith(schema)) },
+                                                            { name: String =>
+                                                              Metrics.Context(environment = "test", groupBy = name)
+                                                            })
 
       override def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] =
         Future.successful(requests.map(r => Response(r, values)))
@@ -97,8 +98,7 @@ class FetcherStructuredTest extends MockitoSugar with MockitoHelper {
 
   @Test
   def fetchGroupByStructuredNamesNestedStructs(): Unit = {
-    val schema = StructType("GbValue",
-                            Array(StructField("count", LongType), StructField("insight", insightSchema)))
+    val schema = StructType("GbValue", Array(StructField("count", LongType), StructField("insight", insightSchema)))
     val values: Map[String, AnyRef] =
       Map("count" -> Long.box(7L), "insight" -> positionalInsight("looks good", Seq("clean", "quiet")))
 
@@ -187,8 +187,8 @@ class FetcherStructuredTest extends MockitoSugar with MockitoHelper {
   def fetchJoinStructuredNarrowsSupersetSchema(): Unit = {
     // JoinCodec.valueSchema spans base and derived fields while a response holds only one set;
     // the record's schema should describe what is actually there.
-    val schema = StructType("JoinValue",
-                            Array(StructField("base_count", LongType), StructField("derived_count", LongType)))
+    val schema =
+      StructType("JoinValue", Array(StructField("base_count", LongType), StructField("derived_count", LongType)))
     val fetcher = joinFetcher(schema, Success(Map("derived_count" -> Long.box(9L))))
 
     val record =

--- a/online/src/test/scala/ai/chronon/online/FetcherStructuredTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherStructuredTest.scala
@@ -1,0 +1,212 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online
+
+import ai.chronon.api._
+import ai.chronon.online.Fetcher.{Request, Response, StructuredResponse}
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.{Before, Test}
+import org.mockito.Answers
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.util
+import scala.collection.Seq
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Success, Try}
+
+/**
+  * Covers the structured fetch entry points. Both wrap the classic map-returning fetch and re-key
+  * struct-typed values by name, so these tests stub the underlying fetch and the schema lookup and
+  * assert on the shape of the resulting FeatureRecord.
+  */
+class FetcherStructuredTest extends MockitoSugar with MockitoHelper {
+
+  private val GroupByName = "unit_test.listing_signals"
+  private val JoinName = "unit_test/listing_join"
+
+  private val contentSchema =
+    StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
+  private val insightSchema =
+    StructType("Insight", Array(StructField("summary", StringType), StructField("contents", ListType(contentSchema))))
+
+  private var kvStore: KVStore = _
+
+  @Before
+  def setup(): Unit = {
+    kvStore = mock[KVStore](Answers.RETURNS_DEEP_STUBS)
+    when(kvStore.executionContext).thenReturn(ExecutionContext.global)
+  }
+
+  // A nested struct value in the positional shape AvroConversions.toChrononRow produces.
+  private def positionalInsight(summary: String, texts: Seq[String]): Array[Any] = {
+    val contents = new util.ArrayList[Any]()
+    texts.foreach(t => contents.add(Array[Any]("HIGHLIGHT", t)))
+    Array[Any](summary, contents)
+  }
+
+  private def servingInfoWith(schema: StructType): GroupByServingInfoParsed = {
+    val servingInfo = mock[GroupByServingInfoParsed]
+    when(servingInfo.responseChrononSchema).thenReturn(schema)
+    servingInfo
+  }
+
+  private def groupByFetcher(schema: StructType, values: Try[Map[String, AnyRef]]): FetcherBase =
+    new FetcherBase(kvStore) {
+      override lazy val getGroupByServingInfo: TTLCache[String, Try[GroupByServingInfoParsed]] =
+        new TTLCache[String, Try[GroupByServingInfoParsed]](
+          { _: String => Success(servingInfoWith(schema)) },
+          { name: String => Metrics.Context(environment = "test", groupBy = name) })
+
+      override def fetchGroupBys(requests: Seq[Request]): Future[Seq[Response]] =
+        Future.successful(requests.map(r => Response(r, values)))
+    }
+
+  private def joinFetcher(schema: StructType, values: Try[Map[String, AnyRef]]): Fetcher =
+    new Fetcher(kvStore = kvStore, metaDataSet = "test_metadata") {
+      override lazy val getJoinCodecs: TTLCache[String, Try[(JoinCodec, Boolean)]] =
+        new TTLCache[String, Try[(JoinCodec, Boolean)]](
+          { _: String =>
+            val codec = mock[JoinCodec]
+            when(codec.valueSchema).thenReturn(schema)
+            Success((codec, false))
+          },
+          { name: String => Metrics.Context(environment = "test", join = name) }
+        )
+
+      override def fetchJoin(requests: Seq[Request], joinConf: Option[Join] = None): Future[Seq[Response]] =
+        Future.successful(requests.map(r => Response(r, values)))
+    }
+
+  private def await[T](f: Future[T]): T = Await.result(f, 5.seconds)
+
+  @Test
+  def fetchGroupByStructuredNamesNestedStructs(): Unit = {
+    val schema = StructType("GbValue",
+                            Array(StructField("count", LongType), StructField("insight", insightSchema)))
+    val values: Map[String, AnyRef] =
+      Map("count" -> Long.box(7L), "insight" -> positionalInsight("looks good", Seq("clean", "quiet")))
+
+    val fetcher = groupByFetcher(schema, Success(values))
+    val responses = await(fetcher.fetchGroupByStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
+
+    assertEquals(1, responses.size)
+    val record = responses.head.values.get
+    assertEquals(7L, record.getLong("count"))
+
+    val insight = record.getStruct("insight")
+    assertEquals("looks good", insight.getString("summary"))
+    val contents = insight.getStructList("contents")
+    assertEquals(2, contents.size)
+    assertEquals("clean", contents.head.getString("text"))
+    assertEquals("quiet", contents(1).getString("text"))
+  }
+
+  @Test
+  def fetchGroupByStructuredPreservesRequests(): Unit = {
+    val schema = StructType("GbValue", Array(StructField("count", LongType)))
+    val fetcher = groupByFetcher(schema, Success(Map("count" -> Long.box(1L))))
+    val request = Request(GroupByName, Map("listing" -> Long.box(42L)))
+
+    val responses = await(fetcher.fetchGroupByStructured(Seq(request)))
+    assertEquals(request, responses.head.request)
+  }
+
+  @Test
+  def fetchGroupByStructuredSurfacesFetchFailure(): Unit = {
+    val schema = StructType("GbValue", Array(StructField("count", LongType)))
+    val boom = new RuntimeException("kv store exploded")
+    val fetcher = groupByFetcher(schema, scala.util.Failure(boom))
+
+    val responses = await(fetcher.fetchGroupByStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
+    assertTrue(responses.head.values.isFailure)
+    assertEquals(boom, responses.head.values.failed.get)
+  }
+
+  @Test
+  def fetchGroupByStructuredHandlesNullValueMap(): Unit = {
+    // fetchGroupBys returns a null value map when the key is absent from the KV store.
+    val schema = StructType("GbValue", Array(StructField("count", LongType)))
+    val fetcher = groupByFetcher(schema, Success(null))
+
+    val responses = await(fetcher.fetchGroupByStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
+    assertEquals(null, responses.head.values.get)
+  }
+
+  @Test
+  def fetchJoinStructuredNamesNestedStructs(): Unit = {
+    val schema = StructType(
+      "JoinValue",
+      Array(StructField("gb_count", LongType), StructField("gb_insight", insightSchema))
+    )
+    val values: Map[String, AnyRef] =
+      Map("gb_count" -> Long.box(3L), "gb_insight" -> positionalInsight("ok", Seq("spotless")))
+
+    val fetcher = joinFetcher(schema, Success(values))
+    val responses = await(fetcher.fetchJoinStructured(Seq(Request(JoinName, Map("listing" -> Long.box(1L))))))
+
+    assertEquals(1, responses.size)
+    val record = responses.head.values.get
+    assertEquals(3L, record.getLong("gb_count"))
+    assertEquals("spotless", record.getStruct("gb_insight").getStructList("contents").head.getString("text"))
+  }
+
+  @Test
+  def fetchJoinStructuredRetainsExceptionKeys(): Unit = {
+    // A join response can carry per-join-part failures alongside good values. Those keys are not
+    // in the value schema, so they must still be reachable from the structured response.
+    val schema = StructType("JoinValue", Array(StructField("gb_count", LongType)))
+    val values: Map[String, AnyRef] =
+      Map("gb_count" -> Long.box(3L), "some_part_exception" -> "part blew up")
+
+    val fetcher = joinFetcher(schema, Success(values))
+    val record =
+      await(fetcher.fetchJoinStructured(Seq(Request(JoinName, Map("listing" -> Long.box(1L)))))).head.values.get
+
+    assertEquals(3L, record.getLong("gb_count"))
+    assertTrue(record.hasErrors)
+    assertEquals("part blew up", record.errors("some_part_exception"))
+  }
+
+  @Test
+  def fetchJoinStructuredNarrowsSupersetSchema(): Unit = {
+    // JoinCodec.valueSchema spans base and derived fields while a response holds only one set;
+    // the record's schema should describe what is actually there.
+    val schema = StructType("JoinValue",
+                            Array(StructField("base_count", LongType), StructField("derived_count", LongType)))
+    val fetcher = joinFetcher(schema, Success(Map("derived_count" -> Long.box(9L))))
+
+    val record =
+      await(fetcher.fetchJoinStructured(Seq(Request(JoinName, Map("listing" -> Long.box(1L)))))).head.values.get
+
+    assertEquals(Seq("derived_count"), record.schema.fields.map(_.name).toSeq)
+    assertEquals(None, record.getLongOpt("base_count"))
+    assertEquals(Some(9L), record.getLongOpt("derived_count"))
+  }
+
+  @Test
+  def fetchJoinStructuredHandlesBatchOfRequests(): Unit = {
+    val schema = StructType("JoinValue", Array(StructField("gb_count", LongType)))
+    val fetcher = joinFetcher(schema, Success(Map("gb_count" -> Long.box(2L))))
+    val requests = (1 to 5).map(i => Request(JoinName, Map("listing" -> Long.box(i.toLong))))
+
+    val responses: Seq[StructuredResponse] = await(fetcher.fetchJoinStructured(requests))
+    assertEquals(5, responses.size)
+    responses.foreach(r => assertEquals(2L, r.values.get.getLong("gb_count")))
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/GroupByServingInfoParsedSchemaTest.scala
+++ b/online/src/test/scala/ai/chronon/online/GroupByServingInfoParsedSchemaTest.scala
@@ -1,0 +1,101 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online
+
+import ai.chronon.api.{Builders, GroupByServingInfo, PartitionSpec, StructType}
+import ai.chronon.online.serde.AvroConversions
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+
+/**
+  * Pins the schema accessors on GroupByServingInfoParsed.
+  *
+  * `deriveFunc` previously computed its two arguments inline. It now reads them from the
+  * `keyChrononSchema` and `baseValueChrononSchema` lazy vals so that `responseChrononSchema` can
+  * share them without recomputing Catalyst work per request. `deriveFunc` sits on the live
+  * `FetcherBase.fetchGroupBys` path, so these tests assert the refactor is value-preserving: if
+  * the inputs are identical, the derivation behavior is unchanged by construction.
+  */
+class GroupByServingInfoParsedSchemaTest {
+
+  private val keySchema = StructType.from("Key", Array("user" -> ai.chronon.api.StringType))
+  private val valueSchema = StructType.from(
+    "Value",
+    Array("amount_dollars_sum_15d" -> ai.chronon.api.LongType, "amount_dollars_sum_30d" -> ai.chronon.api.LongType)
+  )
+
+  private def servingInfo(derivations: Seq[ai.chronon.api.Derivation] = null): GroupByServingInfoParsed = {
+    val info = new GroupByServingInfo()
+    // aggregations left null: exercises the no-aggregation branch, where the base value schema is
+    // the selected schema rather than the aggregator output schema.
+    info.setGroupBy(
+      Builders.GroupBy(
+        metaData = Builders.MetaData(name = "unit_test.serving_info_schemas"),
+        keyColumns = Seq("user"),
+        derivations = derivations
+      ))
+    info.setKeyAvroSchema(AvroConversions.fromChrononSchema(keySchema).toString(true))
+    info.setSelectedAvroSchema(AvroConversions.fromChrononSchema(valueSchema).toString(true))
+    info.setBatchEndDate("2026-08-10")
+    new GroupByServingInfoParsed(info, PartitionSpec(format = "yyyy-MM-dd", spanMillis = 86400000L))
+  }
+
+  @Test
+  def keyChrononSchemaMatchesTheKeyCodecSchemaItReplaced(): Unit = {
+    // deriveFunc used to pass `keyCodec.chrononSchema.asInstanceOf[StructType]`; it now passes
+    // `keyChrononSchema`. Both reduce to toChrononSchema(parse(keyAvroSchema)).
+    val info = servingInfo()
+    assertEquals(info.keyCodec.chrononSchema.asInstanceOf[StructType], info.keyChrononSchema)
+  }
+
+  @Test
+  def baseValueChrononSchemaMatchesTheInlineExpressionItReplaced(): Unit = {
+    // deriveFunc used to compute this inline as
+    //   if (groupBy.aggregations == null) selectedChrononSchema else outputChrononSchema
+    val info = servingInfo()
+    assertTrue("test fixture should exercise the no-aggregation branch", info.groupBy.aggregations == null)
+    assertEquals(info.selectedChrononSchema, info.baseValueChrononSchema)
+  }
+
+  @Test
+  def responseSchemaIsTheBaseSchemaWithoutDerivations(): Unit = {
+    val info = servingInfo()
+    assertEquals(info.baseValueChrononSchema, info.responseChrononSchema)
+  }
+
+  @Test
+  def responseSchemaReflectsRenameOnlyDerivations(): Unit = {
+    // A rename-only derivation set avoids Catalyst, so this stays a pure schema assertion.
+    val info = servingInfo(
+      Seq(
+        Builders.Derivation(name = "sum_15d", expression = "amount_dollars_sum_15d"),
+        Builders.Derivation(name = "sum_30d", expression = "amount_dollars_sum_30d")
+      ))
+    val names = info.responseChrononSchema.fields.map(_.name).toSet
+    assertEquals(Set("sum_15d", "sum_30d"), names)
+  }
+
+  @Test
+  def schemaAccessorsAreStableAcrossCalls(): Unit = {
+    // They are lazy vals now rather than recomputed expressions; a second read must be identical
+    // (and, for responseChrononSchema, must not redo the derived-field resolution).
+    val info = servingInfo()
+    assertTrue(info.keyChrononSchema eq info.keyChrononSchema)
+    assertTrue(info.baseValueChrononSchema eq info.baseValueChrononSchema)
+    assertTrue(info.responseChrononSchema eq info.responseChrononSchema)
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/serde/AvroCodecStructuredTest.scala
+++ b/online/src/test/scala/ai/chronon/online/serde/AvroCodecStructuredTest.scala
@@ -28,18 +28,17 @@ class AvroCodecStructuredTest {
   // Mirrors the review_quality_insight_validation example from the structured-data design doc:
   // a struct field ("review_quality_insight_validation") containing a list of structs ("items"),
   // each of which contains a nested list of structs ("contents").
-  private val contentSchema = StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
-  private val itemSchema = StructType(
-    "Item",
-    Array(StructField("id_action", StringType),
-          StructField("id_source", StringType),
-          StructField("contents", ListType(contentSchema))))
+  private val contentSchema =
+    StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
+  private val itemSchema = StructType("Item",
+                                      Array(StructField("id_action", StringType),
+                                            StructField("id_source", StringType),
+                                            StructField("contents", ListType(contentSchema))))
   private val insightSchema = StructType("Insight", Array(StructField("items", ListType(itemSchema))))
-  private val rootSchema = StructType(
-    "Root",
-    Array(StructField("content_type", StringType),
-          StructField("id_review", LongType),
-          StructField("review_quality_insight_validation", insightSchema)))
+  private val rootSchema = StructType("Root",
+                                      Array(StructField("content_type", StringType),
+                                            StructField("id_review", LongType),
+                                            StructField("review_quality_insight_validation", insightSchema)))
 
   @Test
   def testDecodeStructuredNamesNestedStructsAndListsOfStructs(): Unit = {

--- a/online/src/test/scala/ai/chronon/online/serde/AvroCodecStructuredTest.scala
+++ b/online/src/test/scala/ai/chronon/online/serde/AvroCodecStructuredTest.scala
@@ -1,0 +1,97 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online.serde
+
+import ai.chronon.api._
+import org.apache.avro.generic.GenericData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import java.util
+
+class AvroCodecStructuredTest {
+
+  // Mirrors the review_quality_insight_validation example from the structured-data design doc:
+  // a struct field ("review_quality_insight_validation") containing a list of structs ("items"),
+  // each of which contains a nested list of structs ("contents").
+  private val contentSchema = StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
+  private val itemSchema = StructType(
+    "Item",
+    Array(StructField("id_action", StringType),
+          StructField("id_source", StringType),
+          StructField("contents", ListType(contentSchema))))
+  private val insightSchema = StructType("Insight", Array(StructField("items", ListType(itemSchema))))
+  private val rootSchema = StructType(
+    "Root",
+    Array(StructField("content_type", StringType),
+          StructField("id_review", LongType),
+          StructField("review_quality_insight_validation", insightSchema)))
+
+  @Test
+  def testDecodeStructuredNamesNestedStructsAndListsOfStructs(): Unit = {
+    val avroSchemaStr = AvroConversions.fromChrononSchema(rootSchema).toString(true)
+    val codec = new AvroCodec(avroSchemaStr)
+
+    val content1: Array[Any] = Array("HIGHLIGHT", "Great host")
+    val content2: Array[Any] = Array("HIGHLIGHT", "Spotless")
+    val contentsList = new util.ArrayList[Any]()
+    contentsList.add(content1)
+    contentsList.add(content2)
+
+    val item1: Array[Any] = Array("CLARIFY_CHECKIN_PROCESS", "review:12345", contentsList)
+    val itemsList = new util.ArrayList[Any]()
+    itemsList.add(item1)
+
+    val insight: Array[Any] = Array(itemsList)
+    val row: Array[Any] = Array("REVIEW_QUALITY", 12345L, insight)
+
+    val record =
+      AvroConversions.fromChrononRow(row, codec.chrononSchema, codec.schema).asInstanceOf[GenericData.Record]
+    val bytes = codec.encodeBinary(record)
+
+    // Sanity check: the classic decodeMap loses the nested field names - structs come back as
+    // bare positional arrays/lists.
+    val flat = codec.decodeMap(bytes)
+    assertEquals("REVIEW_QUALITY", flat("content_type"))
+    assertEquals(classOf[Array[Any]], flat("review_quality_insight_validation").getClass)
+
+    val featureRecord = codec.decodeStructured(bytes)
+    assertEquals("REVIEW_QUALITY", featureRecord.getString("content_type"))
+    assertEquals(12345L, featureRecord.getLong("id_review"))
+
+    val insightRecord = featureRecord.getStruct("review_quality_insight_validation")
+    val items = insightRecord.getStructList("items")
+    assertEquals(1, items.size)
+
+    val firstItem = items.head
+    assertEquals("CLARIFY_CHECKIN_PROCESS", firstItem.getString("id_action"))
+    assertEquals("review:12345", firstItem.getString("id_source"))
+
+    val contents = firstItem.getStructList("contents")
+    assertEquals(2, contents.size)
+    assertEquals("HIGHLIGHT", contents.head.getString("kind"))
+    assertEquals("Great host", contents.head.getString("text"))
+    assertEquals("Spotless", contents(1).getString("text"))
+  }
+
+  @Test
+  def testDecodeStructuredOfNullBytesIsNull(): Unit = {
+    val avroSchemaStr = AvroConversions.fromChrononSchema(rootSchema).toString(true)
+    val codec = new AvroCodec(avroSchemaStr)
+    assertEquals(null, codec.decodeStructured(null))
+  }
+}

--- a/online/src/test/scala/ai/chronon/online/serde/FeatureRecordTest.scala
+++ b/online/src/test/scala/ai/chronon/online/serde/FeatureRecordTest.scala
@@ -25,18 +25,17 @@ import java.util
 
 class FeatureRecordTest {
 
-  private val contentSchema = StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
-  private val itemSchema = StructType(
-    "Item",
-    Array(StructField("id_action", StringType),
-          StructField("id_source", StringType),
-          StructField("contents", ListType(contentSchema))))
+  private val contentSchema =
+    StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
+  private val itemSchema = StructType("Item",
+                                      Array(StructField("id_action", StringType),
+                                            StructField("id_source", StringType),
+                                            StructField("contents", ListType(contentSchema))))
   private val insightSchema = StructType("Insight", Array(StructField("items", ListType(itemSchema))))
-  private val rootSchema = StructType(
-    "Root",
-    Array(StructField("content_type", StringType),
-          StructField("id_review", LongType),
-          StructField("review_quality_insight_validation", insightSchema)))
+  private val rootSchema = StructType("Root",
+                                      Array(StructField("content_type", StringType),
+                                            StructField("id_review", LongType),
+                                            StructField("review_quality_insight_validation", insightSchema)))
 
   @Test
   def testFlatValuesPassThrough(): Unit = {
@@ -174,10 +173,11 @@ class FeatureRecordTest {
                                   StructField("l", LongType),
                                   StructField("f", FloatType),
                                   StructField("d", DoubleType)))
-    val record = FeatureRecord.fromValueMap(
-      schema,
-      Map("i" -> Integer.valueOf(5), "l" -> java.lang.Long.valueOf(6L), "f" -> java.lang.Float.valueOf(1.5f),
-        "d" -> java.lang.Double.valueOf(2.5d)))
+    val record = FeatureRecord.fromValueMap(schema,
+                                            Map("i" -> Integer.valueOf(5),
+                                                "l" -> java.lang.Long.valueOf(6L),
+                                                "f" -> java.lang.Float.valueOf(1.5f),
+                                                "d" -> java.lang.Double.valueOf(2.5d)))
 
     assertEquals(5L, record.getLong("i"))
     assertEquals(Some(5L), record.getLongOpt("i"))
@@ -204,9 +204,9 @@ class FeatureRecordTest {
     javaMapShape.put("kind", "HIGHLIGHT")
     javaMapShape.put("text", "Spotless")
 
-    val schema = StructType("Outer",
-                            Array(StructField("from_scala_map", contentSchema),
-                                  StructField("from_java_map", contentSchema)))
+    val schema = StructType(
+      "Outer",
+      Array(StructField("from_scala_map", contentSchema), StructField("from_java_map", contentSchema)))
     val record =
       FeatureRecord.fromValueMap(schema, Map("from_scala_map" -> scalaMapShape, "from_java_map" -> javaMapShape))
 

--- a/online/src/test/scala/ai/chronon/online/serde/FeatureRecordTest.scala
+++ b/online/src/test/scala/ai/chronon/online/serde/FeatureRecordTest.scala
@@ -1,0 +1,248 @@
+/*
+ *    Copyright (C) 2023 The Chronon Authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ai.chronon.online.serde
+
+import ai.chronon.api._
+import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue}
+import org.junit.Test
+import org.scalatest.Assertions.intercept
+
+import java.util
+
+class FeatureRecordTest {
+
+  private val contentSchema = StructType("Content", Array(StructField("kind", StringType), StructField("text", StringType)))
+  private val itemSchema = StructType(
+    "Item",
+    Array(StructField("id_action", StringType),
+          StructField("id_source", StringType),
+          StructField("contents", ListType(contentSchema))))
+  private val insightSchema = StructType("Insight", Array(StructField("items", ListType(itemSchema))))
+  private val rootSchema = StructType(
+    "Root",
+    Array(StructField("content_type", StringType),
+          StructField("id_review", LongType),
+          StructField("review_quality_insight_validation", insightSchema)))
+
+  @Test
+  def testFlatValuesPassThrough(): Unit = {
+    val schema = StructType("Flat", Array(StructField("a", StringType), StructField("b", LongType)))
+    val record = FeatureRecord.fromValueMap(schema, Map("a" -> "hello", "b" -> 5L))
+    assertEquals("hello", record.getString("a"))
+    assertEquals(5L, record.getLong("b"))
+  }
+
+  @Test
+  def testNestedStructAndListOfStructsAreNamedAtEveryLevel(): Unit = {
+    // Mirrors the shape produced by AvroConversions.toChrononRow: nested structs are positional
+    // Array[Any], lists are java.util.ArrayList[Any]. Only the top level arrives already keyed by
+    // name (as a fetcher response map would).
+    val content1: Array[Any] = Array("HIGHLIGHT", "Great host")
+    val content2: Array[Any] = Array("HIGHLIGHT", "Spotless")
+    val contentsList = new util.ArrayList[Any]()
+    contentsList.add(content1)
+    contentsList.add(content2)
+
+    val item1: Array[Any] = Array("CLARIFY_CHECKIN_PROCESS", "review:12345", contentsList)
+    val itemsList = new util.ArrayList[Any]()
+    itemsList.add(item1)
+
+    val insight: Array[Any] = Array(itemsList)
+
+    val valueMap: Map[String, Any] = Map(
+      "content_type" -> "REVIEW_QUALITY",
+      "id_review" -> 12345L,
+      "review_quality_insight_validation" -> insight
+    )
+
+    val record = FeatureRecord.fromValueMap(rootSchema, valueMap)
+
+    assertEquals("REVIEW_QUALITY", record.getString("content_type"))
+    assertEquals(12345L, record.getLong("id_review"))
+
+    val insightRecord = record.getStruct("review_quality_insight_validation")
+    val items = insightRecord.getStructList("items")
+    assertEquals(1, items.size)
+
+    val firstItem = items.head
+    assertEquals("CLARIFY_CHECKIN_PROCESS", firstItem.getString("id_action"))
+    assertEquals("review:12345", firstItem.getString("id_source"))
+
+    val contents = firstItem.getStructList("contents")
+    assertEquals(2, contents.size)
+    assertEquals("HIGHLIGHT", contents.head.getString("kind"))
+    assertEquals("Great host", contents.head.getString("text"))
+    assertEquals("Spotless", contents(1).getString("text"))
+  }
+
+  @Test
+  def testListOfPrimitivesIsNotWrapped(): Unit = {
+    val schema = StructType("WithList", Array(StructField("tags", ListType(StringType))))
+    val tagsList = new util.ArrayList[Any]()
+    tagsList.add("a")
+    tagsList.add("b")
+    val record = FeatureRecord.fromValueMap(schema, Map("tags" -> tagsList))
+    assertEquals(List("a", "b"), record.getList[String]("tags"))
+  }
+
+  @Test
+  def testMissingFieldIsOmitted(): Unit = {
+    val schema = StructType("Sparse", Array(StructField("a", StringType), StructField("b", StringType)))
+    val record = FeatureRecord.fromValueMap(schema, Map("a" -> "present"))
+    assertEquals("present", record.getString("a"))
+    assertTrue(record.values.get("b").isEmpty)
+    // the schema is narrowed to what the response actually carried
+    assertEquals(Seq("a"), record.schema.fields.map(_.name).toSeq)
+  }
+
+  @Test
+  def testNullTopLevelMapYieldsNullRecord(): Unit = {
+    assertNull(FeatureRecord.fromValueMap(rootSchema, null))
+  }
+
+  @Test
+  def testExceptionKeysAreRetainedEvenThoughTheyAreNotInTheSchema(): Unit = {
+    // fetchJoin / fetchGroupBys report partial failures as `<name>_exception` entries in the value
+    // map. Those keys are never part of the declared value schema, so they must pass through
+    // rather than be dropped, otherwise a structured caller cannot see the failure at all.
+    val schema = StructType("WithErrors", Array(StructField("a", StringType)))
+    val record = FeatureRecord.fromValueMap(
+      schema,
+      Map("a" -> "ok", "some_group_by_exception" -> "boom", "derivation_fetch_exception" -> "kaboom"))
+
+    assertEquals("ok", record.getString("a"))
+    assertTrue(record.hasErrors)
+    assertEquals(Set("some_group_by_exception", "derivation_fetch_exception"), record.errors.keySet)
+    assertEquals("boom", record.errors("some_group_by_exception"))
+  }
+
+  @Test
+  def testNoErrorsOnACleanRecord(): Unit = {
+    val schema = StructType("Clean", Array(StructField("a", StringType)))
+    val record = FeatureRecord.fromValueMap(schema, Map("a" -> "ok"))
+    assertFalse(record.hasErrors)
+    assertTrue(record.errors.isEmpty)
+  }
+
+  @Test
+  def testPresentButNullFieldYieldsNoneNotSomeNull(): Unit = {
+    // Nulls are routine: a groupBy with no data for a key returns nulls, and model-transform
+    // passthrough inserts nulls explicitly. `Some(null)` would defeat the point of the Option and
+    // break `.orElse(default)` at the call site.
+    val schema = StructType("Nullable",
+                            Array(StructField("s", StringType),
+                                  StructField("n", LongType),
+                                  StructField("b", BooleanType),
+                                  StructField("st", insightSchema)))
+    val record =
+      FeatureRecord.fromValueMap(schema, Map("s" -> null, "n" -> null, "b" -> null, "st" -> null))
+
+    assertEquals(None, record.getStringOpt("s"))
+    assertEquals(None, record.getLongOpt("n"))
+    assertEquals(None, record.getBooleanOpt("b"))
+    assertEquals(None, record.getStructOpt("st"))
+    assertEquals("fallback", record.getStringOpt("s").getOrElse("fallback"))
+  }
+
+  @Test
+  def testAbsentFieldAlsoYieldsNone(): Unit = {
+    val schema = StructType("Absent", Array(StructField("s", StringType)))
+    val record = FeatureRecord.fromValueMap(schema, Map.empty[String, Any])
+    assertEquals(None, record.getStringOpt("s"))
+  }
+
+  @Test
+  def testNumericGettersWidenAcrossTypes(): Unit = {
+    // A Chronon IntType field read as a Long matters because the Thrift-based consumer path maps
+    // i64 fields onto getLongOpt.
+    val schema = StructType("Nums",
+                            Array(StructField("i", IntType),
+                                  StructField("l", LongType),
+                                  StructField("f", FloatType),
+                                  StructField("d", DoubleType)))
+    val record = FeatureRecord.fromValueMap(
+      schema,
+      Map("i" -> Integer.valueOf(5), "l" -> java.lang.Long.valueOf(6L), "f" -> java.lang.Float.valueOf(1.5f),
+        "d" -> java.lang.Double.valueOf(2.5d)))
+
+    assertEquals(5L, record.getLong("i"))
+    assertEquals(Some(5L), record.getLongOpt("i"))
+    assertEquals(5, record.getInt("i"))
+    assertEquals(6, record.getInt("l"))
+    assertEquals(1.5d, record.getDouble("f"), 0.0001)
+    assertEquals(2.5d, record.getDouble("d"), 0.0001)
+  }
+
+  @Test
+  def testNonNumericFieldReadAsNumberFailsClearly(): Unit = {
+    val schema = StructType("Mixed", Array(StructField("s", StringType)))
+    val record = FeatureRecord.fromValueMap(schema, Map("s" -> "not a number"))
+    val ex = intercept[IllegalArgumentException](record.getLong("s"))
+    assertTrue(ex.getMessage.contains("not numeric"))
+  }
+
+  @Test
+  def testStructArrivingAsFieldKeyedMapIsNamed(): Unit = {
+    // Derived struct columns can surface as maps keyed by field name rather than positional
+    // arrays; Row.to handles the same two shapes.
+    val scalaMapShape: Map[String, Any] = Map("kind" -> "HIGHLIGHT", "text" -> "Great host")
+    val javaMapShape = new util.HashMap[String, Any]()
+    javaMapShape.put("kind", "HIGHLIGHT")
+    javaMapShape.put("text", "Spotless")
+
+    val schema = StructType("Outer",
+                            Array(StructField("from_scala_map", contentSchema),
+                                  StructField("from_java_map", contentSchema)))
+    val record =
+      FeatureRecord.fromValueMap(schema, Map("from_scala_map" -> scalaMapShape, "from_java_map" -> javaMapShape))
+
+    assertEquals("Great host", record.getStruct("from_scala_map").getString("text"))
+    assertEquals("Spotless", record.getStruct("from_java_map").getString("text"))
+  }
+
+  @Test
+  def testListOfStructsArrivingAsFieldKeyedMaps(): Unit = {
+    val schema = StructType("WithStructList", Array(StructField("contents", ListType(contentSchema))))
+    val elems = new util.ArrayList[Any]()
+    elems.add(Map("kind" -> "HIGHLIGHT", "text" -> "a"))
+    elems.add(Map("kind" -> "LOWLIGHT", "text" -> "b"))
+    val record = FeatureRecord.fromValueMap(schema, Map("contents" -> elems))
+
+    val contents = record.getStructList("contents")
+    assertEquals(2, contents.size)
+    assertEquals("a", contents.head.getString("text"))
+    assertEquals("LOWLIGHT", contents(1).getString("kind"))
+  }
+
+  @Test
+  def testMapTypedFieldWithStructValues(): Unit = {
+    val schema = StructType("WithMap", Array(StructField("by_id", MapType(StringType, contentSchema))))
+    val inner = new util.HashMap[Any, Any]()
+    inner.put("k1", Array[Any]("HIGHLIGHT", "text one"))
+    val record = FeatureRecord.fromValueMap(schema, Map("by_id" -> inner))
+
+    val asMap = record.getMap[FeatureRecord]("by_id")
+    assertEquals("text one", asMap("k1").getString("text"))
+  }
+
+  @Test
+  def testUnsupportedStructShapeFailsClearly(): Unit = {
+    val schema = StructType("Bad", Array(StructField("s", contentSchema)))
+    val ex = intercept[IllegalArgumentException](FeatureRecord.fromValueMap(schema, Map("s" -> "just a string")))
+    assertTrue(ex.getMessage.contains("Content"))
+  }
+}


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

We are adding struct data support for Chronon fetch to solve the problem. Created a generic object class FeatureRecord and enable Chronon fetch to return FeatureRecord through fetchJoinStructured and fetchGroupByStructured. The original fetch Join and GroupBy remain unchanged. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Struct-valued features currently lose their field names: Chronon serializes structs positionally, so a nested field like  arrives as a list of unkeyed values and consumers must cast by field order. We are adding the struct response support to unblock struct-valued feature parsing.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@yuli-han @pkundurthy 
