### PR TITLE
[Streaming] Move chained egress RowCount emission to executors

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -307,17 +307,26 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
     implicit val structTypeEncoder: Encoder[Mutation] = Encoders.kryo[Mutation]
     val deserialized: Dataset[Mutation] = df
       .as[Array[Byte]]
-      .map { arr =>
-        ingressContext.increment(Metrics.Name.RowCount)
-        ingressContext.count(Metrics.Name.Bytes, arr.length)
-        try {
-          streamDecoder.decode(arr)
-        } catch {
-          case ex: Throwable =>
-            logger.error(s"Error while decoding streaming events from stream: ${dataStream.topicInfo.name}", ex)
-            ingressContext.incrementException(ex)
-            null
-        }
+      .mapPartitions { arrs =>
+        // Aggregate per-partition: one increment() call per raw message multiplies the StatsD
+        // packet count with message volume, so the executor's own JVM-wide UDP client sees more
+        // loss the higher the load. The per-partition byte/row totals below go out as a single
+        // count() per batch instead.
+        var byteCount = 0L
+        val mutations = arrs.map { arr =>
+          byteCount += arr.length
+          try {
+            streamDecoder.decode(arr)
+          } catch {
+            case ex: Throwable =>
+              logger.error(s"Error while decoding streaming events from stream: ${dataStream.topicInfo.name}", ex)
+              ingressContext.incrementException(ex)
+              null
+          }
+        }.toArray
+        ingressContext.count(Metrics.Name.RowCount, mutations.length)
+        ingressContext.count(Metrics.Name.Bytes, byteCount)
+        mutations.iterator
       }
       .filter { mutation =>
         if (mutation == null) {


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->
writeToKVStore currently collects the whole micro-batch to the driver before converting rows to PutRequests and counting them, so RowCount (and the null-percent checks inside toPutRequest) compete with every other per-row driver-side metric for the single JVM-wide StatsD client's queue. Build the PutRequests (and count them) inside a mapPartitions stage before collect() instead, so each partition's count goes out through that executor's own StatsD client - the same reason ingress metrics, which are already emitted per-partition in decode(), don't see this contention.

The actual KV store write (multiPutWithNotification/multiPut), key/value/freshness sampled distributions, and PushNotificationCount/ success/failure counts are unchanged.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->


## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [x] Integration tested

## Checklist
- [ ] Documentation update

## Reviewers
@pengyu-hou @Shiyinghaha 
