### PR TITLE
[Streaming] Write chained GroupBy micro-batches from the executors

### DIFF
--- a/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
+++ b/spark/src/main/scala/ai/chronon/spark/ChrononKryoRegistrator.scala
@@ -85,6 +85,8 @@ class ChrononKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.types.Metadata",
       "ai.chronon.api.Row",
       "ai.chronon.spark.KeyWithHash",
+      // collected back to the driver, one per partition, by the chained-GroupBy streaming write
+      "ai.chronon.spark.streaming.PartitionWriteSummary",
       "ai.chronon.aggregator.base.MomentsIR",
       "ai.chronon.aggregator.windowing.BatchIr",
       "ai.chronon.aggregator.base.ApproxHistogramIr",

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -25,7 +25,7 @@ import ai.chronon.online._
 import ai.chronon.spark.catalog.TableUtils
 import ai.chronon.spark.{EncoderUtil, GenericRowHandler}
 import com.google.gson.Gson
-import org.apache.spark.api.java.function.{ForeachPartitionFunction, MapPartitionsFunction, VoidFunction2}
+import org.apache.spark.api.java.function.{MapPartitionsFunction, VoidFunction2}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.{DataStreamWriter, Trigger}
@@ -76,6 +76,18 @@ object LocalIOCache {
     }
     kvStore
   }
+}
+
+// Result of writing one partition of a micro-batch, aggregated on the driver so that the
+// batch-level metrics keep the shape they had when the whole batch was written from the driver.
+// writeLatencyMillis is -1 when the partition attempted no write (empty partition, or debug mode).
+private[streaming] case class PartitionWriteSummary(rowCount: Long,
+                                                    resultCount: Long,
+                                                    successCount: Long,
+                                                    writeLatencyMillis: Long)
+
+private[streaming] object PartitionWriteSummary {
+  val notAttempted: PartitionWriteSummary = PartitionWriteSummary(0, 0, 0, -1)
 }
 
 class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map.empty, debug: Boolean, lagMillis: Int)(
@@ -151,6 +163,10 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
   // Timeout for the KV write of one partition of a micro-batch. The write is awaited inside the
   // task, so this bounds how long a stuck KV store can hold a task before the batch fails.
   private val putTimeoutMillis: Long = getProp("put_timeout_millis", "30000").toLong
+
+  // Latency of one partition's write, emitted per partition alongside the per-batch
+  // Metrics.Name.WriteLatencyMillis that the driver aggregates from the partition summaries.
+  private val PartitionWriteLatencyMillis = "partition.write.latency.millis"
 
   private case class PutRequestHelper(inputSchema: StructType) extends Serializable {
     @transient implicit lazy val logger = LoggerFactory.getLogger(getClass)
@@ -742,6 +758,54 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
       }
     }
 
+    // Encode and write one partition of a micro-batch on its own executor. Returns what the
+    // driver needs to emit the batch-level metrics, so those keep the shape they had when the whole
+    // batch was written from the driver: per-row metrics are emitted here, where they are spread
+    // across executors, and per-batch metrics are aggregated by the caller.
+    def writePartition(rows: Iterator[Row], bytesCap: Int): PartitionWriteSummary = {
+      val kvStore = LocalIOCache.getOrSetKvStore { () => apiImpl.genKvStore }
+      val putRequests = rows.map(putRequestHelper.toPutRequest).toArray
+      if (debug) {
+        logger.info(s" Partition size to write to kv store: ${putRequests.length}")
+        PartitionWriteSummary.notAttempted
+      } else if (putRequests.isEmpty) {
+        PartitionWriteSummary.notAttempted
+      } else {
+        val egressCtx = context.withSuffix("egress")
+        val bytesRate = batchSampleRate(bytesCap, putRequests.length)
+        putRequests.foreach(request => emitRequestMetric(request, egressCtx, bytesRate))
+
+        // Report kvStore metrics
+        val kvContext = egressCtx.withSuffix("put")
+        val writeStartMillis = System.currentTimeMillis()
+        val writeFuture = notificationTopic match {
+          case Some(topic) =>
+            kvStore.multiPutWithNotification(putRequests, topic)
+          case None =>
+            kvStore.multiPut(putRequests)
+        }
+        // Await inside the task. The driver-side version never waited on the future, so batch
+        // duration ignored KV latency, a slow KV store accumulated unbounded in-flight writes on
+        // the driver, and a rejected write only showed up as a metric. Awaiting gives Structured
+        // Streaming real backpressure and lets a write failure fail its batch.
+        Try(Await.result(writeFuture, Duration(putTimeoutMillis, MILLISECONDS))) match {
+          case Success(results) =>
+            val writeLatencyMillis = System.currentTimeMillis() - writeStartMillis
+            // Per-write percentiles, which the per-batch WriteLatencyMillis emitted by the caller
+            // (a max over partitions) hides. This is the metric that names a straggler partition.
+            kvContext.distribution(PartitionWriteLatencyMillis, writeLatencyMillis)
+            val successCount = results.count(identity)
+            PartitionWriteSummary(rowCount = putRequests.count(_.tsMillis.isDefined),
+                                  resultCount = results.size,
+                                  successCount = successCount,
+                                  writeLatencyMillis = writeLatencyMillis)
+          case Failure(exception) =>
+            kvContext.incrementException(exception)
+            throw exception
+        }
+      }
+    }
+
     // Encode and write from the executors, one task per partition. Collecting the micro-batch to
     // the driver made this stage a single-threaded, single-JVM funnel: Avro encoding of every key
     // and value, every per-row metric, and the whole KV write ran in one foreachBatch thread, so
@@ -751,64 +815,46 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
     writer.foreachBatch {
       new VoidFunction2[DataFrame, java.lang.Long] {
         override def call(df: DataFrame, l: lang.Long): Unit = {
-          // Dataset.rdd is a lazy val that foreachPartition reuses, so this neither submits a job
-          // nor re-plans the query. Sampling caps are per-batch budgets, so they are split across
-          // the partitions that now emit them independently.
-          val partitionCount = math.max(df.rdd.getNumPartitions, 1)
+          // Dataset.rdd is a lazy val, so deriving it here neither submits a job nor re-plans the
+          // query. Sampling caps are per-batch budgets, so they are split across the partitions
+          // that now emit them independently.
+          val rdd = df.rdd
+          val partitionCount = math.max(rdd.getNumPartitions, 1)
           val partitionBytesSampleCap = math.max(bytesSampleCap / partitionCount, 1)
 
-          df.foreachPartition(
-            new ForeachPartitionFunction[Row] {
-              override def call(rows: util.Iterator[Row]): Unit = {
-                val kvStore = LocalIOCache.getOrSetKvStore { () => apiImpl.genKvStore }
-                val putRequests = rows.toScala.map(putRequestHelper.toPutRequest).toArray
-                if (debug) {
-                  logger.info(s" Partition size to write to kv store: ${putRequests.length}")
-                } else if (putRequests.nonEmpty) {
-                  val egressCtx = context.withSuffix("egress")
-                  val bytesRate = batchSampleRate(partitionBytesSampleCap, putRequests.length)
-                  putRequests.foreach(request => emitRequestMetric(request, egressCtx, bytesRate))
-                  // RowCount is a plain sum, so emit it once per partition instead of once per row.
-                  // The StatsD client is a single JVM-wide instance draining one queue to one UDP
-                  // socket, and the version in use has no client-side aggregation, so per-row
-                  // emission puts thousands of messages per batch ahead of every other metric
-                  // sharing that client. Matches the pattern PushNotificationCount uses below.
-                  egressCtx.count(Metrics.Name.RowCount, putRequests.count(_.tsMillis.isDefined))
+          // One summary per partition - four longs each - so aggregating on the driver costs a
+          // negligible collect and no extra job, and lets the batch-level metrics below keep the
+          // shape they had before this stage was parallelized: exact per-batch counters, and one
+          // WriteLatencyMillis sample per batch rather than one per partition.
+          val summaries = rdd
+            .mapPartitions(rows => Iterator(writePartition(rows, partitionBytesSampleCap)))
+            .collect()
 
-                  // Report kvStore metrics
-                  val kvContext = egressCtx.withSuffix("put")
-                  val writeStartMillis = System.currentTimeMillis()
-                  val writeFuture = notificationTopic match {
-                    case Some(topic) =>
-                      kvStore.multiPutWithNotification(putRequests, topic)
-                    case None =>
-                      kvStore.multiPut(putRequests)
-                  }
-                  // Await inside the task. The driver-side version never waited on the future, so
-                  // batch duration ignored KV latency, a slow KV store accumulated unbounded
-                  // in-flight writes on the driver, and a rejected write only showed up as a
-                  // metric. Awaiting gives Structured Streaming real backpressure and lets a write
-                  // failure fail its batch.
-                  Try(Await.result(writeFuture, Duration(putTimeoutMillis, MILLISECONDS))) match {
-                    case Success(results) =>
-                      kvContext.distribution(Metrics.Name.WriteLatencyMillis,
-                                             System.currentTimeMillis() - writeStartMillis)
-                      if (notificationTopic.isDefined)
-                        kvContext.count(Metrics.Name.PushNotificationCount, results.size)
-                      // Aggregate per-partition for the same reason as RowCount above: the StatsD
-                      // client is a single JVM-wide instance, so per-row increments queue thousands
-                      // of messages ahead of every other metric sharing that client.
-                      val successCount = results.count(identity)
-                      if (successCount > 0) kvContext.count("success", successCount)
-                      if (successCount < results.size) kvContext.count("failure", results.size - successCount)
-                    case Failure(exception) =>
-                      kvContext.incrementException(exception)
-                      throw exception
-                  }
-                }
-              }
-            }
-          )
+          if (!debug) {
+            val egressCtx = context.withSuffix("egress")
+            val kvContext = egressCtx.withSuffix("put")
+
+            // RowCount is a plain sum, so emit it once per batch instead of once per row. The StatsD
+            // client is a single JVM-wide instance draining one queue to one UDP socket, and the
+            // version in use has no client-side aggregation, so per-row emission puts thousands of
+            // messages per batch ahead of every other metric sharing that client.
+            egressCtx.count(Metrics.Name.RowCount, summaries.map(_.rowCount).sum)
+
+            val resultCount = summaries.map(_.resultCount).sum
+            val successCount = summaries.map(_.successCount).sum
+            if (notificationTopic.isDefined && resultCount > 0)
+              kvContext.count(Metrics.Name.PushNotificationCount, resultCount)
+            if (successCount > 0) kvContext.count("success", successCount)
+            if (successCount < resultCount) kvContext.count("failure", resultCount - successCount)
+
+            // Max over the partitions that actually wrote: the closest analogue of the old
+            // whole-batch number, which timed the one multiPut that carried the entire batch. Note
+            // that it reads lower than that number, because each write now carries a fraction of
+            // the rows - see PartitionWriteLatencyMillis above for the per-write distribution.
+            val writeLatencies = summaries.map(_.writeLatencyMillis).filter(_ >= 0)
+            if (writeLatencies.nonEmpty)
+              kvContext.distribution(Metrics.Name.WriteLatencyMillis, writeLatencies.max)
+          }
         }
       }
     }

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -46,10 +46,9 @@ import scala.util.{Failure, Success, Try}
 // micro batching destroys and re-creates these objects repeatedly through ForeachBatchWriter and MapFunction
 // this allows for re-use
 //
-// Both builders are called from executor tasks, where several tasks of the same micro-batch run
-// concurrently in one JVM. Without the double-checked lock each of them can see a null and build
-// its own Fetcher / KVStore, which defeats the caching this object exists for and multiplies the
-// connection pools per executor. @volatile is what makes the unlocked fast path safe.
+// Both builders run in executor tasks, where concurrent tasks of one micro-batch share a JVM. The
+// double-checked lock (with @volatile) keeps them from each building their own Fetcher / KVStore,
+// and its connection pool, which is what this cache exists to avoid.
 object LocalIOCache {
   @volatile private var fetcher: Fetcher = null
   @volatile private var kvStore: KVStore = null
@@ -78,9 +77,8 @@ object LocalIOCache {
   }
 }
 
-// Result of writing one partition of a micro-batch, aggregated on the driver so that the
-// batch-level metrics keep the shape they had when the whole batch was written from the driver.
-// writeLatencyMillis is -1 when the partition attempted no write (empty partition, or debug mode).
+// What the driver needs to emit the batch-level metrics after writing per partition.
+// writeLatencyMillis is -1 when no write was attempted (empty partition, or debug mode).
 private[streaming] case class PartitionWriteSummary(rowCount: Long,
                                                     resultCount: Long,
                                                     successCount: Long,
@@ -160,12 +158,12 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
   // external inference services have higher latency (e.g. large model backends).
   private val chainTimeoutMillis: Long = getProp("timeout_millis", "5000").toLong
 
-  // Timeout for the KV write of one partition of a micro-batch. The write is awaited inside the
-  // task, so this bounds how long a stuck KV store can hold a task before the batch fails.
-  private val putTimeoutMillis: Long = getProp("put_timeout_millis", "30000").toLong
+  // Watchdog on the awaited KV write, not an SLA: nothing in Spark bounds a task's runtime, so a
+  // future left pending would hang the micro-batch forever. Raise it if the KV client's own
+  // timeout-and-retry budget approaches it - a lower bound turns slowness into task failures.
+  private val putTimeoutMillis: Long = getProp("put_timeout_millis", "10000").toLong
 
-  // Latency of one partition's write, emitted per partition alongside the per-batch
-  // Metrics.Name.WriteLatencyMillis that the driver aggregates from the partition summaries.
+  // Per-partition companion to the per-batch Metrics.Name.WriteLatencyMillis.
   private val PartitionWriteLatencyMillis = "partition.write.latency.millis"
 
   private case class PutRequestHelper(inputSchema: StructType) extends Serializable {
@@ -758,10 +756,8 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
       }
     }
 
-    // Encode and write one partition of a micro-batch on its own executor. Returns what the
-    // driver needs to emit the batch-level metrics, so those keep the shape they had when the whole
-    // batch was written from the driver: per-row metrics are emitted here, where they are spread
-    // across executors, and per-batch metrics are aggregated by the caller.
+    // Encodes and writes one partition on its own executor, emitting the per-row metrics there.
+    // The returned summary lets the caller emit the batch-level metrics from the driver.
     def writePartition(rows: Iterator[Row], bytesCap: Int): PartitionWriteSummary = {
       val kvStore = LocalIOCache.getOrSetKvStore { () => apiImpl.genKvStore }
       val putRequests = rows.map(putRequestHelper.toPutRequest).toArray
@@ -784,15 +780,14 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
           case None =>
             kvStore.multiPut(putRequests)
         }
-        // Await inside the task. The driver-side version never waited on the future, so batch
-        // duration ignored KV latency, a slow KV store accumulated unbounded in-flight writes on
-        // the driver, and a rejected write only showed up as a metric. Awaiting gives Structured
-        // Streaming real backpressure and lets a write failure fail its batch.
+        // Awaiting gives Structured Streaming real backpressure; the driver-side version never
+        // waited, so batch duration ignored KV latency and in-flight writes piled up unbounded. It
+        // buys no failure propagation from an implementation that reports per-request failures
+        // in-band through Seq[Boolean] rather than failing the future.
         Try(Await.result(writeFuture, Duration(putTimeoutMillis, MILLISECONDS))) match {
           case Success(results) =>
             val writeLatencyMillis = System.currentTimeMillis() - writeStartMillis
-            // Per-write percentiles, which the per-batch WriteLatencyMillis emitted by the caller
-            // (a max over partitions) hides. This is the metric that names a straggler partition.
+            // Per-write percentiles, hidden by the caller's per-batch max. Names a straggler.
             kvContext.distribution(PartitionWriteLatencyMillis, writeLatencyMillis)
             val successCount = results.count(identity)
             PartitionWriteSummary(rowCount = putRequests.count(_.tsMillis.isDefined),
@@ -806,26 +801,21 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
       }
     }
 
-    // Encode and write from the executors, one task per partition. Collecting the micro-batch to
-    // the driver made this stage a single-threaded, single-JVM funnel: Avro encoding of every key
-    // and value, every per-row metric, and the whole KV write ran in one foreachBatch thread, so
-    // adding executors sped up the fetch and derive stages and then queued all of their output
-    // behind that one thread. Per partition, encode CPU and write throughput now scale with the
-    // partition count of the incoming stream (see spark.chronon.stream.chain.batch_repartition).
+    // Write from the executors, one task per partition. Collecting to the driver made this a
+    // single-threaded funnel - Avro encoding, per-row metrics and the KV write all in one
+    // foreachBatch thread - so executor count could not raise write throughput. It now scales with
+    // the partition count of the incoming stream (spark.chronon.stream.chain.batch_repartition).
     writer.foreachBatch {
       new VoidFunction2[DataFrame, java.lang.Long] {
         override def call(df: DataFrame, l: lang.Long): Unit = {
-          // Dataset.rdd is a lazy val, so deriving it here neither submits a job nor re-plans the
-          // query. Sampling caps are per-batch budgets, so they are split across the partitions
-          // that now emit them independently.
+          // Dataset.rdd is a lazy val that mapPartitions reuses: no extra job, no re-planning.
+          // The sampling caps are per-batch budgets, split across the partitions that emit them.
           val rdd = df.rdd
           val partitionCount = math.max(rdd.getNumPartitions, 1)
           val partitionBytesSampleCap = math.max(bytesSampleCap / partitionCount, 1)
 
-          // One summary per partition - four longs each - so aggregating on the driver costs a
-          // negligible collect and no extra job, and lets the batch-level metrics below keep the
-          // shape they had before this stage was parallelized: exact per-batch counters, and one
-          // WriteLatencyMillis sample per batch rather than one per partition.
+          // Four longs per partition, so aggregating on the driver costs a negligible collect and
+          // keeps the batch-level metrics below exactly as they were before parallelizing.
           val summaries = rdd
             .mapPartitions(rows => Iterator(writePartition(rows, partitionBytesSampleCap)))
             .collect()
@@ -834,10 +824,8 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
             val egressCtx = context.withSuffix("egress")
             val kvContext = egressCtx.withSuffix("put")
 
-            // RowCount is a plain sum, so emit it once per batch instead of once per row. The StatsD
-            // client is a single JVM-wide instance draining one queue to one UDP socket, and the
-            // version in use has no client-side aggregation, so per-row emission puts thousands of
-            // messages per batch ahead of every other metric sharing that client.
+            // Plain sums, emitted once per batch: the JVM-wide StatsD client has no client-side
+            // aggregation, so per-row emission floods the one queue it drains to a UDP socket.
             egressCtx.count(Metrics.Name.RowCount, summaries.map(_.rowCount).sum)
 
             val resultCount = summaries.map(_.resultCount).sum
@@ -847,10 +835,8 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
             if (successCount > 0) kvContext.count("success", successCount)
             if (successCount < resultCount) kvContext.count("failure", resultCount - successCount)
 
-            // Max over the partitions that actually wrote: the closest analogue of the old
-            // whole-batch number, which timed the one multiPut that carried the entire batch. Note
-            // that it reads lower than that number, because each write now carries a fraction of
-            // the rows - see PartitionWriteLatencyMillis above for the per-write distribution.
+            // Max over the partitions that wrote - closest analogue of the old whole-batch number,
+            // and lower than it, since each write now carries a fraction of the rows.
             val writeLatencies = summaries.map(_.writeLatencyMillis).filter(_ >= 0)
             if (writeLatencies.nonEmpty)
               kvContext.distribution(Metrics.Name.WriteLatencyMillis, writeLatencies.max)

--- a/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
+++ b/spark/src/main/scala/ai/chronon/spark/streaming/JoinSourceRunner.scala
@@ -25,7 +25,7 @@ import ai.chronon.online._
 import ai.chronon.spark.catalog.TableUtils
 import ai.chronon.spark.{EncoderUtil, GenericRowHandler}
 import com.google.gson.Gson
-import org.apache.spark.api.java.function.{MapPartitionsFunction, VoidFunction2}
+import org.apache.spark.api.java.function.{ForeachPartitionFunction, MapPartitionsFunction, VoidFunction2}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.{DataStreamWriter, Trigger}
@@ -41,25 +41,38 @@ import java.{lang, util}
 import scala.concurrent.duration.{Duration, DurationInt, MILLISECONDS}
 import scala.concurrent.{Await, Future}
 import scala.util.ScalaJavaConversions.{IteratorOps, JIteratorOps, ListOps, MapOps}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 // micro batching destroys and re-creates these objects repeatedly through ForeachBatchWriter and MapFunction
 // this allows for re-use
+//
+// Both builders are called from executor tasks, where several tasks of the same micro-batch run
+// concurrently in one JVM. Without the double-checked lock each of them can see a null and build
+// its own Fetcher / KVStore, which defeats the caching this object exists for and multiplies the
+// connection pools per executor. @volatile is what makes the unlocked fast path safe.
 object LocalIOCache {
-  private var fetcher: Fetcher = null
-  private var kvStore: KVStore = null
+  @volatile private var fetcher: Fetcher = null
+  @volatile private var kvStore: KVStore = null
   @volatile var fetcherWarmedUp: Boolean = false
 
   def getOrSetFetcher(builderFunc: () => Fetcher): Fetcher = {
     if (fetcher == null) {
-      fetcher = builderFunc()
+      synchronized {
+        if (fetcher == null) {
+          fetcher = builderFunc()
+        }
+      }
     }
     fetcher
   }
 
   def getOrSetKvStore(builderFunc: () => KVStore): KVStore = {
     if (kvStore == null) {
-      kvStore = builderFunc()
+      synchronized {
+        if (kvStore == null) {
+          kvStore = builderFunc()
+        }
+      }
     }
     kvStore
   }
@@ -134,6 +147,10 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
   // Timeout for async chain operations (KV fetch and model transforms). Can be tuned when
   // external inference services have higher latency (e.g. large model backends).
   private val chainTimeoutMillis: Long = getProp("timeout_millis", "5000").toLong
+
+  // Timeout for the KV write of one partition of a micro-batch. The write is awaited inside the
+  // task, so this bounds how long a stuck KV store can hold a task before the batch fails.
+  private val putTimeoutMillis: Long = getProp("put_timeout_millis", "30000").toLong
 
   private case class PutRequestHelper(inputSchema: StructType) extends Serializable {
     @transient implicit lazy val logger = LoggerFactory.getLogger(getClass)
@@ -699,11 +716,14 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
       .trigger(Trigger.ProcessingTime(microBatchIntervalMillis))
     val putRequestHelper = PutRequestHelper(joinSourceDf.schema)
 
-    // Per-row metrics are emitted from the driver, where a whole micro-batch is collected, so the
-    // number of messages one batch hands to the JVM-wide StatsD client grows with traffic. Cap the
-    // messages per batch instead of the fraction of rows: pick the sample rate so that roughly
-    // `cap` rows are emitted regardless of batch size, and never sample more than the default rate.
-    // The rate is carried in each message, so the backend still reconstructs count and sum.
+    // Per-row metrics are emitted once per row of a micro-batch, so the number of messages one
+    // batch hands to the JVM-wide StatsD client grows with traffic. Cap the messages instead of the
+    // fraction of rows: pick the sample rate so that roughly `cap` rows are emitted regardless of
+    // batch size, and never sample more than the default rate. The rate is carried in each message,
+    // so the backend still reconstructs count and sum.
+    //
+    // The cap is a per-batch budget, and each partition emits on its own executor, so the caller
+    // divides it by the partition count before passing it in here.
     //
     // FreshnessMillis is left uncapped - its percentiles are actively alerted on, and reducing the
     // sample count for it would make those percentiles noisier during large batches. Key and value
@@ -722,49 +742,73 @@ class JoinSourceRunner(groupByConf: api.GroupBy, conf: Map[String, String] = Map
       }
     }
 
+    // Encode and write from the executors, one task per partition. Collecting the micro-batch to
+    // the driver made this stage a single-threaded, single-JVM funnel: Avro encoding of every key
+    // and value, every per-row metric, and the whole KV write ran in one foreachBatch thread, so
+    // adding executors sped up the fetch and derive stages and then queued all of their output
+    // behind that one thread. Per partition, encode CPU and write throughput now scale with the
+    // partition count of the incoming stream (see spark.chronon.stream.chain.batch_repartition).
     writer.foreachBatch {
       new VoidFunction2[DataFrame, java.lang.Long] {
         override def call(df: DataFrame, l: lang.Long): Unit = {
-          val kvStore = LocalIOCache.getOrSetKvStore { () => apiImpl.genKvStore }
-          val data = df.collect()
-          val putRequests = data.map(putRequestHelper.toPutRequest)
-          if (debug) {
-            logger.info(s" Final df size to write: ${data.length}")
-            logger.info(s" Size of putRequests to kv store- ${putRequests.length}")
-          } else {
-            val egressCtx = context.withSuffix("egress")
-            val bytesRate = batchSampleRate(bytesSampleCap, putRequests.length)
-            putRequests.foreach(request => emitRequestMetric(request, egressCtx, bytesRate))
-            // RowCount is a plain sum, so emit it once per batch instead of once per row. The StatsD
-            // client is a single JVM-wide instance draining one queue to one UDP socket, and the
-            // version in use has no client-side aggregation, so per-row emission puts thousands of
-            // messages per batch ahead of every other metric sharing that client. Matches the
-            // per-batch pattern PushNotificationCount already uses below.
-            egressCtx.count(Metrics.Name.RowCount, putRequests.count(_.tsMillis.isDefined))
+          // Dataset.rdd is a lazy val that foreachPartition reuses, so this neither submits a job
+          // nor re-plans the query. Sampling caps are per-batch budgets, so they are split across
+          // the partitions that now emit them independently.
+          val partitionCount = math.max(df.rdd.getNumPartitions, 1)
+          val partitionBytesSampleCap = math.max(bytesSampleCap / partitionCount, 1)
 
-            // Report kvStore metrics
-            val kvContext = egressCtx.withSuffix("put")
-            val writeStartMillis = System.currentTimeMillis()
-            val writeFuture = notificationTopic match {
-              case Some(topic) =>
-                kvStore.multiPutWithNotification(putRequests, topic)
-              case None =>
-                kvStore.multiPut(putRequests)
+          df.foreachPartition(
+            new ForeachPartitionFunction[Row] {
+              override def call(rows: util.Iterator[Row]): Unit = {
+                val kvStore = LocalIOCache.getOrSetKvStore { () => apiImpl.genKvStore }
+                val putRequests = rows.toScala.map(putRequestHelper.toPutRequest).toArray
+                if (debug) {
+                  logger.info(s" Partition size to write to kv store: ${putRequests.length}")
+                } else if (putRequests.nonEmpty) {
+                  val egressCtx = context.withSuffix("egress")
+                  val bytesRate = batchSampleRate(partitionBytesSampleCap, putRequests.length)
+                  putRequests.foreach(request => emitRequestMetric(request, egressCtx, bytesRate))
+                  // RowCount is a plain sum, so emit it once per partition instead of once per row.
+                  // The StatsD client is a single JVM-wide instance draining one queue to one UDP
+                  // socket, and the version in use has no client-side aggregation, so per-row
+                  // emission puts thousands of messages per batch ahead of every other metric
+                  // sharing that client. Matches the pattern PushNotificationCount uses below.
+                  egressCtx.count(Metrics.Name.RowCount, putRequests.count(_.tsMillis.isDefined))
+
+                  // Report kvStore metrics
+                  val kvContext = egressCtx.withSuffix("put")
+                  val writeStartMillis = System.currentTimeMillis()
+                  val writeFuture = notificationTopic match {
+                    case Some(topic) =>
+                      kvStore.multiPutWithNotification(putRequests, topic)
+                    case None =>
+                      kvStore.multiPut(putRequests)
+                  }
+                  // Await inside the task. The driver-side version never waited on the future, so
+                  // batch duration ignored KV latency, a slow KV store accumulated unbounded
+                  // in-flight writes on the driver, and a rejected write only showed up as a
+                  // metric. Awaiting gives Structured Streaming real backpressure and lets a write
+                  // failure fail its batch.
+                  Try(Await.result(writeFuture, Duration(putTimeoutMillis, MILLISECONDS))) match {
+                    case Success(results) =>
+                      kvContext.distribution(Metrics.Name.WriteLatencyMillis,
+                                             System.currentTimeMillis() - writeStartMillis)
+                      if (notificationTopic.isDefined)
+                        kvContext.count(Metrics.Name.PushNotificationCount, results.size)
+                      // Aggregate per-partition for the same reason as RowCount above: the StatsD
+                      // client is a single JVM-wide instance, so per-row increments queue thousands
+                      // of messages ahead of every other metric sharing that client.
+                      val successCount = results.count(identity)
+                      if (successCount > 0) kvContext.count("success", successCount)
+                      if (successCount < results.size) kvContext.count("failure", results.size - successCount)
+                    case Failure(exception) =>
+                      kvContext.incrementException(exception)
+                      throw exception
+                  }
+                }
+              }
             }
-            writeFuture
-              .andThen {
-                case Success(results) =>
-                  kvContext.distribution(Metrics.Name.WriteLatencyMillis, System.currentTimeMillis() - writeStartMillis)
-                  if (notificationTopic.isDefined) kvContext.count(Metrics.Name.PushNotificationCount, results.size)
-                  // Aggregate per-batch for the same reason as RowCount above: the StatsD client is a
-                  // single JVM-wide instance, so per-row increments from one batch queue thousands of
-                  // messages ahead of every other metric sharing that client.
-                  val successCount = results.count(identity)
-                  if (successCount > 0) kvContext.count("success", successCount)
-                  if (successCount < results.size) kvContext.count("failure", results.size - successCount)
-                case Failure(exception) => kvContext.incrementException(exception)
-              }(kvStore.executionContext)
-          }
+          )
         }
       }
     }


### PR DESCRIPTION
## Problem

`writeToKVStore` collected each micro-batch to the driver with `df.collect()`, then ran everything else in one `foreachBatch` thread of one JVM: Avro encoding of every key and value, every per-row metric, and the KV write.

The fetch and derive stages scale with executor count. Their whole output then queued behind that one thread, so adding executors could not raise write throughput, and driver heap grew with batch size.

## What changed

- **Encode and write per partition.** Each task builds its own `PutRequest`s and issues its own `multiPut`, so throughput scales with the partition count of the incoming stream (`spark.chronon.stream.chain.batch_repartition`).
- **The write is awaited inside the task**, bounded by a new `spark.chronon.stream.chain.put_timeout_millis` (default 10s). The old code never waited, so batch duration ignored KV latency and in-flight writes accumulated unbounded on the driver. The bound is a watchdog against a future that never completes — nothing in Spark limits a task's runtime — not an SLA.
- **`LocalIOCache` got a double-checked lock**, since several concurrent tasks per executor could each build their own KVStore and connection pool. The same race already existed for the fetcher in `enrichBaseJoin`.
- **Batch-level metrics keep their existing shape.** Each partition returns a `PartitionWriteSummary` (four longs) that the driver aggregates, so `RowCount`, `success`, `failure`, and `PushNotificationCount` are still one exact message per batch, and `WriteLatencyMillis` one sample per batch. `mapPartitions` + `collect` is the same single job `foreachPartition` ran.

## Notes for review

**`WriteLatencyMillis` changes value, not shape.** It is now the max over the partitions that wrote, where before it timed the one `multiPut` carrying the whole batch. It reads *lower*, since each write now carries a fraction of the rows, so thresholds tuned to the old value need retuning downward. The max also understates total write wall-clock when partitions outnumber cores, and excludes encode time, to stay comparable to the old metric.

**New metric:** `egress.put.partition.write.latency.millis` — the per-write distribution the per-batch max hides, which is what names a straggler partition.

**Per-row metrics stay on the executors** (`FreshnessMillis`, `KeyBytes`, `ValueBytes`); routing them through the driver would rebuild the funnel this removes. Their per-batch sampling caps are divided by the partition count now emitting them, so samples per batch are unchanged.

**Batch processing time will rise** even as throughput improves, because the awaited write is inside the batch.

**How much the await buys depends on the KVStore.** One that fails the future fails its batch here and gets a Spark task retry. One that reports per-request failures in-band through `Seq[Boolean]` never reaches the `Failure` branch, so there the await gives backpressure and nothing more — failed rows are counted into `egress.put.failure` and dropped, as before.

## Verification

`sbt spark_uber/compile` and `scalafmt` clean. `GroupByUploadTest` (6/6) and `ChainingFetcherTest` (2/2) pass; the former is what caught the missing Kryo registration, since it builds a session with `registrationRequired`.

Tests run in local mode, so multi-executor `LocalIOCache` behavior and the write fan-out are verified by construction rather than execution — worth a cluster run on one GroupBy before merge.

## Not included

- **A failure-ratio threshold on in-band `false` results.** For a KVStore that reports failures that way it is the only route to a retry, but the boolean does not say *why* a request failed, so a threshold would also retry permanently-unwritable requests before killing the query. Needs a decision first.
- **Capping `PutKeyNullPercent` / `PutValueNullPercent`**, still per row and outside the sampling cap. Spread across executors now, so no longer a bottleneck.
