### PR TITLE
[Logging] Read log schemas from the schema store instead of table properties

### DIFF
--- a/api/src/main/scala/ai/chronon/api/Constants.scala
+++ b/api/src/main/scala/ai/chronon/api/Constants.scala
@@ -40,6 +40,9 @@ object Constants {
   val ChrononDynamicTable = "chronon_dynamic_table"
   val ChrononOOCTable: String = "chronon_ooc_table"
   val ChrononLogTable: String = "chronon_log_table"
+  // points a flattened log table at the schema store table holding its schema_hash -> schema mapping.
+  // supersedes the unbounded, per-version schema_hash_* table properties that used to be written here.
+  val LoggingSchemaTable: String = "chronon_logging_schema_table"
   val ChrononMetadataKey = "ZIPLINE_METADATA"
   val SchemaPublishEvent = "SCHEMA_PUBLISH_EVENT"
   val StatsBatchDataset = "CHRONON_STATS_BATCH"

--- a/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
+++ b/spark/src/main/scala/ai/chronon/spark/BootstrapInfo.scala
@@ -195,10 +195,12 @@ object BootstrapInfo {
           ))
       })
 
-    // Retrieve schema_hash mapping info from Hive table properties
+    // Retrieve the schema_hash mapping from the schema store table that the log table points at, falling back
+    // to the legacy inline table properties. Log bootstrap parts are read over the fill range (see
+    // Join.computeBootstrapTable), so `range` bounds the hashes that can appear in matched_hashes.
     val logHashes = logBootstrapParts.flatMap { part =>
       LogFlattenerJob
-        .readSchemaTableProperties(tableUtils, part.table)
+        .readLoggingSchemas(tableUtils, part.table, range)
         .mapValues(LoggingSchema.parseLoggingSchema(_).valueFields.fields)
         .toSeq
     }.toMap

--- a/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
+++ b/spark/src/main/scala/ai/chronon/spark/LogFlattenerJob.scala
@@ -195,12 +195,40 @@ class LogFlattenerJob(session: SparkSession,
       .toMap
   }
 
-  def buildTableProperties(schemaMap: Map[String, String]): Map[String, String] = {
-    def escape(str: String): String = str.replace("""\""", """\\""")
-    (LogFlattenerJob.readSchemaTableProperties(tableUtils, joinConf.metaData.loggedTable) ++ schemaMap)
-      .map {
-        case (key, value) => (escape(s"${Constants.SchemaHash}_$key"), escape(value))
-      }
+  /**
+    * Records where the schema_hash -> schema mapping for this log table can be read from, rather than
+    * inlining the mapping itself. Previously one schema_hash_* property was written per schema version,
+    * each holding a full serialized Avro schema and never pruned; on wide joins that grew metadata.json
+    * to hundreds of MB and broke metadata reads. The mapping already lives in the schema store table,
+    * so a single pointer is enough for readers to resolve it.
+    */
+  def buildTableProperties(): Map[String, String] = Map(Constants.LoggingSchemaTable -> schemaTable)
+
+  private def hasLoggingSchemaPointer: Boolean =
+    tableUtils
+      .getTableProperties(joinConf.metaData.loggedTable)
+      .getOrElse(Map.empty)
+      .get(Constants.LoggingSchemaTable)
+      .exists(_.nonEmpty)
+
+  /**
+    * Drops the schema_hash_* properties accumulated by earlier versions of this job. Runs on every
+    * flattener run so affected tables self-heal once this ships, with no separate migration.
+    * Always called after the partitions are written, so the pointer is in place before the inline
+    * copy of the mapping is removed.
+    */
+  private def pruneLegacySchemaProperties(): Unit = {
+    val table = joinConf.metaData.loggedTable
+    val legacyKeys = tableUtils
+      .getTableProperties(table)
+      .getOrElse(Map.empty)
+      .keys
+      .filter(_.startsWith(s"${Constants.SchemaHash}_"))
+      .toSeq
+    if (legacyKeys.nonEmpty) {
+      logger.info(s"Removing ${legacyKeys.size} legacy ${Constants.SchemaHash}_* table properties from $table")
+      tableUtils.unsetTableProperties(table, legacyKeys)
+    }
   }
 
   private def columnCount(): Int = {
@@ -213,7 +241,12 @@ class LogFlattenerJob(session: SparkSession,
       return
     }
     val unfilledRanges = getUnfilledRanges(logTable, joinConf.metaData.loggedTable)
-    if (unfilledRanges.isEmpty) return
+    if (unfilledRanges.isEmpty) {
+      // nothing to write, but a table that already has the pointer may still carry legacy properties to drop,
+      // so a caught-up table still gets cleaned up rather than keeping its accumulated blobs indefinitely
+      if (hasLoggingSchemaPointer) pruneLegacySchemaProperties()
+      return
+    }
     val joinName = joinConf.metaData.nameToFilePath
 
     val start = System.currentTimeMillis()
@@ -227,7 +260,7 @@ class LogFlattenerJob(session: SparkSession,
       val schemaMap = schemaStringsMap.mapValues(LoggingSchema.parseLoggingSchema).map(identity).toMap
       val flattenedDf = flattenKeyValueBytes(rawDf, schemaMap)
 
-      val schemaTblProps = buildTableProperties(schemaStringsMap)
+      val schemaTblProps = buildTableProperties()
       logger.info("======= Log table schema =======")
       logger.info(flattenedDf.schema.pretty)
       tableUtils.insertPartitions(
@@ -247,6 +280,9 @@ class LogFlattenerJob(session: SparkSession,
 
       (inputRowCount, outputRowCount)
     }
+
+    pruneLegacySchemaProperties()
+
     val totalInputRowCount = rowCounts.map(_._1).sum
     val totalOutputRowCount = rowCounts.map(_._2).sum
     val columnAfterCount = columnCount()
@@ -272,5 +308,78 @@ object LogFlattenerJob {
         case (key, value) => (key.substring(Constants.SchemaHash.length + 1), value)
       }
       .toMap
+  }
+
+  /**
+    * Resolves the schema_hash -> serialized schema mapping for a flattened log table, covering only the
+    * hashes that actually appear in `range`.
+    *
+    * Prefers the schema store table named by the table's [[Constants.LoggingSchemaTable]] property, and falls
+    * back to the legacy inline schema_hash_* properties for tables that have not been re-run by a version of
+    * LogFlattenerJob that writes the pointer. The fallback keeps this deployable ahead of the write-path
+    * change, and can be dropped once every log table has been re-run.
+    */
+  def readLoggingSchemas(tableUtils: TableUtils, logTable: String, range: PartitionRange): Map[String, String] = {
+    val schemaTableOpt = tableUtils
+      .getTableProperties(logTable)
+      .getOrElse(Map.empty)
+      .get(Constants.LoggingSchemaTable)
+      .filter(_.nonEmpty)
+
+    schemaTableOpt match {
+      case Some(schemaTable) if tableUtils.tableExists(schemaTable) =>
+        fetchSchemasForRange(tableUtils, logTable, schemaTable, range)
+      case Some(schemaTable) =>
+        throw new IllegalStateException(
+          s"$logTable declares ${Constants.LoggingSchemaTable}='$schemaTable' but that table does not exist. " +
+            s"Logging schemas cannot be resolved for range $range.")
+      case None =>
+        readSchemaTableProperties(tableUtils, logTable)
+    }
+  }
+
+  /**
+    * Reads the schemas for the distinct hashes present in the log table over `range`. The hash set is narrowed
+    * first so the driver only materializes the schema versions the backfill can actually encounter, instead of
+    * every version the schema store has ever recorded across all joins.
+    */
+  private def fetchSchemasForRange(tableUtils: TableUtils,
+                                   logTable: String,
+                                   schemaTable: String,
+                                   range: PartitionRange): Map[String, String] = {
+    val schemaTableDs = tableUtils.lastAvailablePartition(schemaTable)
+    if (schemaTableDs.isEmpty) {
+      throw new IllegalStateException(s"$schemaTable has no partitions available!")
+    }
+
+    val hashes = range
+      .scanQueryDf(query = null, logTable)
+      .select(col(Constants.SchemaHash))
+      .where(col(Constants.SchemaHash).isNotNull)
+      .distinct()
+      .collect()
+      .map(_.getString(0))
+      .toSeq
+
+    if (hashes.isEmpty) return Map.empty
+
+    val schemas = tableUtils.sparkSession
+      .table(schemaTable)
+      .where(col(tableUtils.partitionColumn) === schemaTableDs.get)
+      .where(col(Constants.SchemaHash).isin(hashes: _*))
+      .select(col(Constants.SchemaHash), col("schema_value_last").as("schema_value"))
+      .collect()
+      .map(row => (row.getString(0), row.getString(1)))
+      .toMap
+
+    // fail here rather than letting the gap surface downstream as an unrelated-looking covering-set error
+    val missing = hashes.filterNot(schemas.contains)
+    if (missing.nonEmpty) {
+      throw new IllegalStateException(
+        s"$schemaTable partition ${schemaTableDs.get} is missing ${missing.size} of ${hashes.size} schema " +
+          s"hashes present in $logTable over $range: ${missing.take(10).mkString(", ")}. " +
+          s"Logging schemas cannot be resolved for those rows.")
+    }
+    schemas
   }
 }

--- a/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
+++ b/spark/src/main/scala/ai/chronon/spark/catalog/TableUtils.scala
@@ -337,6 +337,9 @@ case class TableUtils(sparkSession: SparkSession) {
   @transient lazy val logger = LoggerFactory.getLogger(getClass)
 
   private val ARCHIVE_TIMESTAMP_FORMAT = "yyyyMMddHHmmss"
+  // table properties are re-read and fully parsed on every table load, so bulk data written here degrades
+  // every reader of the table. warn well below the point where engines start timing out on metadata reads.
+  private val PropertiesSizeWarnBytes = 256 * 1024
   @transient private lazy val archiveTimestampFormatter = DateTimeFormatter
     .ofPattern(ARCHIVE_TIMESTAMP_FORMAT)
     .withZone(ZoneId.of("UTC"))
@@ -845,16 +848,51 @@ case class TableUtils(sparkSession: SparkSession) {
           s"'$key' = '$value'"
       }
       .mkString(", ")
-    val query = s"ALTER TABLE $tableName SET TBLPROPERTIES ($propertiesString)"
-    sql(query)
+    if (properties.nonEmpty) {
+      warnOnOversizedProperties(tableName, properties)
+      val query = s"ALTER TABLE $tableName SET TBLPROPERTIES ($propertiesString)"
+      sql(query)
+    }
 
     // remove any properties that were set previously during archiving
     if (unsetProperties.nonEmpty) {
-      val unsetPropertiesString = unsetProperties.map(s => s"'$s'").mkString(", ")
+      unsetTableProperties(tableName, unsetProperties)
+    }
+
+  }
+
+  /**
+    * Table properties live in metadata that engines re-read and fully parse on every table load, so they are
+    * meant for a bounded set of small config values. Writing bulk data here inflates that metadata for every
+    * reader of the table. Warn rather than fail, since this is a shared utility and an existing pipeline
+    * tripping the threshold should not be broken by an upgrade.
+    */
+  private def warnOnOversizedProperties(tableName: String, properties: Map[String, String]): Unit = {
+    val totalBytes = properties.iterator.map { case (k, v) => k.length + Option(v).map(_.length).getOrElse(0) }.sum
+    if (totalBytes > PropertiesSizeWarnBytes) {
+      val largest = properties.toSeq
+        .sortBy { case (_, v) => -Option(v).map(_.length).getOrElse(0) }
+        .take(3)
+        .map { case (k, v) => s"$k (${Option(v).map(_.length).getOrElse(0)} bytes)" }
+        .mkString(", ")
+      logger.warn(
+        s"Setting ${properties.size} table properties totaling $totalBytes bytes on $tableName, above the " +
+          s"${PropertiesSizeWarnBytes} byte threshold. Table properties are read and parsed on every " +
+          s"table load by every engine, so bulk data does not belong here - store it in a table instead. " +
+          s"Largest: $largest")
+    }
+  }
+
+  /**
+    * Drops table properties by key. Chunked because callers may need to remove a large accumulated
+    * set at once, and a single ALTER statement listing thousands of keys risks tripping SQL length limits.
+    */
+  def unsetTableProperties(tableName: String, keys: Seq[String], chunkSize: Int = 100): Unit = {
+    keys.distinct.grouped(chunkSize).foreach { batch =>
+      val unsetPropertiesString = batch.map(s => s"'$s'").mkString(", ")
       val unsetQuery = s"ALTER TABLE $tableName UNSET TBLPROPERTIES IF EXISTS ($unsetPropertiesString)"
       sql(unsetQuery)
     }
-
   }
 
   def chunk(partitions: Set[String]): Seq[PartitionRange] = {

--- a/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
+++ b/spark/src/test/scala/ai/chronon/spark/test/SchemaEvolutionTest.scala
@@ -24,7 +24,7 @@ import ai.chronon.online._
 import ai.chronon.online.serde.SparkConversions
 import ai.chronon.spark.Extensions.DataframeOps
 import ai.chronon.spark.catalog.TableUtils
-import ai.chronon.spark.{LogFlattenerJob, LoggingSchema, SparkSessionBuilder}
+import ai.chronon.spark.{LogFlattenerJob, LoggingSchema, PartitionRange, SparkSessionBuilder}
 import junit.framework.TestCase
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -370,12 +370,26 @@ class SchemaEvolutionTest extends TestCase {
       .table(joinConf.metaData.loggedTable)
       .where(col(tableUtils.partitionColumn) === offlineDs)
     assertEquals(2, flattenedDf.count())
+
+    // schemas resolve through the schema store table that the log table points at
+    val range = PartitionRange(offlineDs, offlineDs)(tableUtils)
     assertTrue(
       LogFlattenerJob
-        .readSchemaTableProperties(tableUtils, joinConf.metaData.loggedTable)
+        .readLoggingSchemas(tableUtils, joinConf.metaData.loggedTable, range)
         .mapValues(LoggingSchema.parseLoggingSchema)
         .values
         .nonEmpty)
+
+    // and the log table carries a bounded pointer rather than one property per schema version
+    val tblProps = tableUtils.getTableProperties(joinConf.metaData.loggedTable).getOrElse(Map.empty)
+    assertEquals(Some(mockApi.schemaTable), tblProps.get(Constants.LoggingSchemaTable))
+    assertTrue(
+      s"Expected no inline ${Constants.SchemaHash}_* properties, found: ${tblProps.keys
+        .filter(_.startsWith(s"${Constants.SchemaHash}_"))
+        .mkString(", ")}",
+      tblProps.keys.count(_.startsWith(s"${Constants.SchemaHash}_")) == 0
+    )
+
     flattenedDf
   }
 
@@ -504,6 +518,23 @@ class SchemaEvolutionTest extends TestCase {
     /* removed features are never removed from the table */
     assertTrue(removedFeatures.forall(flattenedDf12.schema.fieldNames.contains(_)))
     assertTrue(removedFeatures.forall(flattenedDf34.schema.fieldNames.contains(_)))
+
+    /*
+     * legacy inline schema_hash_* properties written by older versions of the job are pruned on the next
+     * run, so already-bloated tables recover without a separate migration
+     */
+    val loggedTable = joinSuiteV2.joinConf.metaData.loggedTable
+    val legacyKey = s"${Constants.SchemaHash}_legacyhash"
+    tableUtils.alterTableProperties(loggedTable, Map(legacyKey -> """{"key_schema":"x"}"""))
+    assertTrue(tableUtils.getTableProperties(loggedTable).getOrElse(Map.empty).contains(legacyKey))
+
+    // the table is caught up at this point, so this exercises the no-unfilled-ranges prune path
+    new LogFlattenerJob(spark, joinSuiteV2.joinConf, "2022-10-05", mockApi.logTable, mockApi.schemaTable)
+      .buildLogTable()
+
+    val prunedProps = tableUtils.getTableProperties(loggedTable).getOrElse(Map.empty)
+    assertFalse(prunedProps.contains(legacyKey))
+    assertEquals(Some(mockApi.schemaTable), prunedProps.get(Constants.LoggingSchemaTable))
   }
 
   def testAddFeatures(): Unit = {


### PR DESCRIPTION
## Problem

`LogFlattenerJob` stored every schema version it had ever seen as an Iceberg table property — one `schema_hash_*` entry per version, each holding a full serialized Avro schema, with nothing pruning them. On wide joins each blob is ~134KB; accumulated versions have grown `metadata.json` into the hundreds of MB (one table carries 1,086 versions / 88MB).

Table properties are re-read and fully parsed on **every** table load by every engine, so they are meant for a bounded set of small config values. This is already breaking metadata reads — Trino queries against affected tables time out — and the shared Iceberg REST catalog is exposed to an OOM as these files keep growing without bound. A fleet-wide scan found 35 tables over threshold, ~551MB combined, with `schema_hash_*` accounting for 95–99.99% of the bloat in every case.

## Approach

The mapping is redundant: it already lives in the schema store table that the flattener itself reads from (`LogUtils.buildLogSchemaGroupBy` — keyed on `schema_hash`, unwindowed `LAST`, so every partition holds every hash ever seen). So write a single pointer naming that table and resolve the mapping through it.

- **`buildTableProperties`** writes only `chronon_logging_schema_table`, making the property set fixed-size regardless of schema version count.
- **`readLoggingSchemas`** resolves hashes from the schema store, narrowed to those present in the log table over the fill range, so the driver materializes only the versions a backfill can actually encounter — not every version the store holds across all joins. Falls back to the legacy inline properties when no pointer is present.
- **`BootstrapInfo`** — the only production consumer (verified by grep) — reads through it. `range` is the correct bound because `Join.computeBootstrapTable` reads log bootstrap parts over `unfilledRange`, not the part's own start/end, so those are exactly the hashes that can appear in `matched_hashes`.
- **`pruneLegacySchemaProperties`** drops accumulated `schema_hash_*` keys on every run, so affected tables recover without a separate migration. Runs after the partition write so the pointer is in place first, and also on the caught-up path so a table that stops logging doesn't keep its blobs.
- Missing hashes now fail with an explicit message rather than surfacing downstream as an unrelated-looking covering-set error from `Join.scala:162`.

Also in `TableUtils`: extracted `unsetTableProperties` (chunked at 100 keys, since a single `ALTER` listing hundreds risks SQL length limits), guarded `SET` against an empty map, and added a 256KB warning naming the table and its largest entries — complementing the warehouse team's server-side `NonSystemPropertySizeGuard` (DWSS-4355) by surfacing this at the write rather than as a read failure later.

## ⚠️ Deployment order

The reader must be live **everywhere** before any table is pruned, or log-bootstrap backfills lose their schema mapping. The legacy fallback exists precisely so the reader can ship first. Happy to split into two commits if the rollout can't guarantee that ordering.

## Testing

`SchemaEvolutionTest`, `LogBootstrapTest`, `DerivationTest`, `TableBootstrapTest`, `AvroValidationTest` — 13/13 pass.

- `verifyOfflineTables` now asserts schemas resolve through the pointer *and* that zero `schema_hash_*` properties remain. The existing tests run it twice across a schema change, so the bounded-property invariant is covered.
- Added a prune regression test that plants a legacy key and confirms removal; confirmed via logs it genuinely fires (`Removing 1 legacy schema_hash_* table properties`) through the caught-up path rather than passing vacuously.
- Confirmed `LogBootstrapTest` exercises the new pointer path (`readLoggingSchemas` → `fetchSchemasForRange`), not the fallback.

## Follow-ups (not in this PR)

- Port / version-bump into `chronon-internal` (`ai.chronon-internal` 0.0.8-airbnb), where the affected pipelines run.
- Update client DAGs/packages to stop relying on the table properties.
- Drop the legacy fallback once every log table has been re-run.
