### PR TITLE
Fixing naming convention (singular vs plural) for new fetching structured data functions

### DIFF
--- a/online/src/main/java/ai/chronon/online/JavaFetcher.java
+++ b/online/src/main/java/ai/chronon/online/JavaFetcher.java
@@ -234,7 +234,7 @@ public class JavaFetcher {
         // Convert java requests to scala requests
         Seq<Request> scalaRequests = convertJavaRequestList(requests, true, startTs);
         // Get responses from the fetcher
-        Future<Seq<StructuredResponse>> scalaResponses = this.fetcher.fetchGroupByStructured(scalaRequests);
+        Future<Seq<StructuredResponse>> scalaResponses = this.fetcher.fetchGroupBysStructured(scalaRequests);
         // Convert responses to CompletableFuture
         return convertStructuredResponses(scalaResponses);
     }

--- a/online/src/main/scala/ai/chronon/online/FetcherBase.scala
+++ b/online/src/main/scala/ai/chronon/online/FetcherBase.scala
@@ -569,7 +569,7 @@ class FetcherBase(kvStore: KVStore,
     * that the classic map response is already shaped by - derivations included - so this is
     * purely an alternative view of the same values.
     */
-  def fetchGroupByStructured(
+  def fetchGroupBysStructured(
       requests: scala.collection.Seq[Request]): Future[scala.collection.Seq[StructuredResponse]] = {
     fetchGroupBys(requests).map { responses =>
       responses.map { response =>

--- a/online/src/test/scala/ai/chronon/online/FetcherStructuredTest.scala
+++ b/online/src/test/scala/ai/chronon/online/FetcherStructuredTest.scala
@@ -97,13 +97,13 @@ class FetcherStructuredTest extends MockitoSugar with MockitoHelper {
   private def await[T](f: Future[T]): T = Await.result(f, 5.seconds)
 
   @Test
-  def fetchGroupByStructuredNamesNestedStructs(): Unit = {
+  def fetchGroupBysStructuredNamesNestedStructs(): Unit = {
     val schema = StructType("GbValue", Array(StructField("count", LongType), StructField("insight", insightSchema)))
     val values: Map[String, AnyRef] =
       Map("count" -> Long.box(7L), "insight" -> positionalInsight("looks good", Seq("clean", "quiet")))
 
     val fetcher = groupByFetcher(schema, Success(values))
-    val responses = await(fetcher.fetchGroupByStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
+    val responses = await(fetcher.fetchGroupBysStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
 
     assertEquals(1, responses.size)
     val record = responses.head.values.get
@@ -118,33 +118,33 @@ class FetcherStructuredTest extends MockitoSugar with MockitoHelper {
   }
 
   @Test
-  def fetchGroupByStructuredPreservesRequests(): Unit = {
+  def fetchGroupBysStructuredPreservesRequests(): Unit = {
     val schema = StructType("GbValue", Array(StructField("count", LongType)))
     val fetcher = groupByFetcher(schema, Success(Map("count" -> Long.box(1L))))
     val request = Request(GroupByName, Map("listing" -> Long.box(42L)))
 
-    val responses = await(fetcher.fetchGroupByStructured(Seq(request)))
+    val responses = await(fetcher.fetchGroupBysStructured(Seq(request)))
     assertEquals(request, responses.head.request)
   }
 
   @Test
-  def fetchGroupByStructuredSurfacesFetchFailure(): Unit = {
+  def fetchGroupBysStructuredSurfacesFetchFailure(): Unit = {
     val schema = StructType("GbValue", Array(StructField("count", LongType)))
     val boom = new RuntimeException("kv store exploded")
     val fetcher = groupByFetcher(schema, scala.util.Failure(boom))
 
-    val responses = await(fetcher.fetchGroupByStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
+    val responses = await(fetcher.fetchGroupBysStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
     assertTrue(responses.head.values.isFailure)
     assertEquals(boom, responses.head.values.failed.get)
   }
 
   @Test
-  def fetchGroupByStructuredHandlesNullValueMap(): Unit = {
+  def fetchGroupBysStructuredHandlesNullValueMap(): Unit = {
     // fetchGroupBys returns a null value map when the key is absent from the KV store.
     val schema = StructType("GbValue", Array(StructField("count", LongType)))
     val fetcher = groupByFetcher(schema, Success(null))
 
-    val responses = await(fetcher.fetchGroupByStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
+    val responses = await(fetcher.fetchGroupBysStructured(Seq(Request(GroupByName, Map("listing" -> Long.box(1L))))))
     assertEquals(null, responses.head.values.get)
   }
 


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->


Fixes a naming inconsistency introduced with the structured fetch methods in #1139.

The Scala method was named `fetchGroupByStructured` (singular), but the convention is plural: E.g. the existing `FetcherBase.fetchGroupBys`.

The Java wrapper of `fetchGroupByStructured`  (`JavaFetcher.fetchGroupBysStructured`) correctly uses the plural form, and no update is needed. 

`fetchJoinStructured` already matched its `fetchJoin` counterpart and is unchanged. The pre-existing singular/plural split between `fetchJoin` and `fetchGroupBys` is untouched.

### Changes

  - `FetcherBase.scala`: `fetchGroupByStructured` -> `fetchGroupBysStructured`
  - `JavaFetcher.java`: updated the delegation call
  - `FetcherStructuredTest.scala`: updated call sites and test method names



## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @yuli-han 
