### PR TITLE
Remove the checkpointLocation feature from streaming with micro batches

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -1070,13 +1070,13 @@ object Driver {
         onlineJar.foreach(session.sparkContext.addJar)
       implicit val apiImpl = args.impl(args.serializableProps)
 
-      def startQuery(): StreamingQuery = {
-        if (groupByConf.streamingSource.get.isSetJoinSource) {
-          new JoinSourceRunner(groupByConf,
-                               args.serializableProps,
-                               args.debug(),
-                               args.lagMillis.getOrElse(2000)).chainedStreamingQuery.start()
-        } else {
+      if (groupByConf.streamingSource.get.isSetJoinSource) {
+        new JoinSourceRunner(groupByConf,
+                             args.serializableProps,
+                             args.debug(),
+                             args.lagMillis.getOrElse(2000)).chainedStreamingQuery.start().awaitTermination()
+      } else {
+        def startQuery(): StreamingQuery = {
           val streamingSource = groupByConf.streamingSource
           assert(streamingSource.isDefined,
                  "There is no valid streaming source - with a valid topic, and endDate < today")
@@ -1093,10 +1093,9 @@ object Driver {
           new streaming.GroupBy(inputStream, session, groupByConf, args.impl(args.serializableProps), args.debug())
             .run()
         }
+        val maxRetries: Int = session.conf.get("spark.chronon.stream.max_retries", "0").toInt
+        runWithRetries(maxRetries)(startQuery)
       }
-
-      val maxRetries: Int = session.conf.get("spark.chronon.stream.max_retries", "0").toInt
-      runWithRetries(maxRetries)(startQuery)
     }
   }
 

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -685,12 +685,9 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
   private def writeToKVStore(
       joinSourceDf: DataFrame
   ): DataStreamWriter[Row] = {
-    val baseWriter = joinSourceDf.writeStream
+    val writer = joinSourceDf.writeStream
       .outputMode("append")
       .trigger(Trigger.ProcessingTime(microBatchIntervalMillis))
-    val writer = CheckpointConfig
-      .location(groupByConf, session)
-      .foldLeft(baseWriter) { case (w, checkpointLocation) => w.option("checkpointLocation", checkpointLocation) }
     val putRequestHelper = PutRequestHelper(joinSourceDf.schema)
 
     def emitRequestMetric(request: PutRequest, context: Metrics.Context): Unit = {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

- After the implementation of https://github.com/airbnb/chronon/pull/1138 to handle ContinuousTaskRetryException, there was a behavior shift for streaming through micro batches due to the use of permanent checkpointing. When restarted, the current behavior was to pick up from the latest offset and after this change, the job would pick up from the offset from the checkpoint. This lead to some OOM errors since the jobs weren't prepared to deal with the accumulation of data to be processed. This PR reverts that change specifically for micro batches due to this side effect and also the fact that don't face `ContinuousTaskRetryException` errors.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

- Revert to the version before https://github.com/airbnb/chronon/pull/1138 for micro batches. The continuous streaming has benefited from this change and behaved according to the expectation.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- ~[x] Added Unit Tests~
- [x] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers

