### PR TITLE
Fetch a group_by by --conf-path

### DIFF
--- a/docs/source/test_deploy_serve/Test.md
+++ b/docs/source/test_deploy_serve/Test.md
@@ -129,9 +129,33 @@ The next step is to move the data from these tables into your KV store. For this
 
 You can fetch your uploaded conf by its name and with a json of keys. Json types needs to match the key types in hive. So a string should be quoted, an int/long shouldn't be quoted. Note that the json key cannot contain spaces - or it should be properly quoted. Similarly, when a join has multiple keys, there should be no space around the comma. For example, `-k '{"user_id":123,"merchant_id":456}'`. The fetch would return partial results if only some keys are provided. It would also output an error message indicating the missing keys, which is useful in case of typos.
 
+`-t` is the conf type — `join`, `group-by`, or `join-stats`:
+
 ```bash
-python3 ~/.local/bin/run.py --mode=fetch -k '{"user_or_visitor":"u_106386039"}' -n team/join.v1 -t join
+python3 ~/.local/bin/run.py --mode=fetch -k '{"user_or_visitor":"<key_value>"}' -n team/join.v1 -t join
+
+python3 ~/.local/bin/run.py --mode=fetch -k '{"user_or_visitor":"<key_value>"}' -n team/your_group_by.v1 -t group-by
 ```
+
+You can also point at a compiled conf file with `--conf-path` instead of naming it, which is handy while
+iterating on a conf you have not uploaded yet:
+
+```bash
+python3 ~/.local/bin/run.py --mode=fetch -k '{"user_or_visitor":"<key_value>"}' \
+    --conf-path=production/joins/team/your_join.v1 -t join
+
+python3 ~/.local/bin/run.py --mode=fetch -k '{"user_or_visitor":"<key_value>"}' \
+    --conf-path=production/group_bys/team/your_group_by.v1 -t group-by
+```
+
+How much of the file is used differs between the two:
+
+- A **join** is read out of the file, so you can fetch a join whose metadata has not been uploaded, and
+  test an added, removed or renamed `GroupBy`, derivation or external part. Its constituent `GroupBy`s
+  are still served from the KV store.
+- A **group_by** is read only for its name, because the schemas, aggregations and values a fetch needs
+  are the ones its upload wrote to the KV store. After changing a `GroupBy` conf, re-run its upload
+  before fetching again, or the fetch keeps returning the previously uploaded values.
 
 Note that this is simply the test workflow for fetching. For production serving, see the [Serving documentation](./Serve.md).
 

--- a/spark/src/main/scala/ai/chronon/spark/Driver.scala
+++ b/spark/src/main/scala/ai/chronon/spark/Driver.scala
@@ -843,19 +843,18 @@ object Driver {
           if (args.`type`() == "join-stats") {
             fetchStats(args, objectMapper, keyMap, fetcher)
           } else {
-            val featureName = if (args.name.isDefined) {
-              args.name()
-            } else {
-              args.confPath().confPathToKey
-            }
-            lazy val joinConfOption: Option[api.Join] =
-              args.confPath.toOption.map(confPath => parseConf[api.Join](confPath))
+            def requestFor(name: String) = Seq(Fetcher.Request(name, keyMap, args.atMillis.toOption))
             val startNs = System.nanoTime
-            val requests = Seq(Fetcher.Request(featureName, keyMap, args.atMillis.toOption))
             val resultFuture = if (args.`type`() == "join") {
-              fetcher.fetchJoin(requests, joinConfOption)
+              // a join is served from the conf itself when one is passed, so its name is a label
+              val joinName = args.name.toOption.getOrElse(args.confPath().confPathToKey)
+              val joinConf = args.confPath.toOption.map(confPath => parseConf[api.Join](confPath))
+              fetcher.fetchJoin(requestFor(joinName), joinConf)
             } else {
-              fetcher.fetchGroupBys(requests)
+              // a groupBy is keyed by its name: the serving info it needs lives in the batch upload
+              // dataset that `metaData.name` derives, so read the name from the conf, not its path
+              val groupByName = args.name.toOption.getOrElse(parseConf[api.GroupBy](args.confPath()).metaData.name)
+              fetcher.fetchGroupBys(requestFor(groupByName))
             }
             val result = Await.result(resultFuture, 5.seconds)
             val awaitTimeMs = (System.nanoTime - startNs) / 1e6d


### PR DESCRIPTION
## Summary
The local conf path name is parsed incorrectly for the group by. Fix the name parsing errors. 

## Why / Goal

Fetching a locally compiled group_by is the quick way to see what serving would return while iterating on a conf. Today that requires knowing to pass `--name` in the exact form the upload dataset derives from; `--conf-path` reads like it should work and fails naming a dataset the user never asked for.

## Test Plan
- [ ] Added Unit Tests
- [x] Covered by existing CI
- [ ] Integration tested
- [x] tested on gateway machine


## Checklist
- [x] Documentation update

## Reviewers

@yuli-han @Shiyinghaha @pkundurthy @hzding621 