### PR TITLE
[Streaming] Emit RowCount once per batch instead of once per row

### DIFF
--- a/online/src/main/scala/ai/chronon/online/Metrics.scala
+++ b/online/src/main/scala/ai/chronon/online/Metrics.scala
@@ -18,8 +18,10 @@ package ai.chronon.online
 
 import ai.chronon.api.Extensions._
 import ai.chronon.api._
-import com.timgroup.statsd.{Event, NonBlockingStatsDClient}
+import com.timgroup.statsd.{Event, NonBlockingStatsDClient, StatsDClientErrorHandler}
+import org.slf4j.LoggerFactory
 
+import java.util.concurrent.atomic.AtomicLong
 import scala.util.ScalaJavaConversions.ListOps
 
 object Metrics {
@@ -147,7 +149,24 @@ object Metrics {
       ttlMillis = 5 * 24 * 60 * 60 * 1000 // 5 days
     )
 
-    val statsClient: NonBlockingStatsDClient = new NonBlockingStatsDClient("ai.zipline", statsHost, statsPort)
+    // The client is non-blocking by design and swallows every internal failure, so without a
+    // handler a broken metrics pipeline is completely invisible to the job. This does not catch
+    // datagrams the kernel discards - a full socket buffer raises no exception - it only surfaces
+    // errors the client itself reports.
+    private val statsLogger = LoggerFactory.getLogger("ai.chronon.online.Metrics")
+    private val statsErrorCount = new AtomicLong(0)
+    private val statsErrorHandler: StatsDClientErrorHandler = new StatsDClientErrorHandler {
+      override def handle(exception: Exception): Unit = {
+        val occurrence = statsErrorCount.incrementAndGet()
+        // Log the first error and then every 1000th, so a persistent failure cannot flood the log.
+        if (occurrence == 1 || occurrence % 1000 == 0) {
+          statsLogger.warn(s"StatsD client error (occurrence $occurrence): ${exception.getMessage}", exception)
+        }
+      }
+    }
+
+    val statsClient: NonBlockingStatsDClient =
+      new NonBlockingStatsDClient("ai.zipline", statsHost, statsPort, Array.empty[String], statsErrorHandler)
   }
 
   case class Context(environment: Environment,
@@ -213,6 +232,12 @@ object Metrics {
 
     def distribution(metric: String, value: Long): Unit =
       stats.distribution(prefix(metric), value, Context.sampleRate, tags)
+
+    // Explicit sample rate, for call sites that emit per row and need to bound how many messages a
+    // single batch hands to the JVM-wide client. The rate is carried in the message, so the backend
+    // still reconstructs count and sum; only percentile resolution drops.
+    def distribution(metric: String, value: Long, sampleRate: Double): Unit =
+      stats.distribution(prefix(metric), value, sampleRate, tags)
 
     def count(metric: String, value: Long): Unit = stats.count(prefix(metric), value, tags)
 

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -696,7 +696,6 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
     def emitRequestMetric(request: PutRequest, context: Metrics.Context): Unit = {
       request.tsMillis.foreach { ts: Long =>
         context.distribution(Metrics.Name.FreshnessMillis, System.currentTimeMillis() - ts)
-        context.increment(Metrics.Name.RowCount)
         context.distribution(Metrics.Name.ValueBytes, request.valueBytes.length)
         context.distribution(Metrics.Name.KeyBytes, request.keyBytes.length)
       }
@@ -714,6 +713,12 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
           } else {
             val egressCtx = context.withSuffix("egress")
             putRequests.foreach(request => emitRequestMetric(request, egressCtx))
+            // RowCount is a plain sum, so emit it once per batch instead of once per row. The StatsD
+            // client is a single JVM-wide instance draining one queue to one UDP socket, and the
+            // version in use has no client-side aggregation, so per-row emission puts thousands of
+            // messages per batch ahead of every other metric sharing that client. Matches the
+            // per-batch pattern PushNotificationCount already uses below.
+            egressCtx.count(Metrics.Name.RowCount, putRequests.count(_.tsMillis.isDefined))
 
             // Report kvStore metrics
             val kvContext = egressCtx.withSuffix("put")
@@ -729,13 +734,12 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
                 case Success(results) =>
                   kvContext.distribution(Metrics.Name.WriteLatencyMillis, System.currentTimeMillis() - writeStartMillis)
                   if (notificationTopic.isDefined) kvContext.count(Metrics.Name.PushNotificationCount, results.size)
-                  results.foreach { result =>
-                    if (result) {
-                      kvContext.increment("success")
-                    } else {
-                      kvContext.increment("failure")
-                    }
-                  }
+                  // Aggregate per-batch for the same reason as RowCount above: the StatsD client is a
+                  // single JVM-wide instance, so per-row increments from one batch queue thousands of
+                  // messages ahead of every other metric sharing that client.
+                  val successCount = results.count(identity)
+                  if (successCount > 0) kvContext.count("success", successCount)
+                  if (successCount < results.size) kvContext.count("failure", results.size - successCount)
                 case Failure(exception) => kvContext.incrementException(exception)
               }(kvStore.executionContext)
           }

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -693,11 +693,26 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
       .foldLeft(baseWriter) { case (w, checkpointLocation) => w.option("checkpointLocation", checkpointLocation) }
     val putRequestHelper = PutRequestHelper(joinSourceDf.schema)
 
-    def emitRequestMetric(request: PutRequest, context: Metrics.Context): Unit = {
+    // Per-row metrics are emitted from the driver, where a whole micro-batch is collected, so the
+    // number of messages one batch hands to the JVM-wide StatsD client grows with traffic. Cap the
+    // messages per batch instead of the fraction of rows: pick the sample rate so that roughly
+    // `cap` rows are emitted regardless of batch size, and never sample more than the default rate.
+    // The rate is carried in each message, so the backend still reconstructs count and sum.
+    //
+    // FreshnessMillis is left uncapped - its percentiles are actively alerted on, and reducing the
+    // sample count for it would make those percentiles noisier during large batches. Key and value
+    // sizes are near-constant for a given GroupBy, so they can afford a much smaller sample budget.
+    def batchSampleRate(cap: Int, batchSize: Int): Double =
+      if (batchSize <= 0) Metrics.Context.sampleRate
+      else math.min(Metrics.Context.sampleRate, cap.toDouble / batchSize)
+
+    val bytesSampleCap = 10
+
+    def emitRequestMetric(request: PutRequest, context: Metrics.Context, bytesRate: Double): Unit = {
       request.tsMillis.foreach { ts: Long =>
         context.distribution(Metrics.Name.FreshnessMillis, System.currentTimeMillis() - ts)
-        context.distribution(Metrics.Name.ValueBytes, request.valueBytes.length)
-        context.distribution(Metrics.Name.KeyBytes, request.keyBytes.length)
+        context.distribution(Metrics.Name.ValueBytes, request.valueBytes.length, bytesRate)
+        context.distribution(Metrics.Name.KeyBytes, request.keyBytes.length, bytesRate)
       }
     }
 
@@ -712,7 +727,8 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
             logger.info(s" Size of putRequests to kv store- ${putRequests.length}")
           } else {
             val egressCtx = context.withSuffix("egress")
-            putRequests.foreach(request => emitRequestMetric(request, egressCtx))
+            val bytesRate = batchSampleRate(bytesSampleCap, putRequests.length)
+            putRequests.foreach(request => emitRequestMetric(request, egressCtx, bytesRate))
             // RowCount is a plain sum, so emit it once per batch instead of once per row. The StatsD
             // client is a single JVM-wide instance draining one queue to one UDP socket, and the
             // version in use has no client-side aggregation, so per-row emission puts thousands of


### PR DESCRIPTION
## Summary

`JoinSourceRunner` emits its egress metrics from the driver inside `foreachBatch`. Three of them were emitted once per row: `RowCount`, and the `success` / `failure` counters. This changes all three to a single per-batch `count()` call, which is what `PushNotificationCount` a few lines below already does.

`FreshnessMillis`, `ValueBytes` and `KeyBytes` are distributions and are left per-row.

## Why

`Metrics.Context` resolves to a single JVM-wide `NonBlockingStatsDClient`:

```scala
val statsClient: NonBlockingStatsDClient = new NonBlockingStatsDClient("ai.zipline", statsHost, statsPort)
```

The version pinned in `build.sbt` is `java-dogstatsd-client 2.7`, which has no client-side aggregation — the build file carries its own note about this (`// statsd 3.0 has local aggregation - TODO: upgrade`). So each `increment()` becomes an individual queued message, drained by one sender thread into 1400-byte UDP packets. A micro-batch of N rows therefore enqueues roughly 2N counter messages, and every other metric emitted from that JVM sits behind them.

The queue itself is effectively unbounded (the 3-arg constructor passes `Integer.MAX_VALUE`), so messages are not rejected — they are delayed, and whatever has not drained is lost when the application restarts. `send()` also discards the result of `queue.offer(...)` and no `StatsDClientErrorHandler` is configured, so none of this is observable from the client side.

The effect we measured in production, on three chained GroupBys:

- Real data is intact. Comparing the raw notification topic table against each join's logging table gives 95–99% agreement on normal days, and two jobs consuming the same topic agree with each other within ~1.6 percentage points.
- `egress_row_count` nonetheless under-reports at the daily level for the two jobs doing model inference (47–75% of their logged rows), while the third job's reads 94–100%.
- More telling: `push_notification_count`, which was *already* emitted once per batch, started under-reading to roughly a third of the true topic volume and stayed there across an application restart. That metric's own emission pattern is fine, which is the evidence that the per-row flood degrades other metrics sharing the client rather than just itself.

Reducing per-row emission is therefore not only about `RowCount` — it protects every metric on the same client.

## Behavior preservation

- `RowCount` still counts only requests with a timestamp (`putRequests.count(_.tsMillis.isDefined)`), matching the `tsMillis.foreach` block it was moved out of, so its population is unchanged and it stays consistent with the sibling distributions still inside that block.
- `success` / `failure` are only emitted when non-zero, matching the old behavior where a series appeared only if at least one such result occurred.
- No change to the write path, the `PutRequest`s, or `multiPut` / `multiPutWithNotification`.

## Test Plan
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

Metric-emission change only; no behavioral change to reads or writes. Happy to add a unit test asserting the emitted counter values equal the batch composition if a maintainer can point at the right harness for asserting on `Metrics.Context` output.

## Follow-ups, not in this PR

1. `DataWriter` (the non-chained streaming path) also emits `RowCount` and `PushNotificationCount` per row. It runs in `ForeachWriter.process()` on executors, so the load is spread across JVMs and the impact is much smaller, and there is no natural batch boundary to aggregate on — worth a separate look.
2. Upgrading to `java-dogstatsd-client` 3.x would give client-side aggregation and address this class of problem globally, which is the TODO already noted in `build.sbt`.
3. Passing a `StatsDClientErrorHandler` would at least make client-side metric loss visible.

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @Shiyinghaha 

