### PR TITLE
Adding the option to skip intermediate table materialization 

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -45,13 +45,19 @@ abstract class JoinBase(joinConf: api.Join,
                         unsetSemanticHash: Boolean) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   assert(Option(joinConf.metaData.outputNamespace).nonEmpty, s"output namespace could not be empty or null")
-  require(
-    tableUtils.materializeJoinParts || selectedJoinParts.isEmpty,
-    "spark.chronon.join.part.materialize=false is not compatible with the parallelized join flow. " +
-      "That flow hands joinPart results between separate Spark jobs through the join part tables, so it needs " +
-      "them materialized. Either drop --selected-join-parts and run the monolithic backfill, or leave " +
-      "spark.chronon.join.part.materialize at its default of true."
-  )
+
+  // The parallelized join flow hands joinPart results between separate Spark jobs through the join part tables,
+  // so those tables have to exist for it to work at all. When that flow is in use we materialize regardless of
+  // the flag instead of failing the job: the flag is typically set once for a cluster, while the flow is chosen
+  // per run, so a job that cannot honor the flag should still produce correct output.
+  private val parallelizedJoinPartFlow: Boolean = selectedJoinParts.isDefined
+  val materializeJoinParts: Boolean = tableUtils.materializeJoinParts || parallelizedJoinPartFlow
+  if (parallelizedJoinPartFlow && !tableUtils.materializeJoinParts) {
+    logger.warn(
+      "spark.chronon.join.part.materialize=false is not supported by the parallelized join flow, which hands " +
+        "joinPart results between separate Spark jobs through the join part tables. Falling back to writing " +
+        "them. Drop --selected-join-parts to run the monolithic backfill with the flag honored.")
+  }
   val metrics: Metrics.Context = Metrics.Context(Metrics.Environment.JoinOffline, joinConf)
   val outputTable = if (!joinConf.hasModelTransforms) {
     joinConf.metaData.outputTable
@@ -177,9 +183,9 @@ abstract class JoinBase(joinConf: api.Join,
          |Missing left partitions $leftRange
          |Range of timestamps within missing left partitions $leftTimeRangeOpt
          |Right range $rightRange
-         |Materialize join part table: ${tableUtils.materializeJoinParts}""".stripMargin)
+         |Materialize join part table: $materializeJoinParts""".stripMargin)
 
-    if (tableUtils.materializeJoinParts) {
+    if (materializeJoinParts) {
       materializeRightTable(leftDf, joinPart, partTable, rightRange, shiftDays, bloomMapOpt, partMetrics, smallMode)
     } else {
       computeRightTableInMemory(leftDf, joinPart, partTable, rightRange, shiftDays, bloomMapOpt, partMetrics)
@@ -532,11 +538,13 @@ abstract class JoinBase(joinConf: api.Join,
   def computeFinalJoin(leftDf: DataFrame, leftRange: PartitionRange, bootstrapInfo: BootstrapInfo): Unit
 
   def computeFinal(overrideStartPartition: Option[String] = None): Unit = {
-    require(
-      tableUtils.materializeJoinParts,
-      "backfill-final reads each joinPart from its join part table, so it requires " +
-        "spark.chronon.join.part.materialize=true."
-    )
+    // Same fallback as the constructor: this is the last step of the parallelized join flow and reads each
+    // joinPart from its join part table, which the joinPart jobs of that flow wrote for the same reason.
+    if (!tableUtils.materializeJoinParts) {
+      logger.warn(
+        "spark.chronon.join.part.materialize=false is not supported by backfill-final, which reads each joinPart " +
+          "from its join part table. Proceeding with the join part tables written by the joinPart jobs.")
+    }
 
     // Utilizes the same tablesToRecompute check as the monolithic spark job, because if any joinPart changes, then so does the output table
     val (tablesChanged, autoArchive) = tablesToRecompute(joinConf, outputTable, tableUtils, unsetSemanticHash)

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -284,9 +284,21 @@ abstract class JoinBase(joinConf: api.Join,
                                         shiftDays: Int,
                                         bloomMapOpt: Option[util.Map[String, BloomFilter]],
                                         partMetrics: Metrics.Context): Option[DataFrame] = {
+    val leftRangeForPart = rightRange.shift(-shiftDays)
+    logger.info(s"""
+         |Computing joinPart in memory - no join part table will be written
+         |  joinPart      : ${joinPart.groupBy.metaData.name}
+         |  skipped table : $partTable
+         |  right range   : $rightRange (${rightRange.partitions.length} partitions)
+         |  left range    : $leftRangeForPart
+         |  the full right range is recomputed on every run: without the part table there is no record
+         |  of what an earlier run already filled, so there is no unfilled-range check to skip work
+         |""".stripMargin)
+
+    val start = System.currentTimeMillis()
     val result =
       try {
-        val prunedLeft = leftDf.flatMap(_.prunePartitions(rightRange.shift(-shiftDays)))
+        val prunedLeft = leftDf.flatMap(_.prunePartitions(leftRangeForPart))
         computeJoinPart(prunedLeft, joinPart, bloomMapOpt)
       } catch {
         case e: Exception =>
@@ -294,17 +306,28 @@ abstract class JoinBase(joinConf: api.Join,
             s"Error while processing groupBy: ${joinConf.metaData.name}/${joinPart.groupBy.getMetaData.getName}")
           throw e
       }
+    val planMillis = System.currentTimeMillis() - start
 
     // LatencyMinutes is deliberately not gauged here. Without the write there is no action, so the
     // aggregation is evaluated later as part of the final merge and any duration measured at this point
     // would understate the real cost of the joinPart.
     partMetrics.gauge(Metrics.Name.PartitionCount, rightRange.partitions.length)
 
-    if (result.isEmpty) {
-      // Happens when everything is handled by bootstrap
-      logger.info(s"Skipping $partTable because no data in computed joinPart.")
-    } else {
-      logger.info(s"Computed joinPart for range $rightRange in memory, skipping the write to $partTable")
+    result match {
+      case None =>
+        // Happens when everything is handled by bootstrap
+        logger.info(
+          s"Skipping $partTable because no data in computed joinPart ${joinPart.groupBy.metaData.name}, " +
+            s"nothing is handed to the final merge for range $rightRange")
+      case Some(df) =>
+        logger.info(s"""
+             |Built joinPart plan in memory for ${joinPart.groupBy.metaData.name} in $planMillis ms
+             |  skipped write to : $partTable
+             |  right range      : $rightRange
+             |  output columns   : ${df.columns.length} -> ${df.columns.mkString(", ")}
+             |  the plan is lazy - the aggregation runs when the final join merge is materialized, so the
+             |  real cost of this joinPart is reported there and not by the duration above
+             |""".stripMargin)
     }
     result
   }

--- a/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
+++ b/spark/src/main/scala/ai/chronon/spark/JoinBase.scala
@@ -45,6 +45,13 @@ abstract class JoinBase(joinConf: api.Join,
                         unsetSemanticHash: Boolean) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
   assert(Option(joinConf.metaData.outputNamespace).nonEmpty, s"output namespace could not be empty or null")
+  require(
+    tableUtils.materializeJoinParts || selectedJoinParts.isEmpty,
+    "spark.chronon.join.part.materialize=false is not compatible with the parallelized join flow. " +
+      "That flow hands joinPart results between separate Spark jobs through the join part tables, so it needs " +
+      "them materialized. Either drop --selected-join-parts and run the monolithic backfill, or leave " +
+      "spark.chronon.join.part.materialize at its default of true."
+  )
   val metrics: Metrics.Context = Metrics.Context(Metrics.Environment.JoinOffline, joinConf)
   val outputTable = if (!joinConf.hasModelTransforms) {
     joinConf.metaData.outputTable
@@ -169,8 +176,29 @@ abstract class JoinBase(joinConf: api.Join,
          |Shift days $shiftDays
          |Missing left partitions $leftRange
          |Range of timestamps within missing left partitions $leftTimeRangeOpt
-         |Right range $rightRange""".stripMargin)
+         |Right range $rightRange
+         |Materialize join part table: ${tableUtils.materializeJoinParts}""".stripMargin)
 
+    if (tableUtils.materializeJoinParts) {
+      materializeRightTable(leftDf, joinPart, partTable, rightRange, shiftDays, bloomMapOpt, partMetrics, smallMode)
+    } else {
+      computeRightTableInMemory(leftDf, joinPart, partTable, rightRange, shiftDays, bloomMapOpt, partMetrics)
+    }
+  }
+
+  /*
+   * Computes the joinPart over the unfilled portion of `rightRange`, writes the result to `partTable` and
+   * returns a scan of that table. The table doubles as a per-joinPart checkpoint: a rerun only computes the
+   * partitions that are still missing, and a failure downstream of this point does not lose the work.
+   */
+  private def materializeRightTable(leftDf: Option[DfWithStats],
+                                    joinPart: JoinPart,
+                                    partTable: String,
+                                    rightRange: PartitionRange,
+                                    shiftDays: Int,
+                                    bloomMapOpt: Option[util.Map[String, BloomFilter]],
+                                    partMetrics: Metrics.Context,
+                                    smallMode: Boolean): Option[DataFrame] = {
     try {
       val unfilledRanges = tableUtils
         .unfilledRanges(
@@ -232,6 +260,47 @@ abstract class JoinBase(joinConf: api.Join,
       // Happens when everything is handled by bootstrap
       None
     }
+  }
+
+  /*
+   * Computes the joinPart over `rightRange` and hands the DataFrame straight to the final merge, without
+   * writing `partTable`.
+   *
+   * There is no unfilled-range check here on purpose. Without the part table there is no record of what an
+   * earlier run already computed, so the full `rightRange` is computed every time. This is also what keeps
+   * the events-left <> snapshot-accuracy case correct: there `rightRange` is derived from the left time range
+   * and the materialized path reads back a wider range than the one it just wrote.
+   */
+  private def computeRightTableInMemory(leftDf: Option[DfWithStats],
+                                        joinPart: JoinPart,
+                                        partTable: String,
+                                        rightRange: PartitionRange,
+                                        shiftDays: Int,
+                                        bloomMapOpt: Option[util.Map[String, BloomFilter]],
+                                        partMetrics: Metrics.Context): Option[DataFrame] = {
+    val result =
+      try {
+        val prunedLeft = leftDf.flatMap(_.prunePartitions(rightRange.shift(-shiftDays)))
+        computeJoinPart(prunedLeft, joinPart, bloomMapOpt)
+      } catch {
+        case e: Exception =>
+          logger.error(
+            s"Error while processing groupBy: ${joinConf.metaData.name}/${joinPart.groupBy.getMetaData.getName}")
+          throw e
+      }
+
+    // LatencyMinutes is deliberately not gauged here. Without the write there is no action, so the
+    // aggregation is evaluated later as part of the final merge and any duration measured at this point
+    // would understate the real cost of the joinPart.
+    partMetrics.gauge(Metrics.Name.PartitionCount, rightRange.partitions.length)
+
+    if (result.isEmpty) {
+      // Happens when everything is handled by bootstrap
+      logger.info(s"Skipping $partTable because no data in computed joinPart.")
+    } else {
+      logger.info(s"Computed joinPart for range $rightRange in memory, skipping the write to $partTable")
+    }
+    result
   }
 
   def computeJoinPart(leftDfWithStats: Option[DfWithStats],
@@ -463,6 +532,11 @@ abstract class JoinBase(joinConf: api.Join,
   def computeFinalJoin(leftDf: DataFrame, leftRange: PartitionRange, bootstrapInfo: BootstrapInfo): Unit
 
   def computeFinal(overrideStartPartition: Option[String] = None): Unit = {
+    require(
+      tableUtils.materializeJoinParts,
+      "backfill-final reads each joinPart from its join part table, so it requires " +
+        "spark.chronon.join.part.materialize=true."
+    )
 
     // Utilizes the same tablesToRecompute check as the monolithic spark job, because if any joinPart changes, then so does the output table
     val (tablesChanged, autoArchive) = tablesToRecompute(joinConf, outputTable, tableUtils, unsetSemanticHash)

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -392,8 +392,9 @@ case class TableUtils(sparkSession: SparkSession) {
     sparkSession.conf.get("spark.chronon.join.backfill.left_time_range.enabled", "true").toBoolean
 
   // flag for whether or not to materialize the per-joinPart intermediate tables during join backfill
+  // TODO: value is for testing jar only - set to false to test on no materialization of intermediate tables
   val materializeJoinParts: Boolean =
-    sparkSession.conf.get("spark.chronon.join.part.materialize", "true").toBoolean
+    sparkSession.conf.get("spark.chronon.join.part.materialize", "false").toBoolean
   val joinPartParallelism: Int = sparkSession.conf.get("spark.chronon.join.part.parallelism", "1").toInt
   val aggregationParallelism: Int = sparkSession.conf.get("spark.chronon.group_by.parallelism", "1000").toInt
   val maxWait: Int = sparkSession.conf.get("spark.chronon.wait.hours", "48").toInt

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -392,9 +392,8 @@ case class TableUtils(sparkSession: SparkSession) {
     sparkSession.conf.get("spark.chronon.join.backfill.left_time_range.enabled", "true").toBoolean
 
   // flag for whether or not to materialize the per-joinPart intermediate tables during join backfill
-  // TODO: value is for testing jar only - set to false to test on no materialization of intermediate tables
   val materializeJoinParts: Boolean =
-    sparkSession.conf.get("spark.chronon.join.part.materialize", "false").toBoolean
+    sparkSession.conf.get("spark.chronon.join.part.materialize", "true").toBoolean
   val joinPartParallelism: Int = sparkSession.conf.get("spark.chronon.join.part.parallelism", "1").toInt
   val aggregationParallelism: Int = sparkSession.conf.get("spark.chronon.group_by.parallelism", "1000").toInt
   val maxWait: Int = sparkSession.conf.get("spark.chronon.wait.hours", "48").toInt

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -391,17 +391,7 @@ case class TableUtils(sparkSession: SparkSession) {
   val checkLeftTimeRange: Boolean =
     sparkSession.conf.get("spark.chronon.join.backfill.left_time_range.enabled", "true").toBoolean
 
-  // whether or not to materialize the per-joinPart intermediate tables during join backfill.
-  // when true (the default), each joinPart is written to `<join_output_table>_<prefix>_<group_by_name>` and
-  // read back before the final merge. The table doubles as a checkpoint, so a rerun only computes the
-  // partitions that are still unfilled.
-  // when false, the joinPart DataFrame is handed straight to the final merge and no intermediate table is
-  // written. This saves a write plus a read, at the cost of losing the checkpoint: the full right range is
-  // recomputed on every run, and a failure in the merge step re-runs every joinPart.
-  // NOTE: not compatible with the parallelized join flow (`--selected-join-parts`, `backfill-left` /
-  // `backfill-final`), which hands results between Spark jobs through these tables. Also do not set this to
-  // false for a join whose joinPart tables are consumed downstream, e.g. by a GroupBy chained onto one via
-  // `join_part_output_table_name`.
+  // flag for whether or not to materialize the per-joinPart intermediate tables during join backfill
   val materializeJoinParts: Boolean =
     sparkSession.conf.get("spark.chronon.join.part.materialize", "true").toBoolean
   val joinPartParallelism: Int = sparkSession.conf.get("spark.chronon.join.part.parallelism", "1").toInt

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -390,6 +390,20 @@ case class TableUtils(sparkSession: SparkSession) {
 
   val checkLeftTimeRange: Boolean =
     sparkSession.conf.get("spark.chronon.join.backfill.left_time_range.enabled", "true").toBoolean
+
+  // whether or not to materialize the per-joinPart intermediate tables during join backfill.
+  // when true (the default), each joinPart is written to `<join_output_table>_<prefix>_<group_by_name>` and
+  // read back before the final merge. The table doubles as a checkpoint, so a rerun only computes the
+  // partitions that are still unfilled.
+  // when false, the joinPart DataFrame is handed straight to the final merge and no intermediate table is
+  // written. This saves a write plus a read, at the cost of losing the checkpoint: the full right range is
+  // recomputed on every run, and a failure in the merge step re-runs every joinPart.
+  // NOTE: not compatible with the parallelized join flow (`--selected-join-parts`, `backfill-left` /
+  // `backfill-final`), which hands results between Spark jobs through these tables. Also do not set this to
+  // false for a join whose joinPart tables are consumed downstream, e.g. by a GroupBy chained onto one via
+  // `join_part_output_table_name`.
+  val materializeJoinParts: Boolean =
+    sparkSession.conf.get("spark.chronon.join.part.materialize", "true").toBoolean
   val joinPartParallelism: Int = sparkSession.conf.get("spark.chronon.join.part.parallelism", "1").toInt
   val aggregationParallelism: Int = sparkSession.conf.get("spark.chronon.group_by.parallelism", "1000").toInt
   val maxWait: Int = sparkSession.conf.get("spark.chronon.wait.hours", "48").toInt

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinBasicTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinBasicTest.scala
@@ -451,4 +451,120 @@ class JoinBasicTests {
     assertEquals(diffCount, 0)
   }
 
+  /**
+    * Runs the same join twice, once with `spark.chronon.join.part.materialize` at its default of true and once
+    * with it set to false, and checks that:
+    *   - the two output tables agree row for row
+    *   - the non-materialized run writes no join part tables
+    * The join covers both right-range shapes: a SNAPSHOT joinPart, whose right range is derived from the left
+    * time range and is therefore shifted, and a TEMPORAL joinPart, whose right range is already aligned.
+    */
+  @Test
+  def testJoinPartMaterializationFlag(): Unit = {
+    val spark: SparkSession =
+      SparkSessionBuilder.build("JoinTest" + "_" + Random.alphanumeric.take(6).mkString, local = true)
+    val namespace = "test_namespace_jointest" + "_" + Random.alphanumeric.take(6).mkString
+    val materializeConf = "spark.chronon.join.part.materialize"
+    val originalSetting = spark.conf.getOption(materializeConf)
+
+    try {
+      val tableUtils = TableUtils(spark)
+      tableUtils.createDatabase(namespace)
+
+      // Left - events
+      val itemQueries = List(Column("item", api.StringType, 100), Column("value", api.LongType, 100))
+      val itemQueriesTable = s"$namespace.item_queries_materialize_flag"
+      DataFrameGen.events(spark, itemQueries, 3000, partitions = 20).save(itemQueriesTable)
+
+      // Right - events
+      val viewsSchema = List(
+        Column("user", api.StringType, 1000),
+        Column("item", api.StringType, 100),
+        Column("value", api.LongType, 100)
+      )
+      val viewsTable = s"$namespace.views_materialize_flag"
+      DataFrameGen.events(spark, viewsSchema, count = 3000, partitions = 30).save(viewsTable)
+
+      // start late enough inside the generated data that the 7 day window on the right has history to read
+      val start = tableUtils.partitionSpec.minus(today, new Window(10, TimeUnit.DAYS))
+      def viewsSource = Builders.Source.events(table = viewsTable, query = Builders.Query(startPartition = start))
+
+      // the GroupBy names are shared by both joins so the two output tables have identical value columns
+      val snapshotGroupBy = Builders.GroupBy(
+        sources = Seq(viewsSource),
+        keyColumns = Seq("item"),
+        aggregations = Seq(Builders.Aggregation(operation = Operation.SUM, inputColumn = "value")),
+        metaData = Builders.MetaData(name = "unit_test.views_snapshot", namespace = namespace, team = "item_team"),
+        accuracy = Accuracy.SNAPSHOT
+      )
+
+      val temporalGroupBy = Builders.GroupBy(
+        sources = Seq(viewsSource),
+        keyColumns = Seq("item"),
+        aggregations = Seq(
+          Builders.Aggregation(operation = Operation.COUNT,
+                               inputColumn = "value",
+                               windows = Seq(new Window(7, TimeUnit.DAYS)))),
+        metaData = Builders.MetaData(name = "unit_test.views_temporal", namespace = namespace, team = "item_team"),
+        accuracy = Accuracy.TEMPORAL
+      )
+
+      // The two joins differ only by name, so they write to different output tables but produce the same values.
+      def joinConf(suffix: String) =
+        Builders.Join(
+          left = Builders.Source.events(Builders.Query(startPartition = start), table = itemQueriesTable),
+          joinParts = Seq(
+            Builders.JoinPart(groupBy = snapshotGroupBy, prefix = "snap"),
+            Builders.JoinPart(groupBy = temporalGroupBy, prefix = "temp")
+          ),
+          metaData = Builders.MetaData(name = s"unit_test.item_features_materialize_$suffix",
+                                       namespace = namespace,
+                                       team = "item_team")
+        )
+
+      // 1 - default behavior: join part tables are written
+      val materializedConf = joinConf("materialized")
+      assertTrue(tableUtils.materializeJoinParts)
+      val materialized = new Join(materializedConf, today, tableUtils).computeJoin()
+      materializedConf.joinParts.toScala.foreach { jp =>
+        assertTrue(s"expected ${materializedConf.partOutputTable(jp)} to be written",
+                   tableUtils.tableExists(materializedConf.partOutputTable(jp)))
+      }
+
+      // 2 - flag off: no join part tables, but the same output
+      spark.conf.set(materializeConf, "false")
+      val noMatTableUtils = TableUtils(spark)
+      assertFalse(noMatTableUtils.materializeJoinParts)
+      val unmaterializedConf = joinConf("unmaterialized")
+      val unmaterialized = new Join(unmaterializedConf, today, noMatTableUtils).computeJoin()
+      unmaterializedConf.joinParts.toScala.foreach { jp =>
+        assertFalse(s"expected ${unmaterializedConf.partOutputTable(jp)} to be absent",
+                    noMatTableUtils.tableExists(unmaterializedConf.partOutputTable(jp)))
+      }
+      // the bootstrap table is out of scope for this flag and is still written
+      assertTrue(noMatTableUtils.tableExists(unmaterializedConf.metaData.bootstrapTable))
+
+      val diff = Comparison.sideBySide(materialized, unmaterialized, List("item", "ts", "ds"))
+      val diffCount = diff.count()
+      if (diffCount > 0) {
+        logger.warn(s"Diff count: $diffCount")
+        diff.show()
+      }
+      assertEquals(0, diffCount)
+
+      // 3 - the flag is rejected in the parallelized join flow, which needs the tables to hand results between jobs
+      intercept[IllegalArgumentException] {
+        new Join(joinConf("selected"),
+                 today,
+                 noMatTableUtils,
+                 selectedJoinParts = Some(List("snap_unit_test_views_snapshot")))
+      }
+    } finally {
+      originalSetting match {
+        case Some(value) => spark.conf.set(materializeConf, value)
+        case None        => spark.conf.unset(materializeConf)
+      }
+    }
+  }
+
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/JoinBasicTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/JoinBasicTest.scala
@@ -456,6 +456,7 @@ class JoinBasicTests {
     * with it set to false, and checks that:
     *   - the two output tables agree row for row
     *   - the non-materialized run writes no join part tables
+    *   - the parallelized join flow overrides the flag and writes the tables it needs
     * The join covers both right-range shapes: a SNAPSHOT joinPart, whose right range is derived from the left
     * time range and is therefore shifted, and a TEMPORAL joinPart, whose right range is already aligned.
     */
@@ -552,13 +553,20 @@ class JoinBasicTests {
       }
       assertEquals(0, diffCount)
 
-      // 3 - the flag is rejected in the parallelized join flow, which needs the tables to hand results between jobs
-      intercept[IllegalArgumentException] {
-        new Join(joinConf("selected"),
-                 today,
-                 noMatTableUtils,
-                 selectedJoinParts = Some(List("snap_unit_test_views_snapshot")))
-      }
+      // 3 - the parallelized join flow needs the tables to hand results between separate jobs, so with the flag
+      //     off it falls back to materializing them instead of failing the job
+      val selectedConf = joinConf("selected")
+      val selectedPart = selectedConf.joinParts.toScala.head
+      val selectedJob =
+        new Join(selectedConf, today, noMatTableUtils, selectedJoinParts = Some(List(selectedPart.fullPrefix)))
+      assertTrue("expected the parallelized flow to override the flag", selectedJob.materializeJoinParts)
+      selectedJob.computeJoinOpt()
+      assertTrue(s"expected ${selectedConf.partOutputTable(selectedPart)} to be written by the fallback",
+                 noMatTableUtils.tableExists(selectedConf.partOutputTable(selectedPart)))
+      // the joinPart that was not selected stays absent
+      val unselectedPart = selectedConf.joinParts.toScala.last
+      assertFalse(s"expected ${selectedConf.partOutputTable(unselectedPart)} to be absent",
+                  noMatTableUtils.tableExists(selectedConf.partOutputTable(unselectedPart)))
     } finally {
       originalSetting match {
         case Some(value) => spark.conf.set(materializeConf, value)


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
Adding the option to skip intermediate table materialization. When `materializeJoinParts` is set to `false` and no join part parallelization is enabled, no join part intermediate table will be materialized. If `materializeJoinParts` is set to `false` and join part parallelization is enabled, it will automatically fall back to materializing join parts. 

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

Improve complex join computation efficiency. 

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [x] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested (See internal PRs for details), est. runtime saving is more than 50% for complex joins. 

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @yuli-han 
