### PR TITLE
[Streaming] Limit checkpoint to the Spark application

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/streaming/CheckpointConfig.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/CheckpointConfig.scala
@@ -27,6 +27,6 @@ object CheckpointConfig {
   // to avoid changing behavior for callers that haven't opted in.
   def location(groupByConf: api.GroupBy, session: SparkSession): Option[String] =
     session.conf.getOption("spark.chronon.stream.checkpoint_base_dir").map { baseDir =>
-      s"$baseDir/${groupByConf.metaData.nameToFilePath}/"
+      s"$baseDir/${groupByConf.metaData.nameToFilePath}/${session.sparkContext.applicationId}/"
     }
 }

--- a/spark/src/test/scala/ai/chronon/spark/test/CheckpointConfigTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/CheckpointConfigTest.scala
@@ -39,8 +39,8 @@ class CheckpointConfigTest {
   @Test
   def locationIsDerivedFromBaseDirAndGroupByNameWhenConfigured(): Unit = {
     spark.conf.set("spark.chronon.stream.checkpoint_base_dir", "s3://bucket/checkpoints")
-    assertEquals(Some("s3://bucket/checkpoints/unit_test/checkpoint_config_gb/"),
-                 CheckpointConfig.location(groupByConf, spark))
+    val expected = s"s3://bucket/checkpoints/unit_test/checkpoint_config_gb/${spark.sparkContext.applicationId}/"
+    assertEquals(Some(expected), CheckpointConfig.location(groupByConf, spark))
     spark.conf.unset("spark.chronon.stream.checkpoint_base_dir")
   }
 }


### PR DESCRIPTION
## Summary
<!-- Overview of the changes involved in the PR -->

Currently, Chronon's streaming checkpoint is built from `spark.chronon.stream.checkpoint_base_dir` + the GroupBy's name. This path is static -- it depends only on the GroupBy config, not on the specific Spark run. Every retry of the same streaming job (whether it's in the same driver retrying, or a brand-new job submission after a restart) resolver to the exact same checkpoint directory.

**New behavior:** the checkpoint path now has the Spark application ID appended as a suffix, making it unique per Spark application rather than shared across every run of the job. This will guarantee that new tasks from within the same application don't have data gaps.

## Why / Goal
<!-- Use cases and qualitative impact / opportunities unlocked -->

The current behavior doesn't cover data gaps between new Spark applications and this will match the current behavior while allowing us to benefit from the checkpointing for the data gaps between Spark tasks from within the same application.

## Test Plan
<!-- What was the process for testing the PR. How would someone extending / refactoring the work know it works. Not all
of these apply to every PR. -->
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [x] Integration tested

Executed a job manually with this change and worked as expected.

## Checklist
- [ ] Documentation update

## Reviewers

